### PR TITLE
Normalize and validate URLs at the Post boundary

### DIFF
--- a/fetchlinks/tests/test_url_normalization.py
+++ b/fetchlinks/tests/test_url_normalization.py
@@ -1,0 +1,70 @@
+import unittest
+
+from utils import RssPost, normalize_url
+
+
+class NormalizeUrlTests(unittest.TestCase):
+    def test_passes_through_https(self):
+        self.assertEqual(
+            normalize_url('https://example.com/a'),
+            'https://example.com/a',
+        )
+
+    def test_resolves_site_relative_against_base(self):
+        self.assertEqual(
+            normalize_url('/blog/post', base='https://example.com/feed.xml'),
+            'https://example.com/blog/post',
+        )
+
+    def test_resolves_protocol_relative_against_base(self):
+        self.assertEqual(
+            normalize_url('//other.com/x', base='https://example.com/'),
+            'https://other.com/x',
+        )
+
+    def test_drops_relative_with_no_base(self):
+        self.assertEqual(normalize_url('/blog/post'), '')
+
+    def test_drops_typo_scheme(self):
+        self.assertEqual(normalize_url('hhttps://example.com/x'), '')
+
+    def test_drops_empty(self):
+        self.assertEqual(normalize_url(''), '')
+        self.assertEqual(normalize_url('   '), '')
+
+    def test_drops_non_http_scheme(self):
+        self.assertEqual(normalize_url('ftp://example.com/x'), '')
+        self.assertEqual(normalize_url('javascript:alert(1)'), '')
+
+    def test_strips_whitespace(self):
+        self.assertEqual(
+            normalize_url('  https://example.com/x  '),
+            'https://example.com/x',
+        )
+
+
+class RssPostUrlResolutionTests(unittest.TestCase):
+    @staticmethod
+    def _entry(link):
+        # feedparser entries support both dict-style .get() and attribute access.
+        class Entry(dict):
+            def __getattr__(self, name):
+                try:
+                    return self[name]
+                except KeyError as exc:
+                    raise AttributeError(name) from exc
+
+        return Entry(title='t', link=link, published='2026-01-01T00:00:00Z')
+
+    def test_relative_link_resolved_against_feed_source(self):
+        post = RssPost('https://example.com/feed.xml', 'Example', self._entry('/posts/foo'))
+        self.assertEqual(post.urls, ['https://example.com/posts/foo'])
+
+    def test_typo_scheme_dropped(self):
+        post = RssPost('https://example.com/feed.xml', 'Example', self._entry('hhttps://example.com/x'))
+        self.assertEqual(post.urls, [])
+        self.assertFalse(post.post_has_urls)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/utils.py
+++ b/fetchlinks/utils.py
@@ -6,6 +6,7 @@ from datetime import UTC
 import logging
 import re
 from typing import List
+from urllib.parse import urljoin, urlsplit
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,30 @@ def extract_urls_from_text(text: str) -> List[str]:
     return re.findall(r'https?://[^\s)\]>"\']+', text)
 
 
+def normalize_url(url: str, base: str = '') -> str:
+    """Normalize a candidate URL or return '' if it can't be made valid.
+
+    - Strips whitespace.
+    - Resolves protocol-relative ('//host/path') and site-relative ('/path')
+      URLs against `base` when provided.
+    - Rejects anything whose final scheme isn't http/https or that has no host.
+    """
+    if not url:
+        return ''
+    url = url.strip()
+    if not url:
+        return ''
+
+    # Resolve relative forms against the feed/site base when we have one.
+    if base and (url.startswith('//') or url.startswith('/') or not urlsplit(url).scheme):
+        url = urljoin(base, url)
+
+    parts = urlsplit(url)
+    if parts.scheme not in ('http', 'https') or not parts.netloc:
+        return ''
+    return url
+
+
 class Post:
     def __init__(self):
         self.source = ''
@@ -47,9 +72,10 @@ class Post:
         self.urls: List[str] = []
         self.unique_id_string = ''
 
-    def add_url(self, url: str):
-        if url and url not in self.urls:
-            self.urls.append(url)
+    def add_url(self, url: str, base: str = ''):
+        cleaned = normalize_url(url, base)
+        if cleaned and cleaned not in self.urls:
+            self.urls.append(cleaned)
 
     def _generate_unique_url_string(self):
         sorted_urls = sorted(u for u in self.urls if u)
@@ -85,7 +111,8 @@ class RssPost(Post):
         self.author = feed_author
         self.description = post.get('title', '')
         self.direct_link = None
-        self.add_url(post.get('link', ''))
+        # Resolve relative <link> values against the feed's site URL.
+        self.add_url(post.get('link', ''), base=feed_source)
 
         if 'published' in post:
             self.date_created = convert_date_string_for_mysql(post.published)


### PR DESCRIPTION
- New utils.normalize_url(url, base): strips whitespace, resolves protocol-relative ('//host/path') and site-relative ('/path') URLs against an optional base, and rejects anything whose final scheme isn't http/https or that has no host.
- Post.add_url now calls normalize_url, so every Post subclass (Rss, Reddit, Bluesky) gets the same scheme/host validation.
- RssPost passes the feed's source URL as the base, so feeds that emit relative <link> values now produce absolute URLs instead of storing '/posts/foo' style strings.
- Catches publisher typos like 'hhttps://...' too.
- 10 new tests in test_url_normalization.py.