### PR TITLE
D6-D7: standardize CLI args and lazy logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ Once setup is complete, run:
 
 ```bash
 cd fetchlinks/fetchlinks
-python3 fetch_links.py -config data/config/config.json -sources data/config/sources.json
+python3 fetch_links.py
 ```
+
+To use non-default config files, pass `--config` and `--sources`.
 
 ## Config files
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,8 +79,11 @@ Edit fetchlinks/data/config/sources.json:
 
 ```bash
 cd fetchlinks
-python3 fetch_links.py -config data/config/config.json -sources data/config/sources.json
+python3 fetch_links.py
 ```
+
+The default config files are `data/config/config.json` and `data/config/sources.json`.
+To use different files, pass `--config /path/to/config.json --sources /path/to/sources.json`.
 
 On first run, the backend initializes the SQLite database automatically if it does not exist.
 

--- a/fetchlinks/db_setup.py
+++ b/fetchlinks/db_setup.py
@@ -82,7 +82,7 @@ def table_rss_feed_state_configure(conn):
 
 def db_initial_setup(db_location, db_name):
     db_path = Path(db_location) / db_name
-    logger.info(f'Creating or validating {db_path}')
+    logger.info('Creating or validating %s', db_path)
     conn = db_create(db_location, db_name)
     conn.execute('PRAGMA journal_mode=WAL')
     conn.execute('PRAGMA foreign_keys=ON')

--- a/fetchlinks/reddit_links.py
+++ b/fetchlinks/reddit_links.py
@@ -59,7 +59,7 @@ def get_subreddit(subreddit: str, token: str, user_agent: str) -> List[dict]:
         logger.error('Unexpected Reddit payload shape for r/%s', subreddit)
         return []
 
-    logger.debug(f'{subreddit} returned {len(subreddit_posts)} entries')
+    logger.debug('%s returned %s entries', subreddit, len(subreddit_posts))
 
     return subreddit_posts
 

--- a/fetchlinks/startup_and_validate.py
+++ b/fetchlinks/startup_and_validate.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import sys
 from pathlib import Path
 
 import db_setup
@@ -8,6 +9,8 @@ VALID_FIELDS = {'db_info': ['db_name', 'db_location'],
                 'log_info': ['log_config_location', 'log_location', 'log_level']}
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_CONFIG = SCRIPT_DIR / 'data' / 'config' / 'config.json'
+DEFAULT_SOURCES = SCRIPT_DIR / 'data' / 'config' / 'sources.json'
 
 
 def _resolve_relative_to_script(path_str: str) -> Path:
@@ -126,9 +129,16 @@ def _validate_config_fields(config_keys, valid_keys):
 
 def parse_arguments():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-config', help='Config location', type=str, required=True)
-    parser.add_argument('-sources', help='Sources location', type=str, required=True)
-    return parser.parse_args()
+    parser.add_argument('--config', help='Config location', type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument('--sources', help='Sources location', type=Path, default=DEFAULT_SOURCES)
+    # Backward-compatible aliases for the old single-dash spelling. argparse
+    # treats multi-character single-dash tokens as short-option clusters, so
+    # normalize them before parsing.
+    args = [
+        '--config' if arg == '-config' else '--sources' if arg == '-sources' else arg
+        for arg in sys.argv[1:]
+    ]
+    return parser.parse_args(args)
 
 
 def do_startup():

--- a/fetchlinks/tests/test_startup_and_validate.py
+++ b/fetchlinks/tests/test_startup_and_validate.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import startup_and_validate as sv
 
@@ -199,6 +200,37 @@ class ResolveRelativePathTests(unittest.TestCase):
         result = sv._resolve_relative_to_script('db/x.db')
         self.assertTrue(result.is_absolute())
         self.assertEqual(result.parent.parent, sv.SCRIPT_DIR)
+
+
+class ParseArgumentsTests(unittest.TestCase):
+    def test_defaults_to_packaged_config_files(self):
+        with patch('sys.argv', ['fetch_links.py']):
+            args = sv.parse_arguments()
+
+        self.assertEqual(args.config, sv.DEFAULT_CONFIG)
+        self.assertEqual(args.sources, sv.DEFAULT_SOURCES)
+
+    def test_accepts_standard_long_options(self):
+        with patch('sys.argv', [
+            'fetch_links.py',
+            '--config', '/tmp/config.json',
+            '--sources', '/tmp/sources.json',
+        ]):
+            args = sv.parse_arguments()
+
+        self.assertEqual(args.config, Path('/tmp/config.json'))
+        self.assertEqual(args.sources, Path('/tmp/sources.json'))
+
+    def test_legacy_single_dash_options_still_work(self):
+        with patch('sys.argv', [
+            'fetch_links.py',
+            '-config', '/tmp/config.json',
+            '-sources', '/tmp/sources.json',
+        ]):
+            args = sv.parse_arguments()
+
+        self.assertEqual(args.config, Path('/tmp/config.json'))
+        self.assertEqual(args.sources, Path('/tmp/sources.json'))
 
 
 if __name__ == '__main__':

--- a/fetchlinks/utils.py
+++ b/fetchlinks/utils.py
@@ -22,7 +22,7 @@ def convert_date_string_for_mysql(rss_date: str) -> str:
         date_created = datetime.datetime.strftime(date_object, '%Y-%m-%d %H:%M:%S')
     except dateutil.parser.ParserError as e:
         # We couldn't parse the date for some reason. Make it "now" (UTC)
-        logger.error(f'Could not parse date. Error:\n{e}')
+        logger.error('Could not parse date. Error:\n%s', e)
         date_created = datetime.datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S')
     return date_created
 


### PR DESCRIPTION
- Add default config and sources paths for fetch_links.py
- Standardize documented CLI usage around --config/--sources while preserving legacy -config/-sources compatibility
- Replace remaining f-string logging calls with lazy logger formatting
- Update README and setup docs for default CLI usage
- Add parser tests for defaults, long options, and legacy aliases

Full unittest discovery passes: 170 tests.
