### PR TITLE
Add URL hostname keyword denylist

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -92,6 +92,7 @@ chmod 600 ~/.fetchlinks/mastodon-infosec.json
 Edit fetchlinks/data/config/sources.json:
 
 - Keep rss.enabled and reddit.enabled as needed.
+- To exclude extracted URLs by hostname keyword, add `ingest.excluded_url_host_keywords`. For example, `"insider"` blocks `www.businessinsider.com`, while `"businessinsider.com"` blocks that domain and its subdomains. Matching is case-insensitive and only checks URL hostnames, not paths or titles.
 - Bluesky defaults to disabled. Set bluesky.enabled to true only if you created a Bluesky credential file.
 - Mastodon defaults to disabled. Set mastodon.enabled to true only if every enabled mastodon.instances entry has a credential file.
 - Ensure each credential_location path matches your local files.

--- a/fetchlinks/bluesky_links.py
+++ b/fetchlinks/bluesky_links.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 import db_utils
 import ingest_limits
+import url_filters
 from auth import BlueskyAuth
 from utils import BlueskyPost, extract_urls_from_text
 
@@ -155,6 +156,7 @@ def run(
     bluesky_config: dict,
     db_info: dict,
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
+    excluded_url_host_keywords: List[str] | None = None,
 ):
     if not bluesky_config.get('enabled', False):
         logger.info('Bluesky source is disabled; skipping')
@@ -225,6 +227,11 @@ def run(
             parsed_posts.append(parsed)
 
     recent_posts = ingest_limits.filter_posts_by_age(parsed_posts, max_post_age_months, 'Bluesky')
+    recent_posts = url_filters.filter_posts_by_url_host_keywords(
+        recent_posts,
+        excluded_url_host_keywords or [],
+        'Bluesky',
+    )
     inserted_count = db_utils.db_insert(recent_posts, db_full_path)
     db_utils.db_set_bluesky_cursor(next_cursor, db_full_path)
 

--- a/fetchlinks/fetch_links.py
+++ b/fetchlinks/fetch_links.py
@@ -12,6 +12,7 @@ import mastodon_links
 import db_setup
 import ingest_limits
 import startup_and_validate
+import url_filters
 
 
 def configure_logging(config):
@@ -35,22 +36,23 @@ def fetch_links(config: dict, sources: dict):
     :return: Nothing
     """
     max_post_age_months = ingest_limits.max_post_age_months_from_sources(sources)
+    excluded_url_host_keywords = url_filters.excluded_url_host_keywords_from_sources(sources)
 
     rss_config = sources.get('rss')
     if rss_config and rss_config.get('enabled', True):
-        rss_links.run(rss_config['feeds'], config['db_info'], max_post_age_months)
+        rss_links.run(rss_config['feeds'], config['db_info'], max_post_age_months, excluded_url_host_keywords)
 
     reddit_config = sources.get('reddit')
     if reddit_config and reddit_config.get('enabled', True):
-        reddit_links.run(reddit_config, config['db_info'], max_post_age_months)
+        reddit_links.run(reddit_config, config['db_info'], max_post_age_months, excluded_url_host_keywords)
 
     bluesky_config = sources.get('bluesky')
     if bluesky_config and bluesky_config.get('enabled', False):
-        bluesky_links.run(bluesky_config, config['db_info'], max_post_age_months)
+        bluesky_links.run(bluesky_config, config['db_info'], max_post_age_months, excluded_url_host_keywords)
 
     mastodon_config = sources.get('mastodon')
     if mastodon_config and mastodon_config.get('enabled', False):
-        mastodon_links.run(mastodon_config, config['db_info'], max_post_age_months)
+        mastodon_links.run(mastodon_config, config['db_info'], max_post_age_months, excluded_url_host_keywords)
 
 
 def main():

--- a/fetchlinks/mastodon_links.py
+++ b/fetchlinks/mastodon_links.py
@@ -8,6 +8,7 @@ import requests
 
 import db_utils
 import ingest_limits
+import url_filters
 from auth import MastodonAuth
 from utils import MastodonPost, extract_urls_from_text
 
@@ -201,6 +202,7 @@ def _run_instance(
     instance_config: dict,
     db_path: Path,
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
+    excluded_url_host_keywords: list[str] | None = None,
 ) -> int:
     if instance_config.get('enabled', True) is False:
         logger.info('Mastodon source %s is disabled; skipping', instance_config.get('name', '<unnamed>'))
@@ -230,6 +232,11 @@ def _run_instance(
             parsed_posts.append(parsed)
 
     recent_posts = ingest_limits.filter_posts_by_age(parsed_posts, max_post_age_months, f'Mastodon {source_name}')
+    recent_posts = url_filters.filter_posts_by_url_host_keywords(
+        recent_posts,
+        excluded_url_host_keywords or [],
+        f'Mastodon {source_name}',
+    )
     inserted_count = db_utils.db_insert(recent_posts, db_path)
     highest_id = _highest_status_id(statuses)
     if highest_id:
@@ -252,6 +259,7 @@ def run(
     mastodon_config: dict,
     db_info: dict,
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
+    excluded_url_host_keywords: list[str] | None = None,
 ):
     if not mastodon_config.get('enabled', False):
         logger.info('Mastodon source is disabled; skipping')
@@ -260,6 +268,11 @@ def run(
     db_path = Path(db_info['db_location']) / db_info['db_name']
     total_inserted = 0
     for instance_config in mastodon_config['instances']:
-        total_inserted += _run_instance(instance_config, db_path, max_post_age_months)
+        total_inserted += _run_instance(
+            instance_config,
+            db_path,
+            max_post_age_months,
+            excluded_url_host_keywords or [],
+        )
 
     logger.info('Inserted %s Mastodon posts into DB', total_inserted)

--- a/fetchlinks/reddit_links.py
+++ b/fetchlinks/reddit_links.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from utils import RedditPost
 import db_utils
 import ingest_limits
+import url_filters
 from auth import RedditAuth
 
 logger = logging.getLogger(__name__)
@@ -169,11 +170,17 @@ def run(
     reddit_config: dict,
     db_info: dict,
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
+    excluded_url_host_keywords: list[str] | None = None,
 ):
     db_full_path = Path(db_info['db_location']) / db_info['db_name']
     subreddit_posts, state_updates = get_subreddits(reddit_config, db_full_path)
     parsed_posts = parse_posts(subreddit_posts)
     recent_posts = ingest_limits.filter_posts_by_age(parsed_posts, max_post_age_months, 'Reddit')
+    recent_posts = url_filters.filter_posts_by_url_host_keywords(
+        recent_posts,
+        excluded_url_host_keywords or [],
+        'Reddit',
+    )
 
     if recent_posts:
         inserted_count = db_utils.db_insert(recent_posts, db_full_path)

--- a/fetchlinks/rss_links.py
+++ b/fetchlinks/rss_links.py
@@ -16,6 +16,7 @@ import requests
 
 import db_utils
 import ingest_limits
+import url_filters
 from utils import RssPost
 
 logger = logging.getLogger(__name__)
@@ -116,6 +117,7 @@ def run(
     rss_feed_links: list,
     db_info: dict,
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
+    excluded_url_host_keywords: list[str] | None = None,
 ):
     db_full_path = Path(db_info['db_location']) / db_info['db_name']
     cached_states = db_utils.db_get_rss_feed_states(db_full_path)
@@ -127,6 +129,11 @@ def run(
 
     parsed_posts = parse_posts(fetch_results)
     recent_posts = ingest_limits.filter_posts_by_age(parsed_posts, max_post_age_months, 'RSS')
+    recent_posts = url_filters.filter_posts_by_url_host_keywords(
+        recent_posts,
+        excluded_url_host_keywords or [],
+        'RSS',
+    )
 
     counts = {200: 0, 304: 0, 'error': 0}
     for _u, _f, _e, _l, status in fetch_results:

--- a/fetchlinks/startup_and_validate.py
+++ b/fetchlinks/startup_and_validate.py
@@ -106,6 +106,12 @@ def _validate_ingest_settings(ingest_settings: dict):
     if not isinstance(max_post_age_months, int) or max_post_age_months < 1:
         raise ValueError('Ingest max_post_age_months must be a positive integer')
 
+    excluded_url_host_keywords = ingest_settings.get('excluded_url_host_keywords', [])
+    if not isinstance(excluded_url_host_keywords, list):
+        raise ValueError('Ingest excluded_url_host_keywords must be a list of strings')
+    if any(not isinstance(keyword, str) or not keyword.strip() for keyword in excluded_url_host_keywords):
+        raise ValueError('Ingest excluded_url_host_keywords must contain non-empty strings')
+
 
 def _validate_reddit_source(reddit_settings: dict):
     if not reddit_settings.get('credential_location'):

--- a/fetchlinks/tests/test_bluesky_links.py
+++ b/fetchlinks/tests/test_bluesky_links.py
@@ -152,6 +152,27 @@ class BlueskyRunTests(unittest.TestCase):
         self.assertEqual(len(inserted_posts), 1)
         self.assertEqual(inserted_posts[0].urls, ['https://example.com/recent'])
 
+    def test_run_filters_denied_host_keywords_before_insert(self):
+        config = {'enabled': True, 'credential_location': '/tmp/bsky.json'}
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        auth_client = Mock()
+        auth_client.get_client.return_value = object()
+        feed_items = [
+            _timeline_item('https://www.businessinsider.com/story', created_at='2999-01-01T00:00:00.000Z'),
+            _timeline_item('https://example.com/recent', created_at='2999-01-01T00:00:00.000Z'),
+        ]
+
+        with patch.object(bluesky_links, 'BlueskyAuth', return_value=auth_client), \
+             patch.object(bluesky_links.db_utils, 'db_get_bluesky_cursor', return_value=None), \
+             patch.object(bluesky_links, '_fetch_timeline_page', return_value=(feed_items, None)), \
+             patch.object(bluesky_links.db_utils, 'db_insert', return_value=1) as db_insert, \
+             patch.object(bluesky_links.db_utils, 'db_set_bluesky_cursor'):
+            bluesky_links.run(config, db_info, excluded_url_host_keywords=['insider'])
+
+        inserted_posts = db_insert.call_args.args[0]
+        self.assertEqual(len(inserted_posts), 1)
+        self.assertEqual(inserted_posts[0].urls, ['https://example.com/recent'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/fetchlinks/tests/test_fetch_links.py
+++ b/fetchlinks/tests/test_fetch_links.py
@@ -24,10 +24,10 @@ class FetchLinksRoutingTests(unittest.TestCase):
              patch.object(fetch_links.mastodon_links, 'run') as mastodon_run:
             fetch_links.fetch_links(self.config, sources)
 
-        rss_run.assert_called_once_with(['https://feed.example/rss.xml'], self.config['db_info'], default_age)
-        reddit_run.assert_called_once_with(sources['reddit'], self.config['db_info'], default_age)
-        bluesky_run.assert_called_once_with(sources['bluesky'], self.config['db_info'], default_age)
-        mastodon_run.assert_called_once_with(sources['mastodon'], self.config['db_info'], default_age)
+        rss_run.assert_called_once_with(['https://feed.example/rss.xml'], self.config['db_info'], default_age, [])
+        reddit_run.assert_called_once_with(sources['reddit'], self.config['db_info'], default_age, [])
+        bluesky_run.assert_called_once_with(sources['bluesky'], self.config['db_info'], default_age, [])
+        mastodon_run.assert_called_once_with(sources['mastodon'], self.config['db_info'], default_age, [])
 
     def test_passes_configured_ingest_age_limit_to_sources(self):
         sources = {
@@ -38,7 +38,23 @@ class FetchLinksRoutingTests(unittest.TestCase):
         with patch.object(fetch_links.reddit_links, 'run') as reddit_run:
             fetch_links.fetch_links(self.config, sources)
 
-        reddit_run.assert_called_once_with(sources['reddit'], self.config['db_info'], 6)
+        reddit_run.assert_called_once_with(sources['reddit'], self.config['db_info'], 6, [])
+
+    def test_passes_excluded_url_host_keywords_to_sources(self):
+        sources = {
+            'ingest': {'excluded_url_host_keywords': ['insider', 'BusinessInsider.com']},
+            'rss': {'feeds': ['https://feed.example/rss.xml']},
+        }
+
+        with patch.object(fetch_links.rss_links, 'run') as rss_run:
+            fetch_links.fetch_links(self.config, sources)
+
+        rss_run.assert_called_once_with(
+            ['https://feed.example/rss.xml'],
+            self.config['db_info'],
+            fetch_links.ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
+            ['insider', 'businessinsider.com'],
+        )
 
     def test_skips_disabled_sources(self):
         sources = {

--- a/fetchlinks/tests/test_mastodon_links.py
+++ b/fetchlinks/tests/test_mastodon_links.py
@@ -248,7 +248,7 @@ class RunInstanceTests(unittest.TestCase):
         auth_client.headers = {'Authorization': 'Bearer tok'}
         statuses = [
             _status('11', 'https://example.com/old', created_at='2000-01-01T00:00:00.000Z'),
-            _status('12', 'https://example.com/recent', created_at='2999-01-01T00:00:00.000Z'),
+            _status('12', 'https://example.com/recent', card_url='', created_at='2999-01-01T00:00:00.000Z'),
         ]
         db_path = Path('/tmp/db/fetchlinks.db')
 
@@ -264,6 +264,36 @@ class RunInstanceTests(unittest.TestCase):
         self.assertEqual(len(inserted_posts), 1)
         self.assertEqual(inserted_posts[0].urls[0], 'https://example.com/recent')
         set_state.assert_called_once_with('infosec', 'https://infosec.exchange', '12', db_path)
+
+    def test_run_instance_filters_denied_host_keywords_before_insert(self):
+        instance_config = {
+            'name': 'infosec',
+            'instance_url': 'https://infosec.exchange/',
+            'credential_location': '/tmp/mastodon.json',
+        }
+        auth_client = Mock()
+        auth_client.headers = {'Authorization': 'Bearer tok'}
+        statuses = [
+            _status('11', 'https://www.businessinsider.com/story', card_url='', created_at='2999-01-01T00:00:00.000Z'),
+            _status('12', 'https://example.com/recent', card_url='', created_at='2999-01-01T00:00:00.000Z'),
+        ]
+        db_path = Path('/tmp/db/fetchlinks.db')
+
+        with patch.object(mastodon_links, 'MastodonAuth', return_value=auth_client), \
+             patch.object(mastodon_links.db_utils, 'db_get_mastodon_last_seen_id', return_value='10'), \
+             patch.object(mastodon_links, '_fetch_timeline_pages', return_value=statuses), \
+             patch.object(mastodon_links.db_utils, 'db_insert', return_value=1) as db_insert, \
+             patch.object(mastodon_links.db_utils, 'db_set_mastodon_last_seen_id'):
+            inserted = mastodon_links._run_instance(
+                instance_config,
+                db_path,
+                excluded_url_host_keywords=['insider'],
+            )
+
+        self.assertEqual(inserted, 1)
+        inserted_posts = db_insert.call_args.args[0]
+        self.assertEqual(len(inserted_posts), 1)
+        self.assertEqual(inserted_posts[0].urls, ['https://example.com/recent'])
 
 
 class RunTests(unittest.TestCase):
@@ -287,8 +317,8 @@ class RunTests(unittest.TestCase):
             mastodon_links.run(config, db_info)
 
         db_path = Path('/tmp/db') / 'fetchlinks.db'
-        self.assertEqual(run_instance.call_args_list[0].args, ({'name': 'infosec'}, db_path, 3))
-        self.assertEqual(run_instance.call_args_list[1].args, ({'name': 'hachyderm'}, db_path, 3))
+        self.assertEqual(run_instance.call_args_list[0].args, ({'name': 'infosec'}, db_path, 3, []))
+        self.assertEqual(run_instance.call_args_list[1].args, ({'name': 'hachyderm'}, db_path, 3, []))
 
 
 if __name__ == '__main__':

--- a/fetchlinks/tests/test_reddit_links.py
+++ b/fetchlinks/tests/test_reddit_links.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import reddit_links
+from utils import Post
 from utils import RedditPost
 
 
@@ -234,6 +235,25 @@ class RedditRunTests(unittest.TestCase):
         db_path = reddit_links.Path('/tmp/db') / 'fetchlinks.db'
         db_insert.assert_called_once_with([recent_post], db_path)
         set_states.assert_called_once_with(state_updates, db_path)
+
+    def test_run_filters_denied_host_keywords_before_insert(self):
+        reddit_config = {'credential_location': '/tmp/reddit.json', 'subreddits': ['netsec']}
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        state_updates = [('netsec', 't3_new')]
+        post = Post()
+        post.date_created = '2999-01-01 00:00:00'
+        post.add_url('https://www.businessinsider.com/story')
+        post.add_url('https://example.com/allowed')
+        post._generate_unique_url_string()
+
+        with patch.object(reddit_links, 'get_subreddits', return_value=([], state_updates)), \
+             patch.object(reddit_links, 'parse_posts', return_value=[post]), \
+             patch.object(reddit_links.db_utils, 'db_insert', return_value=1) as db_insert, \
+             patch.object(reddit_links.db_utils, 'db_set_reddit_states'):
+            reddit_links.run(reddit_config, db_info, excluded_url_host_keywords=['insider'])
+
+        inserted_posts = db_insert.call_args.args[0]
+        self.assertEqual(inserted_posts[0].urls, ['https://example.com/allowed'])
 
 
 if __name__ == '__main__':

--- a/fetchlinks/tests/test_rss_links.py
+++ b/fetchlinks/tests/test_rss_links.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import requests
 
 import rss_links
+from utils import Post
 
 
 class _FakeResponse:
@@ -284,6 +285,24 @@ class RunTests(unittest.TestCase):
             rss_links.run(['https://feed.example/rss.xml'], db_info, max_post_age_months=3)
 
         db_insert.assert_called_once_with([recent_post], rss_links.Path('/tmp/db') / 'fetchlinks.db')
+
+    def test_run_filters_denied_host_keywords_before_insert(self):
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        post = Post()
+        post.date_created = '2999-01-01 00:00:00'
+        post.add_url('https://www.businessinsider.com/story')
+        post.add_url('https://example.com/allowed')
+        post._generate_unique_url_string()
+
+        with patch.object(rss_links.db_utils, 'db_get_rss_feed_states', return_value={}), \
+             patch.object(rss_links, 'fetch_feeds', return_value=[]), \
+             patch.object(rss_links.db_utils, 'db_set_rss_feed_states'), \
+             patch.object(rss_links, 'parse_posts', return_value=[post]), \
+             patch.object(rss_links.db_utils, 'db_insert', return_value=1) as db_insert:
+            rss_links.run(['https://feed.example/rss.xml'], db_info, excluded_url_host_keywords=['insider'])
+
+        inserted_posts = db_insert.call_args.args[0]
+        self.assertEqual(inserted_posts[0].urls, ['https://example.com/allowed'])
 
 
 if __name__ == '__main__':

--- a/fetchlinks/tests/test_startup_and_validate.py
+++ b/fetchlinks/tests/test_startup_and_validate.py
@@ -175,6 +175,26 @@ class ParseSourcesTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 sv.parse_sources(str(p))
 
+    def test_ingest_excluded_url_host_keywords_must_be_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'ingest': {'excluded_url_host_keywords': 'insider'}})
+            with self.assertRaises(ValueError):
+                sv.parse_sources(str(p))
+
+    def test_ingest_excluded_url_host_keywords_must_be_non_empty_strings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'ingest': {'excluded_url_host_keywords': ['insider', '']}})
+            with self.assertRaises(ValueError):
+                sv.parse_sources(str(p))
+
+    def test_ingest_excluded_url_host_keywords_accepts_strings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'ingest': {'excluded_url_host_keywords': ['insider', 'businessinsider.com']}})
+            sv.parse_sources(str(p))
+
     def test_reddit_enabled_without_creds_raises(self):
         with tempfile.TemporaryDirectory() as tmp:
             p = Path(tmp) / 'sources.json'

--- a/fetchlinks/tests/test_url_filters.py
+++ b/fetchlinks/tests/test_url_filters.py
@@ -1,0 +1,109 @@
+import unittest
+
+import url_filters
+from utils import Post
+
+
+def _make_post(urls):
+    post = Post()
+    post.source = 'https://source.example'
+    post.author = 'author'
+    post.description = 'description'
+    post.direct_link = 'https://source.example/post'
+    post.date_created = '2026-05-02 12:00:00'
+    for url in urls:
+        post.add_url(url)
+    post._generate_unique_url_string()
+    return post
+
+
+class UrlHostKeywordTests(unittest.TestCase):
+    def test_keyword_matches_hostname_contains(self):
+        self.assertTrue(
+            url_filters.url_matches_host_keyword(
+                'https://www.businessinsider.com/story',
+                ['insider'],
+            )
+        )
+
+    def test_domain_keyword_with_dot_matches_hostname(self):
+        self.assertTrue(
+            url_filters.url_matches_host_keyword(
+                'https://markets.businessinsider.com/story',
+                ['businessinsider.com'],
+            )
+        )
+
+    def test_keyword_is_case_insensitive(self):
+        self.assertTrue(
+            url_filters.url_matches_host_keyword(
+                'https://News.BusinessInsider.com/story',
+                ['INSIDER'],
+            )
+        )
+
+    def test_path_only_match_does_not_block_url(self):
+        self.assertFalse(
+            url_filters.url_matches_host_keyword(
+                'https://example.com/businessinsider.com/story',
+                ['businessinsider.com'],
+            )
+        )
+
+    def test_empty_or_invalid_url_does_not_match(self):
+        self.assertFalse(url_filters.url_matches_host_keyword('', ['insider']))
+        self.assertFalse(url_filters.url_matches_host_keyword('not a url', ['insider']))
+
+    def test_non_list_keywords_do_not_match(self):
+        self.assertFalse(
+            url_filters.url_matches_host_keyword(
+                'https://www.businessinsider.com/story',
+                'insider',
+            )
+        )
+
+
+class FilterPostsTests(unittest.TestCase):
+    def test_filters_denied_urls_and_keeps_allowed_urls(self):
+        post = _make_post([
+            'https://www.businessinsider.com/story',
+            'https://example.com/allowed',
+        ])
+        original_unique_id = post.unique_id_string
+
+        filtered = url_filters.filter_posts_by_url_host_keywords([post], ['insider'], 'test')
+
+        self.assertEqual(filtered, [post])
+        self.assertEqual(post.urls, ['https://example.com/allowed'])
+        self.assertNotEqual(post.unique_id_string, original_unique_id)
+
+    def test_skips_post_when_all_urls_denied(self):
+        post = _make_post(['https://www.businessinsider.com/story'])
+
+        filtered = url_filters.filter_posts_by_url_host_keywords([post], ['insider'], 'test')
+
+        self.assertEqual(filtered, [])
+
+    def test_empty_keywords_is_noop(self):
+        post = _make_post(['https://www.businessinsider.com/story'])
+
+        filtered = url_filters.filter_posts_by_url_host_keywords([post], [], 'test')
+
+        self.assertEqual(filtered, [post])
+        self.assertEqual(post.urls, ['https://www.businessinsider.com/story'])
+
+    def test_reads_keywords_from_sources(self):
+        sources = {
+            'ingest': {
+                'excluded_url_host_keywords': [' Insider ', '', 12, 'businessinsider.com'],
+            },
+        }
+
+        self.assertEqual(
+            url_filters.excluded_url_host_keywords_from_sources(sources),
+            ['insider', 'businessinsider.com'],
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fetchlinks/url_filters.py
+++ b/fetchlinks/url_filters.py
@@ -1,0 +1,76 @@
+import logging
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+def excluded_url_host_keywords_from_sources(sources: dict) -> list[str]:
+    ingest_config = sources.get('ingest', {})
+    if not isinstance(ingest_config, dict):
+        return []
+    return normalize_host_keywords(ingest_config.get('excluded_url_host_keywords', []))
+
+
+def normalize_host_keywords(keywords) -> list[str]:
+    if not keywords or not isinstance(keywords, list):
+        return []
+    return [keyword.strip().lower() for keyword in keywords if isinstance(keyword, str) and keyword.strip()]
+
+
+def url_matches_host_keyword(url: str, keywords: list[str]) -> bool:
+    normalized_keywords = normalize_host_keywords(keywords)
+    if not normalized_keywords:
+        return False
+
+    try:
+        hostname = (urlparse(url).hostname or '').lower()
+    except ValueError:
+        return False
+
+    if not hostname:
+        return False
+
+    return any(keyword in hostname for keyword in normalized_keywords)
+
+
+def filter_post_urls_by_host_keywords(post, keywords: list[str]) -> int:
+    kept_urls = []
+    removed_count = 0
+    for url in post.urls:
+        if url_matches_host_keyword(url, keywords):
+            removed_count += 1
+            continue
+        kept_urls.append(url)
+
+    if removed_count:
+        post.urls = kept_urls
+        post._generate_unique_url_string()
+
+    return removed_count
+
+
+def filter_posts_by_url_host_keywords(posts: list, keywords: list[str], source_name: str) -> list:
+    normalized_keywords = normalize_host_keywords(keywords)
+    if not normalized_keywords:
+        return posts
+
+    filtered_posts = []
+    removed_url_count = 0
+    skipped_post_count = 0
+
+    for post in posts:
+        removed_url_count += filter_post_urls_by_host_keywords(post, normalized_keywords)
+        if post.post_has_urls:
+            filtered_posts.append(post)
+        else:
+            skipped_post_count += 1
+
+    if removed_url_count:
+        logger.info(
+            'Filtered %s %s URL(s) matching excluded host keyword(s); skipped %s post(s) with no remaining URLs',
+            removed_url_count,
+            source_name,
+            skipped_post_count,
+        )
+
+    return filtered_posts


### PR DESCRIPTION
## Summary
- add ingest.excluded_url_host_keywords for case-insensitive hostname keyword filtering
- filter RSS, Reddit, Bluesky, and Mastodon post URLs before DB insertion
- skip posts with no URLs left after filtering and regenerate URL-based unique IDs for kept posts
- validate the new sources.json setting and document it in SETUP.md

## Validation
- /home/rich/DEV/fetchlinks_src/venv/bin/python -m unittest discover -s tests
- git diff --check

Note: existing local edits to fetchlinks/data/config/sources.json were intentionally left unstaged and are not part of this PR.