### PR TITLE
Correctness fixes C6-C8

### DIFF
--- a/fetchlinks/db_utils.py
+++ b/fetchlinks/db_utils.py
@@ -32,7 +32,6 @@ def db_insert(fetched_data, db_location):
         'INSERT OR IGNORE INTO post_urls (post_id, position, url, url_hash) '
         'VALUES (?, ?, ?, ?)'
     )
-    lookup_post_sql = 'SELECT idx FROM posts WHERE unique_id_string = ?'
 
     inserted = 0
     try:
@@ -45,12 +44,6 @@ def db_insert(fetched_data, db_location):
                     # Post already exists; leave its URL rows alone.
                     continue
                 post_id = cur.lastrowid
-                if post_id is None:
-                    cur.execute(lookup_post_sql, (post.unique_id_string,))
-                    row = cur.fetchone()
-                    if not row:
-                        continue
-                    post_id = row[0]
                 url_rows = [
                     (post_id, position, url, url_hash)
                     for (position, url, url_hash) in post.get_url_rows()

--- a/fetchlinks/startup_and_validate.py
+++ b/fetchlinks/startup_and_validate.py
@@ -97,11 +97,10 @@ def _validate_config(config: dict):
 
 def _validate_config_fields(config_keys, valid_keys):
     for field in valid_keys:
-        if config_keys.get(field, False):
-            if not isinstance(config_keys.get(field), str):
-                raise ValueError(f'Config file section has incorrect value in: {field}')
-        else:
+        if field not in config_keys:
             raise ValueError(f'Config file section has missing field: {field}')
+        if not isinstance(config_keys[field], str):
+            raise ValueError(f'Config file section has incorrect value in: {field}')
 
 
 def parse_arguments():

--- a/fetchlinks/utils.py
+++ b/fetchlinks/utils.py
@@ -110,7 +110,7 @@ class RssPost(Post):
         self.source = feed_source
         self.author = feed_author
         self.description = post.get('title', '')
-        self.direct_link = None
+        self.direct_link = ''
         # Resolve relative <link> values against the feed's site URL.
         self.add_url(post.get('link', ''), base=feed_source)
 


### PR DESCRIPTION
C6: _validate_config_fields now uses 'field in config_keys' instead
    of '.get(field, False)'. Empty-string values now correctly fail
    validation (previously they were silently treated as missing).

C7: RssPost.direct_link is '' instead of None, matching the empty
    string default in the Post base class and the convention used by
    RedditPost / BlueskyPost.

C8: Remove unreachable lookup_post_sql fallback in db_insert. With
    INSERT OR IGNORE on a hit, rowcount == 0 and we already 'continue';
    on a miss, sqlite3 always populates lastrowid, so the SELECT
    fallback was dead code.