### PR TITLE
Refactor unshorten_links with SSRF protections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ db/
 __pycache__/
 *.py[cod]
 links.txt
+REVIEW_PLAN.md

--- a/fetchlinks/tests/test_unshorten_links.py
+++ b/fetchlinks/tests/test_unshorten_links.py
@@ -1,0 +1,136 @@
+import unittest
+from unittest import mock
+
+import unshorten_links
+
+
+class IsShortenedTests(unittest.TestCase):
+    def test_known_shortener_matches(self):
+        self.assertTrue(unshorten_links.is_shortened('https://bit.ly/abc'))
+        self.assertTrue(unshorten_links.is_shortened('https://t.co/xyz'))
+        self.assertTrue(unshorten_links.is_shortened('https://tinyurl.com/foo'))
+
+    def test_subdomain_of_shortener_matches(self):
+        self.assertTrue(unshorten_links.is_shortened('https://foo.bit.ly/abc'))
+
+    def test_unknown_domain_does_not_match(self):
+        self.assertFalse(unshorten_links.is_shortened('https://example.com/page'))
+        self.assertFalse(unshorten_links.is_shortened('https://en.wikipedia.org/wiki/X'))
+
+    def test_invalid_url_returns_false(self):
+        self.assertFalse(unshorten_links.is_shortened(''))
+        self.assertFalse(unshorten_links.is_shortened('not a url'))
+
+
+class IsSafeTargetTests(unittest.TestCase):
+    def _patch_resolve(self, ip_str):
+        # getaddrinfo returns list of 5-tuples; index [4][0] is the IP string.
+        return mock.patch.object(
+            unshorten_links.socket,
+            'getaddrinfo',
+            return_value=[(None, None, None, '', (ip_str, 0))],
+        )
+
+    def test_rejects_non_http_scheme(self):
+        self.assertFalse(unshorten_links._is_safe_target('ftp://example.com/x'))
+        self.assertFalse(unshorten_links._is_safe_target('file:///etc/passwd'))
+        self.assertFalse(unshorten_links._is_safe_target('javascript:alert(1)'))
+
+    def test_rejects_loopback(self):
+        with self._patch_resolve('127.0.0.1'):
+            self.assertFalse(unshorten_links._is_safe_target('http://localhost/x'))
+
+    def test_rejects_private_ranges(self):
+        for ip in ('10.0.0.1', '192.168.1.1', '172.16.0.1'):
+            with self._patch_resolve(ip):
+                self.assertFalse(unshorten_links._is_safe_target('http://internal/x'))
+
+    def test_rejects_link_local_metadata(self):
+        with self._patch_resolve('169.254.169.254'):
+            self.assertFalse(unshorten_links._is_safe_target('http://metadata/x'))
+
+    def test_rejects_unresolvable_host(self):
+        with mock.patch.object(
+            unshorten_links.socket,
+            'getaddrinfo',
+            side_effect=unshorten_links.socket.gaierror(),
+        ):
+            self.assertFalse(unshorten_links._is_safe_target('http://nope.invalid/x'))
+
+    def test_accepts_public_ip(self):
+        with self._patch_resolve('8.8.8.8'):
+            self.assertTrue(unshorten_links._is_safe_target('https://example.com/x'))
+
+
+class UnshortenUrlTests(unittest.TestCase):
+    def test_follows_redirect_chain(self):
+        responses = [
+            mock.Mock(status_code=301, headers={'Location': 'https://final.example.com/page'}),
+            mock.Mock(status_code=200, headers={}),
+        ]
+
+        def fake_head(self_session, url, **kwargs):
+            return responses.pop(0)
+
+        with mock.patch.object(unshorten_links, '_is_safe_target', return_value=True), \
+             mock.patch('requests.Session.head', autospec=True, side_effect=fake_head):
+            result = unshorten_links.unshorten_url('https://bit.ly/abc')
+
+        self.assertEqual(result, 'https://final.example.com/page')
+
+    def test_returns_none_when_redirect_lands_on_unsafe_target(self):
+        responses = [
+            mock.Mock(status_code=301, headers={'Location': 'http://169.254.169.254/'}),
+        ]
+
+        # Initial URL is safe, redirect target is not.
+        def fake_safe(url):
+            return '169.254' not in url
+
+        def fake_head(self_session, url, **kwargs):
+            return responses.pop(0)
+
+        with mock.patch.object(unshorten_links, '_is_safe_target', side_effect=fake_safe), \
+             mock.patch('requests.Session.head', autospec=True, side_effect=fake_head):
+            result = unshorten_links.unshorten_url('https://bit.ly/abc')
+
+        self.assertIsNone(result)
+
+    def test_returns_none_when_exceeds_redirect_limit(self):
+        # Always redirects, never resolves.
+        infinite = mock.Mock(status_code=301, headers={'Location': 'https://bit.ly/loop'})
+
+        with mock.patch.object(unshorten_links, '_is_safe_target', return_value=True), \
+             mock.patch('requests.Session.head', autospec=True, return_value=infinite):
+            result = unshorten_links.unshorten_url('https://bit.ly/loop')
+
+        self.assertIsNone(result)
+
+
+class UnshortenUrlsTests(unittest.TestCase):
+    def test_skips_non_shortened(self):
+        # No shortened URLs in input → no work done, empty dict.
+        result = unshorten_links.unshorten_urls(['https://example.com/a', 'https://wikipedia.org/x'])
+        self.assertEqual(result, {})
+
+    def test_collects_resolved_urls(self):
+        with mock.patch.object(
+            unshorten_links,
+            'unshorten_url',
+            side_effect=lambda url, session=None: 'https://final.example.com/' + url[-3:],
+        ):
+            result = unshorten_links.unshorten_urls(['https://bit.ly/abc', 'https://t.co/xyz'])
+
+        self.assertEqual(result, {
+            'https://bit.ly/abc': 'https://final.example.com/abc',
+            'https://t.co/xyz': 'https://final.example.com/xyz',
+        })
+
+    def test_omits_failed_resolutions(self):
+        with mock.patch.object(unshorten_links, 'unshorten_url', return_value=None):
+            result = unshorten_links.unshorten_urls(['https://bit.ly/abc'])
+        self.assertEqual(result, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/unshorten_links.py
+++ b/fetchlinks/unshorten_links.py
@@ -1,74 +1,168 @@
-# TODO:
-#  THIS SHOULD BE IN UTILS AND CLEANED UP
+"""Safely resolve shortened URLs to their final destinations.
+
+Hardened against SSRF: rejects redirects to non-public IP addresses and
+non-http(s) schemes. Manually follows redirects so each hop is checked.
+
+Public API:
+    is_shortened(url)  -> bool
+    unshorten_url(url) -> Optional[str]
+    unshorten_urls(iterable[str], max_workers=10) -> dict[str, str]
+"""
+import ipaddress
+import logging
+import socket
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict, Iterable, Optional
+from urllib.parse import urljoin, urlparse
 
 import requests
-from concurrent.futures import ThreadPoolExecutor
-import collections
-import urllib3
-import hashlib
 
-import logging
 logger = logging.getLogger(__name__)
 
-THREADS = 10
+# Known URL shortener hostnames. Domain-suffix match (so 'foo.bit.ly' matches).
+SHORTENER_DOMAINS = frozenset({
+    'bit.ly',
+    'buff.ly',
+    'cutt.ly',
+    'dlvr.it',
+    'fb.me',
+    'goo.gl',
+    'is.gd',
+    'lnkd.in',
+    'ow.ly',
+    'rb.gy',
+    'rebrand.ly',
+    'sans.org',  # sans.org/u/<id>
+    'shorturl.at',
+    't.co',
+    'tinyurl.com',
+    'tiny.cc',
+    'trib.al',
+    'wp.me',
+    'youtu.be',
+})
+
+MAX_REDIRECTS = 5
+REQUEST_TIMEOUT_SECONDS = 5
+DEFAULT_THREADS = 10
+USER_AGENT = 'fetchlinks-unshortener/0.1'
 
 
-def build_hash(link):
-    sha256_hash = hashlib.sha256(link.encode())
-    return sha256_hash.hexdigest()
-
-
-def is_shortened(url):
-    parsed_url = urllib3.util.parse_url(url)
-
-    cntr = collections.Counter(parsed_url.path)
-
-    url_whitelist = [
-        'sans.org/u/',
-        'tinyurl.com'
-    ]
-
-    if any(wlurl in url for wlurl in url_whitelist):
-        return True
-    if cntr['/'] > 1:
+def is_shortened(url: str) -> bool:
+    """Return True if URL hostname matches a known shortener domain."""
+    try:
+        host = (urlparse(url).hostname or '').lower()
+    except ValueError:
         return False
-    if len(parsed_url.host) > 12:
+    if not host:
         return False
-    if parsed_url.path and len(parsed_url.path) > 12:
-        return False
-    if not parsed_url.path or parsed_url.path == '/':
-        return False
+    return any(host == d or host.endswith('.' + d) for d in SHORTENER_DOMAINS)
 
+
+def _is_safe_target(url: str) -> bool:
+    """Reject non-http(s) schemes and any URL whose host resolves to a
+    non-public IP (private, loopback, link-local, multicast, reserved,
+    unspecified). Resolves DNS to catch hostnames that point at internal IPs.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    if parsed.scheme not in ('http', 'https'):
+        return False
+    host = parsed.hostname
+    if not host:
+        return False
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False
+    for info in infos:
+        ip_str = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            return False
+        if (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_multicast or ip.is_reserved or ip.is_unspecified):
+            return False
     return True
 
 
-def unshorten(post):
-    for index, url in enumerate(post.urls):
-        if is_shortened(url['url']):
-            try:
-                r = requests.get(url['url'])
-            except Exception as e:
-                logger.error(e)
-                logger.error('Could not unshorten: {}'.format(url['url']))
-                continue
-            if r.status_code == 200:
-                unshortened_url = r.url
-                post.urls[index]['unshort_url'] = unshortened_url
-                post.urls[index]['unshort_unique_id'] = build_hash(unshortened_url)
-        else:
+def _request_no_follow(session: requests.Session, url: str) -> Optional[requests.Response]:
+    """Issue HEAD with no auto-redirect. Falls back to GET on 405/501."""
+    try:
+        resp = session.head(url, allow_redirects=False, timeout=REQUEST_TIMEOUT_SECONDS)
+    except requests.RequestException as exc:
+        logger.debug('HEAD failed for %s: %s', url, exc)
+        return None
+    if resp.status_code in (405, 501):
+        try:
+            # stream=True so we don't download the body for non-redirects either.
+            resp = session.get(url, allow_redirects=False, timeout=REQUEST_TIMEOUT_SECONDS, stream=True)
+            resp.close()
+        except requests.RequestException as exc:
+            logger.debug('GET fallback failed for %s: %s', url, exc)
+            return None
+    return resp
+
+
+def unshorten_url(url: str, session: Optional[requests.Session] = None) -> Optional[str]:
+    """Manually follow up to MAX_REDIRECTS hops, SSRF-checking each one.
+
+    Returns the final URL on success, or None on failure / unsafe target.
+    """
+    sess = session if session is not None else requests.Session()
+    if session is None:
+        sess.headers['User-Agent'] = USER_AGENT
+
+    current = url
+    for _ in range(MAX_REDIRECTS + 1):
+        if not _is_safe_target(current):
+            logger.warning('Rejecting unsafe URL during unshorten: %s', current)
+            return None
+
+        resp = _request_no_follow(sess, current)
+        if resp is None:
+            return None
+
+        if 300 <= resp.status_code < 400:
+            location = resp.headers.get('Location')
+            if not location:
+                return current
+            current = urljoin(current, location)
             continue
 
-    return post
+        # Non-redirect response — we've arrived.
+        return current
+
+    logger.warning('Exceeded redirect limit for %s', url)
+    return None
 
 
-def unshorten_start(all_posts):
-    # parse tweet for urls key
-    # go through each url and make sure it's not shortened.
-    # if it is, unshorten it
-    # replace that url with the unshortened url in the dictionary
-    # pool = multiprocessing.Pool(processes=THREADS)
-    pool = ThreadPoolExecutor(max_workers=THREADS)
+def unshorten_urls(urls: Iterable[str], max_workers: int = DEFAULT_THREADS) -> Dict[str, str]:
+    """Concurrently resolve shortened URLs.
 
-    results = pool.map(unshorten, all_posts)
+    Returns {original_url: final_url} only for URLs that were detected as
+    shortened, successfully resolved, and whose final URL differs from the
+    original. URLs that aren't shortened or fail resolution are omitted.
+    """
+    targets = list({u for u in urls if is_shortened(u)})
+    if not targets:
+        return {}
 
-    return list(results)
+    results: Dict[str, str] = {}
+    with requests.Session() as session:
+        session.headers['User-Agent'] = USER_AGENT
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            future_to_url = {pool.submit(unshorten_url, u, session): u for u in targets}
+            for future in as_completed(future_to_url):
+                original = future_to_url[future]
+                try:
+                    final = future.result()
+                except Exception as exc:  # defensive; unshorten_url already swallows
+                    logger.debug('unshorten_url raised for %s: %s', original, exc)
+                    continue
+                if final and final != original:
+                    results[original] = final
+    return results


### PR DESCRIPTION
- Reject non-http(s) schemes
- DNS-resolve and reject private/loopback/link-local/multicast/reserved IPs at every redirect hop
- Manually follow redirects (cap 5) instead of trusting requests' auto-follow
- Use HEAD with GET fallback on 405/501; shared Session for connection pooling
- Domain-allow-list shortener detection replaces fragile heuristics
- New stateless API: is_shortened, unshorten_url, unshorten_urls
- Add tests covering SSRF rejection, redirect chain, batch behavior

Also add REVIEW_PLAN.md to .gitignore.