### PR TITLE
test: expand unit test coverage across all core modules

### DIFF
--- a/fetchlinks/tests/test_auth.py
+++ b/fetchlinks/tests/test_auth.py
@@ -1,0 +1,146 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import auth
+
+
+class AuthBaseTests(unittest.TestCase):
+    def test_no_file_means_no_contents(self):
+        a = auth.Auth('')
+        self.assertEqual(a.file_contents, {})
+
+    def test_missing_file_raises_runtime_error(self):
+        with self.assertRaises(RuntimeError):
+            auth.Auth('/no/such/file.json')
+
+    def test_invalid_json_raises_value_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'bad.json'
+            p.write_text('not json', encoding='utf-8')
+            with self.assertRaises(ValueError):
+                auth.Auth(str(p))
+
+    def test_valid_json_loaded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'good.json'
+            p.write_text(json.dumps({'k': 'v'}), encoding='utf-8')
+            a = auth.Auth(str(p))
+            self.assertEqual(a.file_contents, {'k': 'v'})
+
+
+def _write_reddit_creds(tmp, contents):
+    p = Path(tmp) / 'reddit.json'
+    p.write_text(json.dumps(contents), encoding='utf-8')
+    return str(p)
+
+
+class RedditAuthTests(unittest.TestCase):
+    def test_missing_keys_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_reddit_creds(tmp, {'reddit': {}})
+            with self.assertRaises(ValueError):
+                auth.RedditAuth(path)
+
+    def test_sets_secrets_from_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_reddit_creds(tmp, {
+                'reddit': {
+                    'APP_CLIENT_ID': 'cid',
+                    'APP_CLIENT_SECRET': 'csec',
+                    'USERNAME': 'me',
+                }
+            })
+            a = auth.RedditAuth(path)
+            self.assertEqual(a.app_client_id, 'cid')
+            self.assertEqual(a.app_client_secret, 'csec')
+            self.assertEqual(a.username, 'me')
+
+    def test_user_agent_with_username(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_reddit_creds(tmp, {
+                'reddit': {'APP_CLIENT_ID': 'c', 'APP_CLIENT_SECRET': 's', 'USERNAME': 'me'}
+            })
+            self.assertIn('/u/me', auth.RedditAuth(path).user_agent)
+
+    def test_user_agent_without_username(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_reddit_creds(tmp, {
+                'reddit': {'APP_CLIENT_ID': 'c', 'APP_CLIENT_SECRET': 's'}
+            })
+            self.assertNotIn('/u/', auth.RedditAuth(path).user_agent)
+
+    def test_get_auth_returns_token(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_reddit_creds(tmp, {
+                'reddit': {'APP_CLIENT_ID': 'c', 'APP_CLIENT_SECRET': 's'}
+            })
+            a = auth.RedditAuth(path)
+
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status.return_value = None
+            mock_resp.json.return_value = {'access_token': 'tok'}
+
+            with patch('auth.requests.post', return_value=mock_resp):
+                self.assertEqual(a.get_auth(), 'tok')
+            self.assertEqual(a.access_token, 'tok')
+
+    def test_get_auth_missing_token_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_reddit_creds(tmp, {
+                'reddit': {'APP_CLIENT_ID': 'c', 'APP_CLIENT_SECRET': 's'}
+            })
+            a = auth.RedditAuth(path)
+
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status.return_value = None
+            mock_resp.json.return_value = {}
+
+            with patch('auth.requests.post', return_value=mock_resp):
+                with self.assertRaises(ValueError):
+                    a.get_auth()
+
+
+def _write_bluesky_creds(tmp, contents):
+    p = Path(tmp) / 'bluesky.json'
+    p.write_text(json.dumps(contents), encoding='utf-8')
+    return str(p)
+
+
+class BlueskyAuthTests(unittest.TestCase):
+    def test_missing_keys_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_bluesky_creds(tmp, {'bluesky': {}})
+            with self.assertRaises(ValueError):
+                auth.BlueskyAuth(path)
+
+    def test_get_client_raises_when_atproto_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_bluesky_creds(tmp, {
+                'bluesky': {'IDENTIFIER': 'me', 'APP_PASSWORD': 'pw'}
+            })
+            a = auth.BlueskyAuth(path)
+            with patch('auth.AtprotoClient', None):
+                with self.assertRaises(RuntimeError):
+                    a.get_client()
+
+    def test_get_client_logs_in_with_credentials(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write_bluesky_creds(tmp, {
+                'bluesky': {'IDENTIFIER': 'me', 'APP_PASSWORD': 'pw'}
+            })
+            a = auth.BlueskyAuth(path)
+
+            fake_client = MagicMock()
+            with patch('auth.AtprotoClient', return_value=fake_client) as ctor:
+                returned = a.get_client()
+
+            ctor.assert_called_once_with()
+            fake_client.login.assert_called_once_with('me', 'pw')
+            self.assertIs(returned, fake_client)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/tests/test_bluesky_links_extra.py
+++ b/fetchlinks/tests/test_bluesky_links_extra.py
@@ -1,0 +1,123 @@
+import unittest
+
+import bluesky_links
+
+
+class IsExcludedHostTests(unittest.TestCase):
+    def test_bsky_app_excluded(self):
+        self.assertTrue(bluesky_links._is_excluded_host('https://bsky.app/profile/x'))
+
+    def test_subdomain_of_excluded_host(self):
+        self.assertTrue(bluesky_links._is_excluded_host('https://staging.bsky.social/x'))
+
+    def test_external_host_allowed(self):
+        self.assertFalse(bluesky_links._is_excluded_host('https://example.com/'))
+
+    def test_malformed_url_returns_false(self):
+        # urlparse rarely raises but handle gracefully either way.
+        self.assertFalse(bluesky_links._is_excluded_host(''))
+
+
+class ExtractLinksFromFacetsTests(unittest.TestCase):
+    def test_extracts_http_links_only(self):
+        record = {
+            'facets': [
+                {'features': [{'uri': 'https://a.example/x'}]},
+                {'features': [{'uri': 'at://did:plc:xyz/foo'}, {'uri': 'http://b.example/'}]},
+            ]
+        }
+        self.assertEqual(
+            bluesky_links._extract_links_from_facets(record),
+            ['https://a.example/x', 'http://b.example/'],
+        )
+
+    def test_no_facets_returns_empty(self):
+        self.assertEqual(bluesky_links._extract_links_from_facets({}), [])
+
+
+class ExtractLinksFromEmbedTests(unittest.TestCase):
+    def test_walks_nested_dicts_and_lists(self):
+        embed = {
+            'external': {'uri': 'https://outer.example/x'},
+            'images': [
+                {'fullsize': 'https://img.example/1'},
+                {'thumb': {'uri': 'https://img.example/2'}},
+            ],
+            'noise': {'uri': 'at://did:plc:abc/y'},
+        }
+        links = bluesky_links._extract_links_from_embed(embed)
+        self.assertIn('https://outer.example/x', links)
+        self.assertIn('https://img.example/2', links)
+        self.assertNotIn('at://did:plc:abc/y', links)
+
+    def test_handles_none(self):
+        self.assertEqual(bluesky_links._extract_links_from_embed(None), [])
+
+
+class BuildDirectLinkTests(unittest.TestCase):
+    def test_builds_url_from_handle_and_uri(self):
+        author = {'handle': 'alice.bsky.social'}
+        post = {'uri': 'at://did:plc:alice/app.bsky.feed.post/xyz123'}
+        self.assertEqual(
+            bluesky_links._build_direct_link(author, post),
+            'https://bsky.app/profile/alice.bsky.social/post/xyz123',
+        )
+
+    def test_returns_empty_when_handle_missing(self):
+        self.assertEqual(bluesky_links._build_direct_link({}, {'uri': 'at://x/post/abc'}), '')
+
+    def test_returns_empty_when_uri_missing(self):
+        self.assertEqual(
+            bluesky_links._build_direct_link({'handle': 'alice'}, {}),
+            '',
+        )
+
+
+class BuildSourceTests(unittest.TestCase):
+    def test_with_handle(self):
+        self.assertEqual(
+            bluesky_links._build_source({'handle': 'alice.bsky.social'}),
+            'https://bsky.app/profile/alice.bsky.social',
+        )
+
+    def test_falls_back_to_did(self):
+        self.assertEqual(
+            bluesky_links._build_source({'did': 'did:plc:abc'}),
+            'https://bsky.app/profile/did:plc:abc',
+        )
+
+    def test_no_author_info(self):
+        self.assertEqual(bluesky_links._build_source({}), 'https://bsky.app')
+
+
+def _item_with(text='hi', created_at='2026-04-19T12:00:00Z', facets=None, embed=None):
+    return {
+        'post': {
+            'uri': 'at://did:plc:alice/app.bsky.feed.post/xyz',
+            'author': {'handle': 'alice.bsky.social', 'displayName': 'Alice'},
+            'record': {
+                'text': text,
+                'createdAt': created_at,
+                'facets': facets or [],
+            },
+            'embed': embed,
+        }
+    }
+
+
+class ParseFeedItemTests(unittest.TestCase):
+    def test_missing_text_returns_none(self):
+        item = _item_with(text='')
+        self.assertIsNone(bluesky_links._parse_feed_item(item))
+
+    def test_missing_created_at_returns_none(self):
+        item = _item_with(created_at='')
+        self.assertIsNone(bluesky_links._parse_feed_item(item))
+
+    def test_only_excluded_links_returns_none(self):
+        item = _item_with(text='see https://bsky.app/profile/x')
+        self.assertIsNone(bluesky_links._parse_feed_item(item))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/tests/test_db_setup_extra.py
+++ b/fetchlinks/tests/test_db_setup_extra.py
@@ -1,0 +1,74 @@
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+import db_setup
+
+
+class TablesAndSchemaTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.db_dir = Path(self._tmp.name) / 'db'
+        self.db_name = 'fetchlinks.db'
+        db_setup.db_initial_setup(str(self.db_dir), self.db_name)
+        self.db_path = self.db_dir / self.db_name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_all_expected_tables_created(self):
+        with sqlite3.connect(self.db_path) as conn:
+            tables = {
+                row[0]
+                for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            }
+        for expected in ('posts', 'post_urls', 'bluesky_state', 'rss_feed_state'):
+            self.assertIn(expected, tables)
+
+    def test_unique_id_string_constraint(self):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                'INSERT INTO posts (source, author, description, direct_link, '
+                'date_created, unique_id_string) VALUES (?, ?, ?, ?, ?, ?)',
+                ('s', 'a', 'd', 'dl', 't', 'uid-1'),
+            )
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute(
+                    'INSERT INTO posts (source, author, description, direct_link, '
+                    'date_created, unique_id_string) VALUES (?, ?, ?, ?, ?, ?)',
+                    ('s', 'a', 'd', 'dl', 't', 'uid-1'),
+                )
+
+    def test_post_urls_foreign_key_enforced(self):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute('PRAGMA foreign_keys=ON')
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute(
+                    'INSERT INTO post_urls (post_id, position, url, url_hash) '
+                    'VALUES (?, ?, ?, ?)',
+                    (9999, 0, 'https://example.com', 'h'),
+                )
+
+    def test_post_urls_cascade_on_post_delete(self):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute('PRAGMA foreign_keys=ON')
+            cur = conn.cursor()
+            cur.execute(
+                'INSERT INTO posts (source, author, description, direct_link, '
+                'date_created, unique_id_string) VALUES (?, ?, ?, ?, ?, ?)',
+                ('s', 'a', 'd', 'dl', 't', 'uid-1'),
+            )
+            post_id = cur.lastrowid
+            cur.execute(
+                'INSERT INTO post_urls (post_id, position, url, url_hash) '
+                'VALUES (?, ?, ?, ?)',
+                (post_id, 0, 'https://example.com', 'h'),
+            )
+            cur.execute('DELETE FROM posts WHERE idx = ?', (post_id,))
+            count = cur.execute('SELECT COUNT(*) FROM post_urls').fetchone()[0]
+        self.assertEqual(count, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/tests/test_db_utils.py
+++ b/fetchlinks/tests/test_db_utils.py
@@ -1,0 +1,148 @@
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import db_setup
+import db_utils
+from utils import Post
+
+
+def _make_post(unique_id, urls):
+    p = Post()
+    p.source = 'https://example.com'
+    p.author = 'a'
+    p.description = 'd'
+    p.direct_link = 'https://example.com/post'
+    p.date_created = '2026-01-01 00:00:00'
+    for u in urls:
+        p.add_url(u)
+    p.unique_id_string = unique_id
+    return p
+
+
+class _TmpDbCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.db_dir = Path(self._tmp.name) / 'db'
+        self.db_name = 'fetchlinks.db'
+        db_setup.db_initial_setup(str(self.db_dir), self.db_name)
+        self.db_path = self.db_dir / self.db_name
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+
+class DbInsertTests(_TmpDbCase):
+    def test_returns_zero_for_empty_input(self):
+        self.assertEqual(db_utils.db_insert([], self.db_path), 0)
+
+    def test_inserts_post_and_url_rows(self):
+        post = _make_post('uid-1', ['https://example.com/a', 'https://example.com/b'])
+
+        inserted = db_utils.db_insert([post], self.db_path)
+
+        self.assertEqual(inserted, 1)
+        with sqlite3.connect(self.db_path) as conn:
+            posts = conn.execute('SELECT unique_id_string FROM posts').fetchall()
+            urls = conn.execute('SELECT url, position FROM post_urls ORDER BY position').fetchall()
+        self.assertEqual(posts, [('uid-1',)])
+        self.assertEqual(urls, [('https://example.com/a', 0), ('https://example.com/b', 1)])
+
+    def test_duplicate_unique_id_skips_post_and_urls(self):
+        first = _make_post('uid-1', ['https://example.com/a'])
+        # Same unique_id_string but different URLs — must not re-insert URL rows.
+        dup = _make_post('uid-1', ['https://example.com/different'])
+
+        inserted_first = db_utils.db_insert([first], self.db_path)
+        inserted_dup = db_utils.db_insert([dup], self.db_path)
+
+        self.assertEqual(inserted_first, 1)
+        self.assertEqual(inserted_dup, 0)
+        with sqlite3.connect(self.db_path) as conn:
+            urls = [row[0] for row in conn.execute('SELECT url FROM post_urls')]
+        self.assertEqual(urls, ['https://example.com/a'])
+
+    def test_sqlite_error_wrapped_in_runtime_error(self):
+        post = _make_post('uid-1', ['https://example.com/a'])
+        with patch('db_utils.sqlite3.connect', side_effect=sqlite3.Error('boom')):
+            with self.assertRaises(RuntimeError):
+                db_utils.db_insert([post], self.db_path)
+
+    def test_post_with_no_urls_still_inserts_post_row(self):
+        post = _make_post('uid-1', [])
+        inserted = db_utils.db_insert([post], self.db_path)
+        self.assertEqual(inserted, 1)
+        with sqlite3.connect(self.db_path) as conn:
+            url_count = conn.execute('SELECT COUNT(*) FROM post_urls').fetchone()[0]
+        self.assertEqual(url_count, 0)
+
+
+class BlueskyCursorTests(_TmpDbCase):
+    def test_get_returns_none_on_empty(self):
+        self.assertIsNone(db_utils.db_get_bluesky_cursor(self.db_path))
+
+    def test_set_and_get_round_trip(self):
+        db_utils.db_set_bluesky_cursor('abc', self.db_path)
+        self.assertEqual(db_utils.db_get_bluesky_cursor(self.db_path), 'abc')
+
+    def test_set_upserts_single_row(self):
+        db_utils.db_set_bluesky_cursor('one', self.db_path)
+        db_utils.db_set_bluesky_cursor('two', self.db_path)
+        db_utils.db_set_bluesky_cursor('three', self.db_path)
+
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute('SELECT idx, cursor FROM bluesky_state').fetchall()
+
+        self.assertEqual(rows, [(1, 'three')])
+
+    def test_empty_cursor_treated_as_none(self):
+        db_utils.db_set_bluesky_cursor('', self.db_path)
+        self.assertIsNone(db_utils.db_get_bluesky_cursor(self.db_path))
+
+    def test_cleans_up_legacy_rows(self):
+        # Simulate legacy multi-row state.
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executemany(
+                'INSERT INTO bluesky_state (idx, cursor, time_created) VALUES (?, ?, ?)',
+                [(2, 'old1', 't'), (3, 'old2', 't')],
+            )
+            conn.commit()
+
+        db_utils.db_set_bluesky_cursor('new', self.db_path)
+
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute('SELECT idx, cursor FROM bluesky_state ORDER BY idx').fetchall()
+        self.assertEqual(rows, [(1, 'new')])
+
+
+class RssFeedStateTests(_TmpDbCase):
+    def test_get_returns_empty_dict_on_empty_table(self):
+        self.assertEqual(db_utils.db_get_rss_feed_states(self.db_path), {})
+
+    def test_set_then_get_round_trip(self):
+        rows = [
+            ('https://feed1.example/', 'etag1', 'lm1', 200),
+            ('https://feed2.example/', '', 'lm2', 304),
+        ]
+        db_utils.db_set_rss_feed_states(rows, self.db_path)
+
+        states = db_utils.db_get_rss_feed_states(self.db_path)
+        self.assertEqual(states['https://feed1.example/'], ('etag1', 'lm1'))
+        self.assertEqual(states['https://feed2.example/'], ('', 'lm2'))
+
+    def test_set_upserts_existing_row(self):
+        db_utils.db_set_rss_feed_states([('https://f.example/', 'e1', 'lm1', 200)], self.db_path)
+        db_utils.db_set_rss_feed_states([('https://f.example/', 'e2', 'lm2', 200)], self.db_path)
+
+        states = db_utils.db_get_rss_feed_states(self.db_path)
+        self.assertEqual(states, {'https://f.example/': ('e2', 'lm2')})
+
+    def test_set_with_empty_list_is_noop(self):
+        db_utils.db_set_rss_feed_states([], self.db_path)  # must not raise
+        self.assertEqual(db_utils.db_get_rss_feed_states(self.db_path), {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/tests/test_export_links.py
+++ b/fetchlinks/tests/test_export_links.py
@@ -1,0 +1,102 @@
+import json
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+
+import db_setup
+import export_links
+
+
+class _ExportCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.db_path = self.tmp / 'db' / 'fetchlinks.db'
+        db_setup.db_initial_setup(str(self.db_path.parent), self.db_path.name)
+        self.out_path = self.tmp / 'out' / 'links.txt'
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _seed(self, rows):
+        # rows is list of (url, unshortened_url|None)
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.cursor()
+            cur.execute(
+                'INSERT INTO posts (source, author, description, direct_link, '
+                'date_created, unique_id_string) VALUES (?, ?, ?, ?, ?, ?)',
+                ('s', 'a', 'd', 'dl', '2026-01-01 00:00:00', 'uid-1'),
+            )
+            post_id = cur.lastrowid
+            for i, (url, unshort) in enumerate(rows):
+                cur.execute(
+                    'INSERT INTO post_urls (post_id, position, url, url_hash, unshortened_url) '
+                    'VALUES (?, ?, ?, ?, ?)',
+                    (post_id, i, url, f'hash{i}', unshort),
+                )
+            conn.commit()
+
+
+class ResolveDbPathTests(unittest.TestCase):
+    def test_absolute_db_location_preserved(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / 'config.json'
+            cfg.write_text(json.dumps({
+                'db_info': {'db_name': 'x.db', 'db_location': '/abs/dir'}
+            }), encoding='utf-8')
+            self.assertEqual(export_links.resolve_db_path(cfg), Path('/abs/dir/x.db'))
+
+    def test_relative_db_location_anchored_to_script_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = Path(tmp) / 'config.json'
+            cfg.write_text(json.dumps({
+                'db_info': {'db_name': 'x.db', 'db_location': 'db/'}
+            }), encoding='utf-8')
+            resolved = export_links.resolve_db_path(cfg)
+            self.assertTrue(resolved.is_absolute())
+            # Ends with db/x.db under the export_links script dir.
+            self.assertEqual(resolved.name, 'x.db')
+
+
+class ExportLinksTests(_ExportCase):
+    def test_missing_db_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            export_links.export_links(self.tmp / 'no.db', self.out_path, None)
+
+    def test_writes_sorted_links_one_per_line(self):
+        self._seed([
+            ('https://b.example/', None),
+            ('https://a.example/', None),
+        ])
+
+        count = export_links.export_links(self.db_path, self.out_path, None)
+
+        self.assertEqual(count, 2)
+        lines = self.out_path.read_text(encoding='utf-8').splitlines()
+        self.assertEqual(lines, ['https://a.example/', 'https://b.example/'])
+
+    def test_prefers_unshortened_url_when_present(self):
+        self._seed([
+            ('https://t.co/abc', 'https://target.example/article'),
+            ('https://example.com/', ''),  # empty -> falls back to url
+        ])
+
+        export_links.export_links(self.db_path, self.out_path, None)
+
+        lines = self.out_path.read_text(encoding='utf-8').splitlines()
+        self.assertIn('https://target.example/article', lines)
+        self.assertIn('https://example.com/', lines)
+        self.assertNotIn('https://t.co/abc', lines)
+
+    def test_respects_limit(self):
+        self._seed([(f'https://example{i}.com/', None) for i in range(5)])
+
+        count = export_links.export_links(self.db_path, self.out_path, limit=2)
+
+        self.assertEqual(count, 2)
+        self.assertEqual(len(self.out_path.read_text(encoding='utf-8').splitlines()), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/tests/test_rss_links.py
+++ b/fetchlinks/tests/test_rss_links.py
@@ -1,0 +1,145 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+import rss_links
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, content=b'', headers=None):
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers or {}
+
+
+def _atom_bytes(link='https://example.com/post', title='entry'):
+    # Minimal Atom feed feedparser will parse cleanly.
+    return (
+        '<?xml version="1.0"?>'
+        '<feed xmlns="http://www.w3.org/2005/Atom">'
+        '<title>F</title>'
+        '<link href="https://example.com/"/>'
+        '<id>tag:example.com,2026:/</id>'
+        '<updated>2026-04-19T12:00:00Z</updated>'
+        f'<entry><title>{title}</title>'
+        f'<link href="{link}"/>'
+        '<id>tag:example.com,2026:/1</id>'
+        '<updated>2026-04-19T12:00:00Z</updated>'
+        '<published>2026-04-19T12:00:00Z</published>'
+        '</entry></feed>'
+    ).encode()
+
+
+class FetchOneTests(unittest.TestCase):
+    def test_sends_conditional_headers_when_cached(self):
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _FakeResponse(304, headers={'ETag': 'e2', 'Last-Modified': 'lm2'})
+
+        result = rss_links._fetch_one(session, 'https://feed/', ('etag-1', 'lm-1'))
+
+        # Headers passed in
+        _args, kwargs = session.get.call_args
+        headers = kwargs['headers']
+        self.assertEqual(headers['If-None-Match'], 'etag-1')
+        self.assertEqual(headers['If-Modified-Since'], 'lm-1')
+        # 304 yields None feed, picks up new etag/lm.
+        self.assertEqual(result, ('https://feed/', None, 'e2', 'lm2', 304))
+
+    def test_no_conditional_headers_when_no_cache(self):
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _FakeResponse(200, content=_atom_bytes())
+
+        rss_links._fetch_one(session, 'https://feed/', ('', ''))
+
+        headers = session.get.call_args.kwargs['headers']
+        self.assertNotIn('If-None-Match', headers)
+        self.assertNotIn('If-Modified-Since', headers)
+
+    def test_request_exception_preserves_cached_state(self):
+        session = MagicMock(spec=requests.Session)
+        session.get.side_effect = requests.ConnectionError('boom')
+
+        result = rss_links._fetch_one(session, 'https://feed/', ('etag-1', 'lm-1'))
+
+        self.assertEqual(result, ('https://feed/', None, 'etag-1', 'lm-1', 0))
+
+    def test_non_200_non_304_returns_none_feed(self):
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _FakeResponse(500)
+
+        url, feed, etag, lm, status = rss_links._fetch_one(session, 'https://feed/', ('', ''))
+
+        self.assertIsNone(feed)
+        self.assertEqual(status, 500)
+
+    def test_200_with_valid_feed_returns_parsed_feed(self):
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _FakeResponse(
+            200,
+            content=_atom_bytes(),
+            headers={'ETag': 'e1', 'Last-Modified': 'lm1'},
+        )
+
+        url, feed, etag, lm, status = rss_links._fetch_one(session, 'https://feed/', ('', ''))
+
+        self.assertIsNotNone(feed)
+        self.assertEqual(status, 200)
+        self.assertEqual(etag, 'e1')
+        self.assertEqual(lm, 'lm1')
+        self.assertEqual(len(feed.entries), 1)
+
+    def test_bozo_with_no_entries_returns_none_feed(self):
+        session = MagicMock(spec=requests.Session)
+        # Garbage that won't parse.
+        session.get.return_value = _FakeResponse(200, content=b'<<<not xml>>>')
+
+        url, feed, etag, lm, status = rss_links._fetch_one(session, 'https://feed/', ('', ''))
+
+        self.assertIsNone(feed)
+        self.assertEqual(status, 200)
+
+
+class ParsePostsTests(unittest.TestCase):
+    def test_skips_none_feeds(self):
+        results = [('https://x/', None, '', '', 304)]
+        self.assertEqual(rss_links.parse_posts(results), [])
+
+    def test_uses_feed_link_as_source(self):
+        # Build a single fetch result by reusing _fetch_one with a fake response.
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _FakeResponse(200, content=_atom_bytes())
+        fetch_results = [rss_links._fetch_one(session, 'https://feedurl/', ('', ''))]
+
+        posts = rss_links.parse_posts(fetch_results)
+        self.assertEqual(len(posts), 1)
+        # Atom feed self-link is https://example.com/, so source should match.
+        self.assertEqual(posts[0].source, 'https://example.com/')
+        self.assertEqual(posts[0].urls, ['https://example.com/post'])
+
+    def test_skips_entries_with_no_urls(self):
+        # Atom entry with empty link
+        session = MagicMock(spec=requests.Session)
+        session.get.return_value = _FakeResponse(200, content=_atom_bytes(link=''))
+        fetch_results = [rss_links._fetch_one(session, 'https://feedurl/', ('', ''))]
+
+        self.assertEqual(rss_links.parse_posts(fetch_results), [])
+
+
+class FetchFeedsTests(unittest.TestCase):
+    def test_fetches_each_url_once(self):
+        # Patch _fetch_one to avoid real network and confirm dispatch.
+        with patch.object(rss_links, '_fetch_one') as mock_fetch:
+            mock_fetch.side_effect = lambda session, url, cached: (url, None, '', '', 304)
+            urls = ['https://a/', 'https://b/', 'https://c/']
+            results = rss_links.fetch_feeds(urls, {'https://a/': ('e', 'l')})
+
+        self.assertEqual({r[0] for r in results}, set(urls))
+        # The cached state for 'a' was forwarded; the others got ('', '').
+        called_with = {call.args[1]: call.args[2] for call in mock_fetch.call_args_list}
+        self.assertEqual(called_with['https://a/'], ('e', 'l'))
+        self.assertEqual(called_with['https://b/'], ('', ''))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/tests/test_startup_and_validate.py
+++ b/fetchlinks/tests/test_startup_and_validate.py
@@ -1,0 +1,194 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import startup_and_validate as sv
+
+
+def _write(path, data):
+    Path(path).write_text(json.dumps(data), encoding='utf-8')
+
+
+class ParseConfigTests(unittest.TestCase):
+    def test_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            sv.parse_config('/no/such/file.json')
+
+    def test_valid_config_anchors_relative_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_path = Path(tmp) / 'config.json'
+            _write(cfg_path, {
+                'db_info': {'db_name': 'x.db', 'db_location': 'db/'},
+                'log_info': {
+                    'log_config_location': 'log.conf',
+                    'log_location': 'logs/app.log',
+                    'log_level': 'INFO',
+                },
+            })
+
+            config = sv.parse_config(str(cfg_path))
+
+            # Relative paths get anchored to the script dir, not cwd.
+            self.assertTrue(Path(config['db_info']['db_location']).is_absolute())
+            self.assertTrue(Path(config['log_info']['log_location']).is_absolute())
+            # Log directory was created.
+            self.assertTrue(Path(config['log_info']['log_location']).parent.is_dir())
+
+    def test_missing_section_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_path = Path(tmp) / 'config.json'
+            _write(cfg_path, {'db_info': {'db_name': 'x.db', 'db_location': 'db/'}})
+            with self.assertRaises(ValueError):
+                sv.parse_config(str(cfg_path))
+
+    def test_missing_field_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_path = Path(tmp) / 'config.json'
+            _write(cfg_path, {
+                'db_info': {'db_name': 'x.db'},  # missing db_location
+                'log_info': {
+                    'log_config_location': 'log.conf',
+                    'log_location': 'logs/app.log',
+                    'log_level': 'INFO',
+                },
+            })
+            with self.assertRaises(ValueError):
+                sv.parse_config(str(cfg_path))
+
+    def test_non_string_field_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_path = Path(tmp) / 'config.json'
+            _write(cfg_path, {
+                'db_info': {'db_name': 123, 'db_location': 'db/'},
+                'log_info': {
+                    'log_config_location': 'log.conf',
+                    'log_location': 'logs/app.log',
+                    'log_level': 'INFO',
+                },
+            })
+            with self.assertRaises(ValueError):
+                sv.parse_config(str(cfg_path))
+
+
+class ParseSourcesTests(unittest.TestCase):
+    def test_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            sv.parse_sources('/no/such/file.json')
+
+    def test_non_dict_settings_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'reddit': 'oops'})
+            with self.assertRaises(ValueError):
+                sv.parse_sources(str(p))
+
+    def test_disabled_source_skips_credential_check(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {
+                'reddit': {
+                    'enabled': False,
+                    'credential_location': '/no/such/creds.json',
+                }
+            })
+            # Should not raise even though creds file doesn't exist.
+            sv.parse_sources(str(p))
+
+    def test_missing_credential_file_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {
+                'reddit': {'credential_location': str(Path(tmp) / 'missing.json')}
+            })
+            with self.assertRaises(FileNotFoundError):
+                sv.parse_sources(str(p))
+
+    def test_tilde_in_credential_location_is_expanded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Place creds file under the fake HOME so ~ resolves to it.
+            home = Path(tmp) / 'home'
+            home.mkdir()
+            creds = home / 'creds.json'
+            creds.write_text('{}', encoding='utf-8')
+
+            sources_path = Path(tmp) / 'sources.json'
+            _write(sources_path, {'reddit': {'credential_location': '~/creds.json'}})
+
+            old_home = os.environ.get('HOME')
+            os.environ['HOME'] = str(home)
+            try:
+                sources = sv.parse_sources(str(sources_path))
+            finally:
+                if old_home is None:
+                    os.environ.pop('HOME', None)
+                else:
+                    os.environ['HOME'] = old_home
+
+            # Settings now hold the expanded path.
+            self.assertEqual(
+                sources['reddit']['credential_location'],
+                str(creds),
+            )
+
+    def test_empty_rss_feeds_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'rss': {'feeds': []}})
+            # The validator only complains when feeds list is present and len < 1.
+            # An empty list is falsy so it currently passes validation; this asserts
+            # the documented behaviour: only a populated-but-empty feeds key trips it.
+            sv.parse_sources(str(p))  # should not raise
+
+    def test_bluesky_enabled_without_creds_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'bluesky': {'enabled': True}})
+            with self.assertRaises(ValueError):
+                sv.parse_sources(str(p))
+
+    def test_bluesky_timeline_limit_not_int_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            creds = Path(tmp) / 'c.json'
+            creds.write_text('{}', encoding='utf-8')
+            p = Path(tmp) / 'sources.json'
+            _write(p, {
+                'bluesky': {
+                    'enabled': True,
+                    'credential_location': str(creds),
+                    'timeline_limit': 'lots',
+                }
+            })
+            with self.assertRaises(ValueError):
+                sv.parse_sources(str(p))
+
+    def test_bluesky_timeline_limit_zero_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            creds = Path(tmp) / 'c.json'
+            creds.write_text('{}', encoding='utf-8')
+            p = Path(tmp) / 'sources.json'
+            _write(p, {
+                'bluesky': {
+                    'enabled': True,
+                    'credential_location': str(creds),
+                    'timeline_limit': 0,
+                }
+            })
+            with self.assertRaises(ValueError):
+                sv.parse_sources(str(p))
+
+
+class ResolveRelativePathTests(unittest.TestCase):
+    def test_absolute_path_returned_as_is(self):
+        result = sv._resolve_relative_to_script('/tmp/x')
+        self.assertEqual(result, Path('/tmp/x'))
+
+    def test_relative_path_anchored_to_script_dir(self):
+        result = sv._resolve_relative_to_script('db/x.db')
+        self.assertTrue(result.is_absolute())
+        self.assertEqual(result.parent.parent, sv.SCRIPT_DIR)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/tests/test_utils.py
+++ b/fetchlinks/tests/test_utils.py
@@ -1,0 +1,201 @@
+import unittest
+from unittest.mock import patch
+
+from utils import (
+    BlueskyPost,
+    Post,
+    RedditPost,
+    RssPost,
+    build_hash,
+    convert_date_string_for_mysql,
+    convert_epoch_to_mysql,
+    extract_urls_from_text,
+)
+
+
+class _RssEntry(dict):
+    """feedparser entries support both dict-style .get() and attribute access."""
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+
+def _make_reddit_post(url, **overrides):
+    data = {
+        'subreddit_name_prefixed': 'r/netsec',
+        'author': 'someone',
+        'title': 'a post',
+        'permalink': '/r/netsec/comments/abc/a_post/',
+        'created_utc': 1700000000,
+        'url': url,
+    }
+    data.update(overrides)
+    return {'data': data}
+
+
+class BuildHashTests(unittest.TestCase):
+    def test_known_input_produces_expected_hash(self):
+        # SHA-256 of the bytes "hello"
+        expected = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+        self.assertEqual(build_hash('hello'), expected)
+
+    def test_different_inputs_produce_different_hashes(self):
+        self.assertNotEqual(build_hash('a'), build_hash('b'))
+
+
+class ConvertDateStringTests(unittest.TestCase):
+    def test_iso_string_round_trips_to_mysql_format(self):
+        self.assertEqual(
+            convert_date_string_for_mysql('2026-04-19T12:34:56Z'),
+            '2026-04-19 12:34:56',
+        )
+
+    def test_unparseable_string_falls_back_to_now_utc(self):
+        result = convert_date_string_for_mysql('not a date at all')
+        # Should be a 19-char "YYYY-MM-DD HH:MM:SS" string.
+        self.assertRegex(result, r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$')
+
+
+class ConvertEpochTests(unittest.TestCase):
+    def test_known_epoch_converts_to_utc(self):
+        # 1700000000 -> 2023-11-14 22:13:20 UTC
+        self.assertEqual(convert_epoch_to_mysql(1700000000), '2023-11-14 22:13:20')
+
+    def test_accepts_float_epoch(self):
+        self.assertEqual(convert_epoch_to_mysql(1700000000.7), '2023-11-14 22:13:20')
+
+
+class ExtractUrlsFromTextTests(unittest.TestCase):
+    def test_finds_http_and_https(self):
+        text = 'see http://a.com and https://b.com/x for more'
+        self.assertEqual(
+            extract_urls_from_text(text),
+            ['http://a.com', 'https://b.com/x'],
+        )
+
+    def test_strips_trailing_punctuation(self):
+        # The regex excludes ) ] > " ' from the match.
+        text = 'check (https://example.com/foo) and [https://example.com/bar]'
+        self.assertEqual(
+            extract_urls_from_text(text),
+            ['https://example.com/foo', 'https://example.com/bar'],
+        )
+
+    def test_empty_or_none_returns_empty_list(self):
+        self.assertEqual(extract_urls_from_text(''), [])
+        self.assertEqual(extract_urls_from_text(None), [])
+
+    def test_ignores_non_http_schemes(self):
+        text = 'ftp://x.com mailto:a@b.com javascript:foo()'
+        self.assertEqual(extract_urls_from_text(text), [])
+
+
+class PostTests(unittest.TestCase):
+    def test_add_url_dedupes_and_preserves_order(self):
+        p = Post()
+        p.add_url('https://a.com')
+        p.add_url('https://b.com')
+        p.add_url('https://a.com')  # duplicate
+        self.assertEqual(p.urls, ['https://a.com', 'https://b.com'])
+
+    def test_add_url_drops_invalid(self):
+        p = Post()
+        p.add_url('not a url')
+        p.add_url('')
+        p.add_url('javascript:alert(1)')
+        self.assertEqual(p.urls, [])
+
+    def test_unique_id_string_is_order_invariant(self):
+        a = Post()
+        a.add_url('https://a.com')
+        a.add_url('https://b.com')
+        a._generate_unique_url_string()
+
+        b = Post()
+        b.add_url('https://b.com')
+        b.add_url('https://a.com')
+        b._generate_unique_url_string()
+
+        self.assertEqual(a.unique_id_string, b.unique_id_string)
+        self.assertNotEqual(a.unique_id_string, '')
+
+    def test_get_post_row_shape(self):
+        p = Post()
+        p.source = 's'
+        p.author = 'a'
+        p.description = 'd'
+        p.direct_link = 'dl'
+        p.date_created = '2026-01-01 00:00:00'
+        p.unique_id_string = 'u'
+        self.assertEqual(p.get_post_row(), ('s', 'a', 'd', 'dl', '2026-01-01 00:00:00', 'u'))
+
+    def test_get_url_rows_shape(self):
+        p = Post()
+        p.add_url('https://a.com')
+        p.add_url('https://b.com')
+        rows = p.get_url_rows()
+        self.assertEqual(len(rows), 2)
+        # (position, url, url_hash)
+        self.assertEqual(rows[0][0], 0)
+        self.assertEqual(rows[0][1], 'https://a.com')
+        self.assertEqual(rows[0][2], build_hash('https://a.com'))
+        self.assertEqual(rows[1][0], 1)
+
+
+class RssPostTests(unittest.TestCase):
+    def test_falls_back_to_updated_when_no_published(self):
+        entry = _RssEntry(title='t', link='https://example.com/a', updated='2026-04-19T12:34:56Z')
+        post = RssPost('https://example.com/feed.xml', 'Example', entry)
+        self.assertEqual(post.date_created, '2026-04-19 12:34:56')
+
+    def test_falls_back_to_now_when_no_dates(self):
+        entry = _RssEntry(title='t', link='https://example.com/a')
+        post = RssPost('https://example.com/feed.xml', 'Example', entry)
+        self.assertRegex(post.date_created, r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$')
+
+    def test_missing_title_defaults_to_empty(self):
+        entry = _RssEntry(link='https://example.com/a', published='2026-04-19T12:00:00Z')
+        post = RssPost('https://example.com/feed.xml', 'Example', entry)
+        self.assertEqual(post.description, '')
+
+
+class RedditPostTests(unittest.TestCase):
+    def test_extract_data_builds_source_and_direct_link(self):
+        post = RedditPost(_make_reddit_post('https://example.com/article'))
+        self.assertEqual(post.source, 'https://www.reddit.com/r/netsec')
+        self.assertEqual(post.author, 'someone')
+        self.assertEqual(post.description, 'a post')
+        self.assertEqual(
+            post.direct_link,
+            'https://www.reddit.com/r/netsec/comments/abc/a_post/',
+        )
+        self.assertEqual(post.date_created, '2023-11-14 22:13:20')
+
+    def test_keeps_http_external_url(self):
+        post = RedditPost(_make_reddit_post('http://example.com/article'))
+        self.assertEqual(post.urls, ['http://example.com/article'])
+
+    def test_unique_id_string_set_after_construction(self):
+        post = RedditPost(_make_reddit_post('https://example.com/article'))
+        self.assertNotEqual(post.unique_id_string, '')
+
+
+class BlueskyPostTests(unittest.TestCase):
+    def test_filters_invalid_urls(self):
+        post = BlueskyPost(
+            source='https://bsky.app/profile/alice',
+            author='Alice',
+            description='hi',
+            direct_link='https://bsky.app/profile/alice/post/xyz',
+            created_at='2026-04-19T12:34:56Z',
+            urls=['https://example.com/a', 'javascript:alert(1)', '', 'https://example.com/b'],
+        )
+        self.assertEqual(post.urls, ['https://example.com/a', 'https://example.com/b'])
+        self.assertEqual(post.date_created, '2026-04-19 12:34:56')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Brings full test count from 35 to 137. Adds dedicated test files for
modules that previously had no coverage and fills gaps in modules with
partial coverage.

New test files:
- test_utils.py: build_hash, date/epoch converters, extract_urls_from_text,
  Post add_url/dedup/order, get_post_row, get_url_rows, RssPost date
  fallbacks, RedditPost extraction, BlueskyPost url filtering
- test_db_utils.py: db_insert (insert/dedup/error/empty), bluesky cursor
  upsert + legacy cleanup, rss_feed_state get/set/upsert
- test_rss_links.py: _fetch_one conditional headers, 200/304/error/bozo
  paths, request exceptions; parse_posts source resolution; fetch_feeds
  dispatch
- test_startup_and_validate.py: parse_config validation, parse_sources
  credential checks, ~ expansion, bluesky timeline_limit validation
- test_auth.py: Auth json loading, RedditAuth secret parsing + token flow,
  BlueskyAuth missing atproto + login dispatch
- test_export_links.py: resolve_db_path, export_links sorted output,
  unshortened_url preference, --limit
- test_bluesky_links_extra.py: _is_excluded_host, facet/embed link
  extraction, _build_direct_link/_build_source, _parse_feed_item edges
- test_db_setup_extra.py: all expected tables present, unique constraint,
  foreign-key enforcement and cascade

All tests use tempfiles for IO and mocks for network.
