### PR TITLE
D1: Configure logging before sources validation

### DIFF
--- a/fetchlinks/fetch_links.py
+++ b/fetchlinks/fetch_links.py
@@ -43,11 +43,16 @@ def fetch_links(config: dict, sources: dict):
 
 def main():
     try:
-        # Sanity checks
-        config, sources = startup_and_validate.do_startup()
+        # Parse args + config first so we know where to log to.
+        args = startup_and_validate.parse_arguments()
+        config = startup_and_validate.parse_config(args.config)
 
-        # Setup logging
+        # Setup logging BEFORE further validation so any errors below
+        # (e.g. bad sources file, missing credentials) hit the log file.
         configure_logging(config)
+
+        # Validate sources now that logging is up.
+        sources = startup_and_validate.parse_sources(args.sources)
 
         # Actually do stuff
         fetch_links(config, sources)


### PR DESCRIPTION
Previously main() called do_startup() (which validates BOTH config and sources) and only then called configure_logging(). Any failure during sources validation - bad credential paths, malformed sources.json, missing feeds - went only to stderr and never reached the log file.

Split startup into explicit steps in main():
  1. parse args
  2. parse + validate config (so we know where to log)
  3. configure logging
  4. parse + validate sources
  5. fetch_links

do_startup() is left in place for any other callers.