### PR TITLE
Correctness fixes C1-C4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 venv/
 data/logs/
+**/data/logs/
 fetch_links.log
 *.log
+*.log.*
 db/
 .vscode/
 .idea/

--- a/fetchlinks/db_utils.py
+++ b/fetchlinks/db_utils.py
@@ -65,6 +65,7 @@ def db_insert(fetched_data, db_location):
 
 
 def db_get_bluesky_cursor(db_location):
+    # Read latest by idx so we still work on legacy DBs that have multiple rows.
     db_command = """SELECT cursor FROM bluesky_state ORDER BY idx DESC LIMIT 1"""
 
     try:
@@ -82,13 +83,21 @@ def db_get_bluesky_cursor(db_location):
 
 
 def db_set_bluesky_cursor(cursor, db_location):
-    db_command = """INSERT INTO bluesky_state (cursor, time_created) values (?, ?)"""
+    # Upsert single-row state at idx=1 so the table doesn't grow unbounded.
+    # Also clean up any legacy rows from when this table grew on every run.
+    upsert_sql = (
+        'INSERT INTO bluesky_state (idx, cursor, time_created) VALUES (1, ?, ?) '
+        'ON CONFLICT(idx) DO UPDATE SET cursor = excluded.cursor, '
+        'time_created = excluded.time_created'
+    )
+    cleanup_sql = 'DELETE FROM bluesky_state WHERE idx != 1'
 
     try:
         with sqlite3.connect(db_location) as db:
             _ensure_bluesky_state_table(db)
             cur = db.cursor()
-            cur.execute(db_command, [cursor or '', datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S')])
+            cur.execute(upsert_sql, [cursor or '', datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S')])
+            cur.execute(cleanup_sql)
             db.commit()
     except sqlite3.Error as exc:
         raise RuntimeError(f'Could not persist bluesky cursor: {exc}') from exc

--- a/fetchlinks/tests/test_reddit_links.py
+++ b/fetchlinks/tests/test_reddit_links.py
@@ -2,6 +2,20 @@ import unittest
 from unittest.mock import Mock, patch
 
 import reddit_links
+from utils import RedditPost
+
+
+def _make_reddit_post(url):
+    return {
+        'data': {
+            'subreddit_name_prefixed': 'r/netsec',
+            'author': 'someone',
+            'title': 'a post',
+            'permalink': '/r/netsec/comments/abc/a_post/',
+            'created_utc': 1700000000,
+            'url': url,
+        }
+    }
 
 
 class RedditLinksTests(unittest.TestCase):
@@ -27,6 +41,29 @@ class RedditLinksTests(unittest.TestCase):
         posts = reddit_links.get_subreddit("netsec", "token", "test-ua/0.1")
 
         self.assertEqual(len(posts), 1)
+
+
+class RedditPostExtractUrlsTests(unittest.TestCase):
+    def test_skips_relative_subreddit_path(self):
+        # Regression: url like "/r/netsec/comments/..." used to leak through
+        # and produce malformed entries.
+        post = RedditPost(_make_reddit_post('/r/netsec/comments/xyz/another/'))
+        self.assertEqual(post.urls, [])
+        self.assertFalse(post.post_has_urls)
+
+    def test_skips_self_post_url(self):
+        post = RedditPost(_make_reddit_post('https://www.reddit.com/r/netsec/comments/xyz/another/'))
+        self.assertEqual(post.urls, [])
+
+    def test_keeps_external_https_url(self):
+        post = RedditPost(_make_reddit_post('https://example.com/article'))
+        self.assertEqual(post.urls, ['https://example.com/article'])
+
+    def test_skips_missing_url_field(self):
+        data = _make_reddit_post('https://example.com')['data']
+        del data['url']
+        post = RedditPost({'data': data})
+        self.assertEqual(post.urls, [])
 
 
 if __name__ == "__main__":

--- a/fetchlinks/utils.py
+++ b/fetchlinks/utils.py
@@ -2,6 +2,7 @@
 import hashlib
 import dateutil.parser
 import datetime
+from datetime import UTC
 import logging
 import re
 from typing import List
@@ -19,15 +20,15 @@ def convert_date_string_for_mysql(rss_date: str) -> str:
         date_object = dateutil.parser.parse(rss_date)
         date_created = datetime.datetime.strftime(date_object, '%Y-%m-%d %H:%M:%S')
     except dateutil.parser.ParserError as e:
-        # We couldn't parse the date for some reason. Make it "now"
+        # We couldn't parse the date for some reason. Make it "now" (UTC)
         logger.error(f'Could not parse date. Error:\n{e}')
-        date_created = datetime.datetime.strftime(datetime.datetime.now(), '%Y-%m-%d %H:%M:%S')
+        date_created = datetime.datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S')
     return date_created
 
 
 def convert_epoch_to_mysql(epoch: float) -> str:
-    date_object = datetime.datetime.utcfromtimestamp(int(epoch))
-    return datetime.datetime.strftime(date_object, '%Y-%m-%d %H:%M:%S')
+    date_object = datetime.datetime.fromtimestamp(int(epoch), tz=UTC)
+    return date_object.strftime('%Y-%m-%d %H:%M:%S')
 
 
 def extract_urls_from_text(text: str) -> List[str]:
@@ -91,7 +92,7 @@ class RssPost(Post):
         elif 'updated' in post:
             self.date_created = convert_date_string_for_mysql(post.updated)
         else:
-            self.date_created = datetime.datetime.strftime(datetime.datetime.now(), '%Y-%m-%d %H:%M:%S')
+            self.date_created = datetime.datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S')
 
         self._generate_unique_url_string()
 


### PR DESCRIPTION
C1: Add regression tests for RedditPost._extract_urls — covers the
    relative-path bug (e.g. '/r/netsec/comments/...'), self-post URLs,
    external URLs, and missing 'url' field.

C2: Replace deprecated datetime.utcfromtimestamp with
    datetime.fromtimestamp(int(epoch), tz=UTC) in convert_epoch_to_mysql.

C3: Use datetime.now(UTC) in fallback paths so dates stay UTC-consistent
    instead of mixing in local time.

C4: Upsert bluesky_state to a single row at idx=1 (ON CONFLICT DO UPDATE)
    and clean up legacy rows on each write so the table no longer grows
    unbounded. Read still tolerates legacy multi-row state via ORDER BY
    idx DESC LIMIT 1.