### PR TITLE
Design fixes D2, D3, D4

### DIFF
--- a/fetchlinks/fetch_links.py
+++ b/fetchlinks/fetch_links.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import rss_links
 import reddit_links
 import bluesky_links
+import db_setup
 import startup_and_validate
 
 
@@ -50,6 +51,11 @@ def main():
         # Setup logging BEFORE further validation so any errors below
         # (e.g. bad sources file, missing credentials) hit the log file.
         configure_logging(config)
+
+        # Ensure DB schema exists. db_initial_setup is idempotent
+        # (CREATE TABLE IF NOT EXISTS), so it's safe to run every time
+        # and means new tables added later get created automatically.
+        db_setup.db_initial_setup(config['db_info']['db_location'], config['db_info']['db_name'])
 
         # Validate sources now that logging is up.
         sources = startup_and_validate.parse_sources(args.sources)

--- a/fetchlinks/startup_and_validate.py
+++ b/fetchlinks/startup_and_validate.py
@@ -7,6 +7,19 @@ import db_setup
 VALID_FIELDS = {'db_info': ['db_name', 'db_location'],
                 'log_info': ['log_config_location', 'log_location', 'log_level']}
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def _resolve_relative_to_script(path_str: str) -> Path:
+    """Resolve a path string relative to the script directory if not absolute.
+
+    Same convention as export_links.py so the app works regardless of cwd.
+    """
+    p = Path(path_str)
+    if not p.is_absolute():
+        p = SCRIPT_DIR / p
+    return p
+
 
 def parse_sources(sources_location: str) -> dict:
     """
@@ -39,17 +52,17 @@ def _validate_sources(sources: dict):
         if settings.get('enabled', True) is False:
             continue
 
-        if settings.get('credential_location', False):
-            if not Path(settings.get('credential_location')).exists():
-                raise FileNotFoundError(f'{source} credential file could not be found at location: {settings.get("credential_location")}')
+        if settings.get('credential_location'):
+            if not Path(settings['credential_location']).exists():
+                raise FileNotFoundError(f'{source} credential file could not be found at location: {settings["credential_location"]}')
 
-    if sources.get('rss', False):
-        if sources['rss'].get('enabled', True) and sources['rss'].get('feeds', False):
+    if sources.get('rss'):
+        if sources['rss'].get('enabled', True) and sources['rss'].get('feeds'):
             if len(sources['rss']['feeds']) < 1:
                 raise ValueError('The Rss config contains no feeds')
 
-    if sources.get('bluesky', False) and sources['bluesky'].get('enabled', False):
-        if not sources['bluesky'].get('credential_location', False):
+    if sources.get('bluesky') and sources['bluesky'].get('enabled', False):
+        if not sources['bluesky'].get('credential_location'):
             raise ValueError('Bluesky source requires credential_location when enabled')
 
         timeline_limit = sources['bluesky'].get('timeline_limit', 50)
@@ -84,15 +97,18 @@ def _validate_config(config: dict):
         else:
             raise ValueError(f'Config file is missing config info: {header}.')
 
-    # check if our log location exists
-    log_path = Path(config['log_info']['log_location'])
-    if not log_path.exists():
-        log_path.parent.mkdir(parents=True, exist_ok=True)
+    # Anchor relative paths to the script directory so the app works
+    # regardless of the current working directory.
+    config['db_info']['db_location'] = str(
+        _resolve_relative_to_script(config['db_info']['db_location'])
+    )
+    config['log_info']['log_location'] = str(
+        _resolve_relative_to_script(config['log_info']['log_location'])
+    )
 
-    # check if we already have a db
-    db_path = Path(config['db_info']['db_location']) / config['db_info']['db_name']
-    if not db_path.exists():
-        db_setup.db_initial_setup(config['db_info']['db_location'], config['db_info']['db_name'])
+    # Make sure the log directory exists.
+    log_path = Path(config['log_info']['log_location'])
+    log_path.parent.mkdir(parents=True, exist_ok=True)
 
 
 def _validate_config_fields(config_keys, valid_keys):

--- a/fetchlinks/utils.py
+++ b/fetchlinks/utils.py
@@ -139,7 +139,7 @@ class RedditPost(Post):
         self.date_created = convert_epoch_to_mysql(post['data']['created_utc'])
 
     def _extract_urls(self, post):
-        if post['data'].get('url', False):
+        if post['data'].get('url'):
             url = post['data']['url']
             if not url.startswith(('http://', 'https://')):
                 return


### PR DESCRIPTION
D2: Anchor relative db_location and log_location to the script
    directory (Path(__file__).parent of startup_and_validate.py),
    matching the convention already used in export_links.py. The app
    now works regardless of the current working directory.

D3: Remove db_setup.db_initial_setup side effect from _validate_config.
    main() now calls it explicitly after configure_logging. Since
    db_initial_setup uses CREATE TABLE IF NOT EXISTS it's safe to run
    every time, and tables added later (e.g. rss_feed_state) get
    created automatically without manual migration.

D4: Replace the .get('foo', False) presence-probe anti-pattern with
    .get('foo') / 'foo' in dict where the False sentinel was just
    standing in for truthiness:
    - startup_and_validate._validate_sources (4 sites)
    - utils.RedditPost._extract_urls Left intact: bluesky_config.get('enabled', False) and sources.get('bluesky', {}).get('enabled', False) where False is the actual semantic default for an enable flag.