### PR TITLE
test: cover orchestrators and edge flows

### DIFF
--- a/fetchlinks/fetch_links.py
+++ b/fetchlinks/fetch_links.py
@@ -32,14 +32,17 @@ def fetch_links(config: dict, sources: dict):
     :param sources: rss links, subreddits, etc...
     :return: Nothing
     """
-    if sources.get('rss', {}).get('enabled', True):
-        rss_links.run(sources['rss']['feeds'], config['db_info'])
+    rss_config = sources.get('rss')
+    if rss_config and rss_config.get('enabled', True):
+        rss_links.run(rss_config['feeds'], config['db_info'])
 
-    if sources.get('reddit', {}).get('enabled', True):
-        reddit_links.run(sources['reddit'], config['db_info'])
+    reddit_config = sources.get('reddit')
+    if reddit_config and reddit_config.get('enabled', True):
+        reddit_links.run(reddit_config, config['db_info'])
 
-    if sources.get('bluesky', {}).get('enabled', False):
-        bluesky_links.run(sources['bluesky'], config['db_info'])
+    bluesky_config = sources.get('bluesky')
+    if bluesky_config and bluesky_config.get('enabled', False):
+        bluesky_links.run(bluesky_config, config['db_info'])
 
 
 def main():

--- a/fetchlinks/startup_and_validate.py
+++ b/fetchlinks/startup_and_validate.py
@@ -60,10 +60,11 @@ def _validate_sources(sources: dict):
             if not Path(expanded).exists():
                 raise FileNotFoundError(f'{source} credential file could not be found at location: {expanded}')
 
-    if sources.get('rss'):
-        if sources['rss'].get('enabled', True) and sources['rss'].get('feeds'):
-            if len(sources['rss']['feeds']) < 1:
-                raise ValueError('The Rss config contains no feeds')
+    rss_settings = sources.get('rss')
+    if rss_settings and rss_settings.get('enabled', True):
+        feeds = rss_settings.get('feeds')
+        if not isinstance(feeds, list) or len(feeds) < 1:
+            raise ValueError('The Rss config contains no feeds')
 
     if sources.get('bluesky') and sources['bluesky'].get('enabled', False):
         if not sources['bluesky'].get('credential_location'):

--- a/fetchlinks/tests/test_auth.py
+++ b/fetchlinks/tests/test_auth.py
@@ -83,8 +83,16 @@ class RedditAuthTests(unittest.TestCase):
             mock_resp.raise_for_status.return_value = None
             mock_resp.json.return_value = {'access_token': 'tok'}
 
-            with patch('auth.requests.post', return_value=mock_resp):
+            with patch('auth.requests.post', return_value=mock_resp) as post:
                 self.assertEqual(a.get_auth(), 'tok')
+
+            post.assert_called_once_with(
+                a.reddit_auth_api_url,
+                headers={'User-Agent': a.user_agent},
+                data={'grant_type': 'client_credentials'},
+                auth=('c', 's'),
+                timeout=20,
+            )
             self.assertEqual(a.access_token, 'tok')
 
     def test_get_auth_missing_token_raises(self):

--- a/fetchlinks/tests/test_bluesky_links.py
+++ b/fetchlinks/tests/test_bluesky_links.py
@@ -1,6 +1,7 @@
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import bluesky_links
 import db_setup
@@ -60,6 +61,75 @@ class BlueskyLinksTests(unittest.TestCase):
             db_utils.db_set_bluesky_cursor('cursor-123', db_path)
 
             self.assertEqual(db_utils.db_get_bluesky_cursor(db_path), 'cursor-123')
+
+
+def _timeline_item(url='https://example.com/article'):
+    return {
+        'post': {
+            'uri': 'at://did:plc:alice/app.bsky.feed.post/xyz123',
+            'author': {'handle': 'alice.bsky.social', 'displayName': 'Alice'},
+            'record': {
+                'text': f'Interesting writeup {url}',
+                'createdAt': '2026-04-19T12:00:00.000Z',
+            },
+        }
+    }
+
+
+class BlueskyRunTests(unittest.TestCase):
+    def test_run_skips_when_disabled(self):
+        with patch.object(bluesky_links, 'BlueskyAuth') as auth_cls, \
+             patch.object(bluesky_links.db_utils, 'db_get_bluesky_cursor') as get_cursor:
+            bluesky_links.run({'enabled': False}, {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'})
+
+        auth_cls.assert_not_called()
+        get_cursor.assert_not_called()
+
+    def test_run_fetches_pages_inserts_posts_and_persists_cursor(self):
+        config = {'enabled': True, 'credential_location': '/tmp/bsky.json', 'timeline_limit': 250}
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        client = object()
+        auth_client = Mock()
+        auth_client.get_client.return_value = client
+        fetch_results = [
+            ([_timeline_item('https://example.com/one')], 'cursor-2'),
+            ([], 'cursor-3'),
+        ]
+
+        with patch.object(bluesky_links, 'BlueskyAuth', return_value=auth_client) as auth_cls, \
+             patch.object(bluesky_links.db_utils, 'db_get_bluesky_cursor', return_value='cursor-1') as get_cursor, \
+             patch.object(bluesky_links, '_fetch_timeline_page', side_effect=fetch_results) as fetch_page, \
+             patch.object(bluesky_links.db_utils, 'db_insert', return_value=1) as db_insert, \
+             patch.object(bluesky_links.db_utils, 'db_set_bluesky_cursor') as set_cursor:
+            bluesky_links.run(config, db_info)
+
+        db_path = bluesky_links.Path('/tmp/db') / 'fetchlinks.db'
+        auth_cls.assert_called_once_with('/tmp/bsky.json')
+        get_cursor.assert_called_once_with(db_path)
+        self.assertEqual(fetch_page.call_args_list[0].args, (client, 'cursor-1', bluesky_links.MAX_TIMELINE_LIMIT))
+        self.assertEqual(fetch_page.call_args_list[1].args, (client, 'cursor-2', bluesky_links.MAX_TIMELINE_LIMIT))
+        inserted_posts = db_insert.call_args.args[0]
+        self.assertEqual(len(inserted_posts), 1)
+        self.assertEqual(inserted_posts[0].urls, ['https://example.com/one'])
+        db_insert.assert_called_once_with(inserted_posts, db_path)
+        set_cursor.assert_called_once_with('cursor-3', db_path)
+
+    def test_run_persists_cursor_even_when_no_items_returned(self):
+        config = {'enabled': True, 'credential_location': '/tmp/bsky.json'}
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        auth_client = Mock()
+        auth_client.get_client.return_value = object()
+
+        with patch.object(bluesky_links, 'BlueskyAuth', return_value=auth_client), \
+             patch.object(bluesky_links.db_utils, 'db_get_bluesky_cursor', return_value='cursor-1'), \
+             patch.object(bluesky_links, '_fetch_timeline_page', return_value=([], 'cursor-2')), \
+             patch.object(bluesky_links.db_utils, 'db_insert', return_value=0) as db_insert, \
+             patch.object(bluesky_links.db_utils, 'db_set_bluesky_cursor') as set_cursor:
+            bluesky_links.run(config, db_info)
+
+        db_path = bluesky_links.Path('/tmp/db') / 'fetchlinks.db'
+        db_insert.assert_called_once_with([], db_path)
+        set_cursor.assert_called_once_with('cursor-2', db_path)
 
 
 if __name__ == '__main__':

--- a/fetchlinks/tests/test_bluesky_links_extra.py
+++ b/fetchlinks/tests/test_bluesky_links_extra.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock, patch
 
 import bluesky_links
 
@@ -54,6 +55,61 @@ class ExtractLinksFromEmbedTests(unittest.TestCase):
         self.assertEqual(bluesky_links._extract_links_from_embed(None), [])
 
 
+class TimelineCallTests(unittest.TestCase):
+    def test_call_timeline_uses_sdk_nested_client_shape(self):
+        client = Mock()
+        client.app.bsky.feed.get_timeline.return_value = {'feed': [], 'cursor': 'next'}
+
+        response = bluesky_links._call_timeline(client, limit=25, cursor='cursor-1')
+
+        client.app.bsky.feed.get_timeline.assert_called_once_with(
+            params={'limit': 25, 'cursor': 'cursor-1'}
+        )
+        self.assertEqual(response, {'feed': [], 'cursor': 'next'})
+
+    def test_call_timeline_uses_legacy_client_shape(self):
+        class LegacyClient:
+            def __init__(self):
+                self.get_timeline = Mock(return_value={'feed': [], 'cursor': 'next'})
+
+        client = LegacyClient()
+
+        response = bluesky_links._call_timeline(client, limit=25, cursor=None)
+
+        client.get_timeline.assert_called_once_with(limit=25, cursor=None)
+        self.assertEqual(response, {'feed': [], 'cursor': 'next'})
+
+    def test_as_dict_accepts_model_dump_objects(self):
+        class ModelDumpObject:
+            def model_dump(self, exclude_none=True, by_alias=True):
+                return {'feed': [], 'cursor': 'next'}
+
+        client = Mock()
+        client.app.bsky.feed.get_timeline.return_value = ModelDumpObject()
+
+        self.assertEqual(
+            bluesky_links._call_timeline(client, limit=10, cursor='c'),
+            {'feed': [], 'cursor': 'next'},
+        )
+
+
+class FetchTimelinePageTests(unittest.TestCase):
+    def test_non_list_feed_payload_returns_empty_page(self):
+        with patch.object(bluesky_links, '_call_timeline', return_value={'feed': 'not-a-list', 'cursor': 'next'}):
+            items, cursor = bluesky_links._fetch_timeline_page(object(), cursor='old', limit=25)
+
+        self.assertEqual(items, [])
+        self.assertIsNone(cursor)
+
+    def test_valid_feed_payload_returns_items_and_cursor(self):
+        expected_items = [{'post': {'record': {'text': 'hi'}}}]
+        with patch.object(bluesky_links, '_call_timeline', return_value={'feed': expected_items, 'cursor': 'next'}):
+            items, cursor = bluesky_links._fetch_timeline_page(object(), cursor='old', limit=25)
+
+        self.assertEqual(items, expected_items)
+        self.assertEqual(cursor, 'next')
+
+
 class BuildDirectLinkTests(unittest.TestCase):
     def test_builds_url_from_handle_and_uri(self):
         author = {'handle': 'alice.bsky.social'}
@@ -106,6 +162,9 @@ def _item_with(text='hi', created_at='2026-04-19T12:00:00Z', facets=None, embed=
 
 
 class ParseFeedItemTests(unittest.TestCase):
+    def test_missing_post_returns_none(self):
+        self.assertIsNone(bluesky_links._parse_feed_item({}))
+
     def test_missing_text_returns_none(self):
         item = _item_with(text='')
         self.assertIsNone(bluesky_links._parse_feed_item(item))

--- a/fetchlinks/tests/test_export_links.py
+++ b/fetchlinks/tests/test_export_links.py
@@ -1,7 +1,9 @@
+import io
 import json
 import sqlite3
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 
 import db_setup
@@ -96,6 +98,26 @@ class ExportLinksTests(_ExportCase):
 
         self.assertEqual(count, 2)
         self.assertEqual(len(self.out_path.read_text(encoding='utf-8').splitlines()), 2)
+
+
+class MainTests(_ExportCase):
+    def test_main_accepts_cli_args_writes_file_and_prints_count(self):
+        self._seed([
+            ('https://b.example/', None),
+            ('https://a.example/', None),
+        ])
+        stdout = io.StringIO()
+
+        with redirect_stdout(stdout):
+            result = export_links.main([
+                '--db', str(self.db_path),
+                '--out', str(self.out_path),
+                '--limit', '1',
+            ])
+
+        self.assertEqual(result, 0)
+        self.assertEqual(self.out_path.read_text(encoding='utf-8').splitlines(), ['https://a.example/'])
+        self.assertIn(f'Wrote 1 URLs to {self.out_path}', stdout.getvalue())
 
 
 if __name__ == '__main__':

--- a/fetchlinks/tests/test_fetch_links.py
+++ b/fetchlinks/tests/test_fetch_links.py
@@ -1,0 +1,121 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import fetch_links
+
+
+class FetchLinksRoutingTests(unittest.TestCase):
+    def setUp(self):
+        self.config = {'db_info': {'db_location': '/tmp', 'db_name': 'fetchlinks.db'}}
+
+    def test_runs_default_rss_and_reddit_and_enabled_bluesky(self):
+        sources = {
+            'rss': {'feeds': ['https://feed.example/rss.xml']},
+            'reddit': {'subreddits': ['netsec']},
+            'bluesky': {'enabled': True, 'credential_location': '/tmp/bsky.json'},
+        }
+
+        with patch.object(fetch_links.rss_links, 'run') as rss_run, \
+             patch.object(fetch_links.reddit_links, 'run') as reddit_run, \
+             patch.object(fetch_links.bluesky_links, 'run') as bluesky_run:
+            fetch_links.fetch_links(self.config, sources)
+
+        rss_run.assert_called_once_with(['https://feed.example/rss.xml'], self.config['db_info'])
+        reddit_run.assert_called_once_with(sources['reddit'], self.config['db_info'])
+        bluesky_run.assert_called_once_with(sources['bluesky'], self.config['db_info'])
+
+    def test_skips_disabled_sources(self):
+        sources = {
+            'rss': {'enabled': False, 'feeds': ['https://feed.example/rss.xml']},
+            'reddit': {'enabled': False, 'subreddits': ['netsec']},
+            'bluesky': {'enabled': False, 'credential_location': '/tmp/bsky.json'},
+        }
+
+        with patch.object(fetch_links.rss_links, 'run') as rss_run, \
+             patch.object(fetch_links.reddit_links, 'run') as reddit_run, \
+             patch.object(fetch_links.bluesky_links, 'run') as bluesky_run:
+            fetch_links.fetch_links(self.config, sources)
+
+        rss_run.assert_not_called()
+        reddit_run.assert_not_called()
+        bluesky_run.assert_not_called()
+
+    def test_missing_source_sections_are_skipped(self):
+        with patch.object(fetch_links.rss_links, 'run') as rss_run, \
+             patch.object(fetch_links.reddit_links, 'run') as reddit_run, \
+             patch.object(fetch_links.bluesky_links, 'run') as bluesky_run:
+            fetch_links.fetch_links(self.config, {})
+
+        rss_run.assert_not_called()
+        reddit_run.assert_not_called()
+        bluesky_run.assert_not_called()
+
+    def test_bluesky_is_disabled_by_default(self):
+        sources = {
+            'rss': {'feeds': ['https://feed.example/rss.xml']},
+            'reddit': {'subreddits': ['netsec']},
+            'bluesky': {'credential_location': '/tmp/bsky.json'},
+        }
+
+        with patch.object(fetch_links.rss_links, 'run'), \
+             patch.object(fetch_links.reddit_links, 'run'), \
+             patch.object(fetch_links.bluesky_links, 'run') as bluesky_run:
+            fetch_links.fetch_links(self.config, sources)
+
+        bluesky_run.assert_not_called()
+
+
+class MainFlowTests(unittest.TestCase):
+    def test_main_runs_startup_steps_in_order(self):
+        events = []
+        args = SimpleNamespace(config='config.json', sources='sources.json')
+        config = {
+            'db_info': {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'},
+            'log_info': {'log_location': '/tmp/fetchlinks.log'},
+        }
+        sources = {'rss': {'feeds': ['https://feed.example/rss.xml']}}
+
+        def record(name, value=None):
+            events.append(name)
+            return value
+
+        with patch.object(fetch_links.startup_and_validate, 'parse_arguments', side_effect=lambda: record('parse_arguments', args)), \
+             patch.object(fetch_links.startup_and_validate, 'parse_config', side_effect=lambda path: record('parse_config', config)), \
+             patch.object(fetch_links, 'configure_logging', side_effect=lambda cfg: record('configure_logging')), \
+             patch.object(fetch_links.db_setup, 'db_initial_setup', side_effect=lambda loc, name: record('db_initial_setup')), \
+             patch.object(fetch_links.startup_and_validate, 'parse_sources', side_effect=lambda path: record('parse_sources', sources)), \
+             patch.object(fetch_links, 'fetch_links', side_effect=lambda cfg, src: record('fetch_links')):
+            fetch_links.main()
+
+        self.assertEqual(events, [
+            'parse_arguments',
+            'parse_config',
+            'configure_logging',
+            'db_initial_setup',
+            'parse_sources',
+            'fetch_links',
+        ])
+
+    def test_main_exits_one_on_exception(self):
+        with patch.object(fetch_links.startup_and_validate, 'parse_arguments', return_value=SimpleNamespace(config='bad.json')), \
+             patch.object(fetch_links.startup_and_validate, 'parse_config', side_effect=ValueError('bad config')), \
+             patch.object(fetch_links.logging, 'exception') as log_exception:
+            with self.assertRaises(SystemExit) as exc:
+                fetch_links.main()
+
+        self.assertEqual(exc.exception.code, 1)
+        log_exception.assert_called_once()
+
+    def test_configure_logging_uses_default_info_for_unknown_level(self):
+        config = {'log_info': {'log_location': '/tmp/fetchlinks-test.log', 'log_level': 'NOPE'}}
+        with patch.object(fetch_links, 'RotatingFileHandler') as handler, \
+             patch.object(fetch_links.logging, 'basicConfig') as basic_config:
+            fetch_links.configure_logging(config)
+
+        handler.assert_called_once()
+        self.assertEqual(basic_config.call_args.kwargs['level'], fetch_links.logging.INFO)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/tests/test_reddit_links.py
+++ b/fetchlinks/tests/test_reddit_links.py
@@ -41,6 +41,44 @@ class RedditLinksTests(unittest.TestCase):
         posts = reddit_links.get_subreddit("netsec", "token", "test-ua/0.1")
 
         self.assertEqual(len(posts), 1)
+        mock_get.assert_called_once_with(
+            url='https://oauth.reddit.com/r/netsec/new/.json',
+            params={'sort': 'new', 'show': 'all', 't': 'all', 'limit': '100'},
+            headers={'Authorization': 'Bearer token', 'User-Agent': 'test-ua/0.1'},
+            timeout=reddit_links.REQUEST_TIMEOUT_SECONDS,
+        )
+
+    @patch("reddit_links.requests.get")
+    def test_get_subreddit_returns_empty_on_invalid_json(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.side_effect = ValueError('not json')
+        mock_get.return_value = mock_response
+
+        posts = reddit_links.get_subreddit("netsec", "token", "test-ua/0.1")
+
+        self.assertEqual(posts, [])
+
+    @patch("reddit_links.requests.get")
+    def test_get_subreddit_returns_empty_on_http_error(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = reddit_links.requests.exceptions.HTTPError('bad')
+        mock_get.return_value = mock_response
+
+        posts = reddit_links.get_subreddit("netsec", "token", "test-ua/0.1")
+
+        self.assertEqual(posts, [])
+
+    @patch("reddit_links.requests.get")
+    def test_get_subreddit_returns_empty_when_children_not_list(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {'data': {'children': {'unexpected': 'shape'}}}
+        mock_get.return_value = mock_response
+
+        posts = reddit_links.get_subreddit("netsec", "token", "test-ua/0.1")
+
+        self.assertEqual(posts, [])
 
 
 class RedditPostExtractUrlsTests(unittest.TestCase):
@@ -64,6 +102,33 @@ class RedditPostExtractUrlsTests(unittest.TestCase):
         del data['url']
         post = RedditPost({'data': data})
         self.assertEqual(post.urls, [])
+
+
+class RedditRunTests(unittest.TestCase):
+    def test_run_does_not_insert_when_no_posts_parse(self):
+        reddit_config = {'credential_location': '/tmp/reddit.json', 'subreddits': ['netsec']}
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+
+        with patch.object(reddit_links, 'get_subreddits', return_value=[_make_reddit_post('https://example.com')]) as get_subreddits, \
+             patch.object(reddit_links, 'parse_posts', return_value=[]) as parse_posts, \
+             patch.object(reddit_links.db_utils, 'db_insert') as db_insert:
+            reddit_links.run(reddit_config, db_info)
+
+        get_subreddits.assert_called_once_with(reddit_config)
+        parse_posts.assert_called_once()
+        db_insert.assert_not_called()
+
+    def test_run_inserts_parsed_posts(self):
+        reddit_config = {'credential_location': '/tmp/reddit.json', 'subreddits': ['netsec']}
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        parsed_posts = [RedditPost(_make_reddit_post('https://example.com/article'))]
+
+        with patch.object(reddit_links, 'get_subreddits', return_value=[_make_reddit_post('https://example.com/article')]), \
+             patch.object(reddit_links, 'parse_posts', return_value=parsed_posts), \
+             patch.object(reddit_links.db_utils, 'db_insert', return_value=1) as db_insert:
+            reddit_links.run(reddit_config, db_info)
+
+        db_insert.assert_called_once_with(parsed_posts, reddit_links.Path('/tmp/db') / 'fetchlinks.db')
 
 
 if __name__ == "__main__":

--- a/fetchlinks/tests/test_rss_links.py
+++ b/fetchlinks/tests/test_rss_links.py
@@ -13,6 +13,14 @@ class _FakeResponse:
         self.headers = headers or {}
 
 
+class _FeedEntry(dict):
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+
 def _atom_bytes(link='https://example.com/post', title='entry'):
     # Minimal Atom feed feedparser will parse cleanly.
     return (
@@ -125,6 +133,31 @@ class ParsePostsTests(unittest.TestCase):
 
         self.assertEqual(rss_links.parse_posts(fetch_results), [])
 
+    def test_skips_malformed_entry_without_stopping_feed(self):
+        feed = MagicMock()
+        feed.feed = {'link': 'https://example.com/', 'title': 'Example'}
+        feed.entries = [object()]
+        fetch_results = [('https://feedurl/', feed, '', '', 200)]
+
+        with patch.object(rss_links, 'RssPost', side_effect=RuntimeError('bad entry')):
+            self.assertEqual(rss_links.parse_posts(fetch_results), [])
+
+    def test_falls_back_to_feed_url_when_feed_metadata_missing(self):
+        feed = MagicMock()
+        feed.feed = {}
+        feed.entries = [_FeedEntry(
+            title='Example post',
+            link='https://example.com/post',
+            published='2026-04-19T12:00:00Z',
+        )]
+        fetch_results = [('https://feedurl.example/rss.xml', feed, '', '', 200)]
+
+        posts = rss_links.parse_posts(fetch_results)
+
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(posts[0].source, 'https://feedurl.example/rss.xml')
+        self.assertEqual(posts[0].author, 'https://feedurl.example/rss.xml')
+
 
 class FetchFeedsTests(unittest.TestCase):
     def test_fetches_each_url_once(self):
@@ -139,6 +172,47 @@ class FetchFeedsTests(unittest.TestCase):
         called_with = {call.args[1]: call.args[2] for call in mock_fetch.call_args_list}
         self.assertEqual(called_with['https://a/'], ('e', 'l'))
         self.assertEqual(called_with['https://b/'], ('', ''))
+
+
+class RunTests(unittest.TestCase):
+    def test_run_persists_feed_state_even_when_no_posts(self):
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        feed_links = ['https://a.example/feed.xml', 'https://b.example/feed.xml']
+        cached_states = {'https://a.example/feed.xml': ('old-etag', 'old-lm')}
+        fetch_results = [
+            ('https://a.example/feed.xml', None, 'new-etag', 'new-lm', 304),
+            ('https://b.example/feed.xml', None, '', '', 0),
+        ]
+
+        with patch.object(rss_links.db_utils, 'db_get_rss_feed_states', return_value=cached_states) as get_states, \
+             patch.object(rss_links, 'fetch_feeds', return_value=fetch_results) as fetch_feeds, \
+             patch.object(rss_links.db_utils, 'db_set_rss_feed_states') as set_states, \
+             patch.object(rss_links, 'parse_posts', return_value=[]) as parse_posts, \
+             patch.object(rss_links.db_utils, 'db_insert') as db_insert:
+            rss_links.run(feed_links, db_info)
+
+        db_path = rss_links.Path('/tmp/db') / 'fetchlinks.db'
+        get_states.assert_called_once_with(db_path)
+        fetch_feeds.assert_called_once_with(feed_links, cached_states)
+        set_states.assert_called_once_with([
+            ('https://a.example/feed.xml', 'new-etag', 'new-lm', 304),
+            ('https://b.example/feed.xml', '', '', 0),
+        ], db_path)
+        parse_posts.assert_called_once_with(fetch_results)
+        db_insert.assert_not_called()
+
+    def test_run_inserts_parsed_posts(self):
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        parsed_posts = [object()]
+
+        with patch.object(rss_links.db_utils, 'db_get_rss_feed_states', return_value={}), \
+             patch.object(rss_links, 'fetch_feeds', return_value=[]), \
+             patch.object(rss_links.db_utils, 'db_set_rss_feed_states'), \
+             patch.object(rss_links, 'parse_posts', return_value=parsed_posts), \
+             patch.object(rss_links.db_utils, 'db_insert', return_value=1) as db_insert:
+            rss_links.run(['https://feed.example/rss.xml'], db_info)
+
+        db_insert.assert_called_once_with(parsed_posts, rss_links.Path('/tmp/db') / 'fetchlinks.db')
 
 
 if __name__ == '__main__':

--- a/fetchlinks/tests/test_startup_and_validate.py
+++ b/fetchlinks/tests/test_startup_and_validate.py
@@ -136,10 +136,21 @@ class ParseSourcesTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             p = Path(tmp) / 'sources.json'
             _write(p, {'rss': {'feeds': []}})
-            # The validator only complains when feeds list is present and len < 1.
-            # An empty list is falsy so it currently passes validation; this asserts
-            # the documented behaviour: only a populated-but-empty feeds key trips it.
-            sv.parse_sources(str(p))  # should not raise
+            with self.assertRaises(ValueError):
+                sv.parse_sources(str(p))
+
+    def test_rss_feeds_must_be_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'rss': {'feeds': 'https://feed.example/rss.xml'}})
+            with self.assertRaises(ValueError):
+                sv.parse_sources(str(p))
+
+    def test_disabled_rss_allows_empty_feeds(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'rss': {'enabled': False, 'feeds': []}})
+            sv.parse_sources(str(p))
 
     def test_bluesky_enabled_without_creds_raises(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/fetchlinks/tests/test_unshorten_links.py
+++ b/fetchlinks/tests/test_unshorten_links.py
@@ -62,6 +62,40 @@ class IsSafeTargetTests(unittest.TestCase):
             self.assertTrue(unshorten_links._is_safe_target('https://example.com/x'))
 
 
+class RequestNoFollowTests(unittest.TestCase):
+    def test_uses_head_without_following_redirects(self):
+        session = mock.Mock()
+        response = mock.Mock(status_code=200)
+        session.head.return_value = response
+
+        result = unshorten_links._request_no_follow(session, 'https://bit.ly/abc')
+
+        self.assertIs(result, response)
+        session.head.assert_called_once_with(
+            'https://bit.ly/abc',
+            allow_redirects=False,
+            timeout=unshorten_links.REQUEST_TIMEOUT_SECONDS,
+        )
+        session.get.assert_not_called()
+
+    def test_falls_back_to_get_on_head_not_allowed_and_closes_response(self):
+        session = mock.Mock()
+        session.head.return_value = mock.Mock(status_code=405)
+        get_response = mock.Mock(status_code=200)
+        session.get.return_value = get_response
+
+        result = unshorten_links._request_no_follow(session, 'https://bit.ly/abc')
+
+        self.assertIs(result, get_response)
+        session.get.assert_called_once_with(
+            'https://bit.ly/abc',
+            allow_redirects=False,
+            timeout=unshorten_links.REQUEST_TIMEOUT_SECONDS,
+            stream=True,
+        )
+        get_response.close.assert_called_once_with()
+
+
 class UnshortenUrlTests(unittest.TestCase):
     def test_follows_redirect_chain(self):
         responses = [

--- a/fetchlinks/tests/test_utils.py
+++ b/fetchlinks/tests/test_utils.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import unittest
 from unittest.mock import patch
 
@@ -54,9 +55,15 @@ class ConvertDateStringTests(unittest.TestCase):
         )
 
     def test_unparseable_string_falls_back_to_now_utc(self):
-        result = convert_date_string_for_mysql('not a date at all')
-        # Should be a 19-char "YYYY-MM-DD HH:MM:SS" string.
-        self.assertRegex(result, r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$')
+        class FixedDateTime(dt.datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return cls(2026, 4, 26, 12, 34, 56, tzinfo=tz)
+
+        with patch('utils.datetime.datetime', FixedDateTime):
+            result = convert_date_string_for_mysql('not a date at all')
+
+        self.assertEqual(result, '2026-04-26 12:34:56')
 
 
 class ConvertEpochTests(unittest.TestCase):
@@ -153,8 +160,16 @@ class RssPostTests(unittest.TestCase):
 
     def test_falls_back_to_now_when_no_dates(self):
         entry = _RssEntry(title='t', link='https://example.com/a')
-        post = RssPost('https://example.com/feed.xml', 'Example', entry)
-        self.assertRegex(post.date_created, r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$')
+
+        class FixedDateTime(dt.datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return cls(2026, 4, 26, 12, 34, 56, tzinfo=tz)
+
+        with patch('utils.datetime.datetime', FixedDateTime):
+            post = RssPost('https://example.com/feed.xml', 'Example', entry)
+
+        self.assertEqual(post.date_created, '2026-04-26 12:34:56')
 
     def test_missing_title_defaults_to_empty(self):
         entry = _RssEntry(link='https://example.com/a', published='2026-04-19T12:00:00Z')


### PR DESCRIPTION
Adds higher-level unit tests around source orchestration, startup order, source run flows, malformed payload handling, and CLI export behavior.

Also pins two small behavior choices uncovered by the new tests:
- missing source sections are skipped instead of raising while routing fetches
- enabled RSS configs must provide a non-empty feeds list

Full unittest discovery passes: 167 tests.
