### PR TITLE
Add URL and description keyword denylist

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -93,6 +93,7 @@ Edit fetchlinks/data/config/sources.json:
 
 - Keep rss.enabled and reddit.enabled as needed.
 - To exclude extracted URLs by hostname keyword, add `ingest.excluded_url_host_keywords`. For example, `"insider"` blocks `www.businessinsider.com`, while `"businessinsider.com"` blocks that domain and its subdomains. Matching is case-insensitive and only checks URL hostnames, not paths or titles.
+- To skip entire posts by full URL or description keyword, add `ingest.excluded_url_or_description_keywords`. For example, `"politics"` blocks URLs containing `/politics/` and descriptions containing the word `politics`; description matching is case-insensitive and whole-word, while URL matching is case-insensitive substring matching.
 - Bluesky defaults to disabled. Set bluesky.enabled to true only if you created a Bluesky credential file.
 - Mastodon defaults to disabled. Set mastodon.enabled to true only if every enabled mastodon.instances entry has a credential file.
 - Ensure each credential_location path matches your local files.

--- a/fetchlinks/bluesky_links.py
+++ b/fetchlinks/bluesky_links.py
@@ -157,6 +157,7 @@ def run(
     db_info: dict,
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
     excluded_url_host_keywords: List[str] | None = None,
+    excluded_url_or_description_keywords: List[str] | None = None,
 ):
     if not bluesky_config.get('enabled', False):
         logger.info('Bluesky source is disabled; skipping')
@@ -230,6 +231,11 @@ def run(
     recent_posts = url_filters.filter_posts_by_url_host_keywords(
         recent_posts,
         excluded_url_host_keywords or [],
+        'Bluesky',
+    )
+    recent_posts = url_filters.filter_posts_by_url_or_description_keywords(
+        recent_posts,
+        excluded_url_or_description_keywords or [],
         'Bluesky',
     )
     inserted_count = db_utils.db_insert(recent_posts, db_full_path)

--- a/fetchlinks/data/config/sources.json
+++ b/fetchlinks/data/config/sources.json
@@ -4,6 +4,10 @@
         "excluded_url_host_keywords": [
             "businessinsider",
             "economist.com"
+        ],
+        "excluded_url_or_description_keywords": [
+            "trump",
+            "covid"
         ]
     },
     "reddit": {

--- a/fetchlinks/fetch_links.py
+++ b/fetchlinks/fetch_links.py
@@ -37,22 +37,47 @@ def fetch_links(config: dict, sources: dict):
     """
     max_post_age_months = ingest_limits.max_post_age_months_from_sources(sources)
     excluded_url_host_keywords = url_filters.excluded_url_host_keywords_from_sources(sources)
+    excluded_url_or_description_keywords = url_filters.excluded_url_or_description_keywords_from_sources(sources)
 
     rss_config = sources.get('rss')
     if rss_config and rss_config.get('enabled', True):
-        rss_links.run(rss_config['feeds'], config['db_info'], max_post_age_months, excluded_url_host_keywords)
+        rss_links.run(
+            rss_config['feeds'],
+            config['db_info'],
+            max_post_age_months,
+            excluded_url_host_keywords,
+            excluded_url_or_description_keywords,
+        )
 
     reddit_config = sources.get('reddit')
     if reddit_config and reddit_config.get('enabled', True):
-        reddit_links.run(reddit_config, config['db_info'], max_post_age_months, excluded_url_host_keywords)
+        reddit_links.run(
+            reddit_config,
+            config['db_info'],
+            max_post_age_months,
+            excluded_url_host_keywords,
+            excluded_url_or_description_keywords,
+        )
 
     bluesky_config = sources.get('bluesky')
     if bluesky_config and bluesky_config.get('enabled', False):
-        bluesky_links.run(bluesky_config, config['db_info'], max_post_age_months, excluded_url_host_keywords)
+        bluesky_links.run(
+            bluesky_config,
+            config['db_info'],
+            max_post_age_months,
+            excluded_url_host_keywords,
+            excluded_url_or_description_keywords,
+        )
 
     mastodon_config = sources.get('mastodon')
     if mastodon_config and mastodon_config.get('enabled', False):
-        mastodon_links.run(mastodon_config, config['db_info'], max_post_age_months, excluded_url_host_keywords)
+        mastodon_links.run(
+            mastodon_config,
+            config['db_info'],
+            max_post_age_months,
+            excluded_url_host_keywords,
+            excluded_url_or_description_keywords,
+        )
 
 
 def main():

--- a/fetchlinks/mastodon_links.py
+++ b/fetchlinks/mastodon_links.py
@@ -203,6 +203,7 @@ def _run_instance(
     db_path: Path,
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
     excluded_url_host_keywords: list[str] | None = None,
+    excluded_url_or_description_keywords: list[str] | None = None,
 ) -> int:
     if instance_config.get('enabled', True) is False:
         logger.info('Mastodon source %s is disabled; skipping', instance_config.get('name', '<unnamed>'))
@@ -237,6 +238,11 @@ def _run_instance(
         excluded_url_host_keywords or [],
         f'Mastodon {source_name}',
     )
+    recent_posts = url_filters.filter_posts_by_url_or_description_keywords(
+        recent_posts,
+        excluded_url_or_description_keywords or [],
+        f'Mastodon {source_name}',
+    )
     inserted_count = db_utils.db_insert(recent_posts, db_path)
     highest_id = _highest_status_id(statuses)
     if highest_id:
@@ -260,6 +266,7 @@ def run(
     db_info: dict,
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
     excluded_url_host_keywords: list[str] | None = None,
+    excluded_url_or_description_keywords: list[str] | None = None,
 ):
     if not mastodon_config.get('enabled', False):
         logger.info('Mastodon source is disabled; skipping')
@@ -273,6 +280,7 @@ def run(
             db_path,
             max_post_age_months,
             excluded_url_host_keywords or [],
+            excluded_url_or_description_keywords or [],
         )
 
     logger.info('Inserted %s Mastodon posts into DB', total_inserted)

--- a/fetchlinks/reddit_links.py
+++ b/fetchlinks/reddit_links.py
@@ -171,6 +171,7 @@ def run(
     db_info: dict,
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
     excluded_url_host_keywords: list[str] | None = None,
+    excluded_url_or_description_keywords: list[str] | None = None,
 ):
     db_full_path = Path(db_info['db_location']) / db_info['db_name']
     subreddit_posts, state_updates = get_subreddits(reddit_config, db_full_path)
@@ -179,6 +180,11 @@ def run(
     recent_posts = url_filters.filter_posts_by_url_host_keywords(
         recent_posts,
         excluded_url_host_keywords or [],
+        'Reddit',
+    )
+    recent_posts = url_filters.filter_posts_by_url_or_description_keywords(
+        recent_posts,
+        excluded_url_or_description_keywords or [],
         'Reddit',
     )
 

--- a/fetchlinks/rss_links.py
+++ b/fetchlinks/rss_links.py
@@ -118,6 +118,7 @@ def run(
     db_info: dict,
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
     excluded_url_host_keywords: list[str] | None = None,
+    excluded_url_or_description_keywords: list[str] | None = None,
 ):
     db_full_path = Path(db_info['db_location']) / db_info['db_name']
     cached_states = db_utils.db_get_rss_feed_states(db_full_path)
@@ -132,6 +133,11 @@ def run(
     recent_posts = url_filters.filter_posts_by_url_host_keywords(
         recent_posts,
         excluded_url_host_keywords or [],
+        'RSS',
+    )
+    recent_posts = url_filters.filter_posts_by_url_or_description_keywords(
+        recent_posts,
+        excluded_url_or_description_keywords or [],
         'RSS',
     )
 

--- a/fetchlinks/startup_and_validate.py
+++ b/fetchlinks/startup_and_validate.py
@@ -112,6 +112,12 @@ def _validate_ingest_settings(ingest_settings: dict):
     if any(not isinstance(keyword, str) or not keyword.strip() for keyword in excluded_url_host_keywords):
         raise ValueError('Ingest excluded_url_host_keywords must contain non-empty strings')
 
+    excluded_url_or_description_keywords = ingest_settings.get('excluded_url_or_description_keywords', [])
+    if not isinstance(excluded_url_or_description_keywords, list):
+        raise ValueError('Ingest excluded_url_or_description_keywords must be a list of strings')
+    if any(not isinstance(keyword, str) or not keyword.strip() for keyword in excluded_url_or_description_keywords):
+        raise ValueError('Ingest excluded_url_or_description_keywords must contain non-empty strings')
+
 
 def _validate_reddit_source(reddit_settings: dict):
     if not reddit_settings.get('credential_location'):

--- a/fetchlinks/tests/test_bluesky_links.py
+++ b/fetchlinks/tests/test_bluesky_links.py
@@ -63,13 +63,13 @@ class BlueskyLinksTests(unittest.TestCase):
             self.assertEqual(db_utils.db_get_bluesky_cursor(db_path), 'cursor-123')
 
 
-def _timeline_item(url='https://example.com/article', created_at='2026-04-19T12:00:00.000Z'):
+def _timeline_item(url='https://example.com/article', created_at='2026-04-19T12:00:00.000Z', text=None):
     return {
         'post': {
             'uri': 'at://did:plc:alice/app.bsky.feed.post/xyz123',
             'author': {'handle': 'alice.bsky.social', 'displayName': 'Alice'},
             'record': {
-                'text': f'Interesting writeup {url}',
+                'text': text or f'Interesting writeup {url}',
                 'createdAt': created_at,
             },
         }
@@ -168,6 +168,27 @@ class BlueskyRunTests(unittest.TestCase):
              patch.object(bluesky_links.db_utils, 'db_insert', return_value=1) as db_insert, \
              patch.object(bluesky_links.db_utils, 'db_set_bluesky_cursor'):
             bluesky_links.run(config, db_info, excluded_url_host_keywords=['insider'])
+
+        inserted_posts = db_insert.call_args.args[0]
+        self.assertEqual(len(inserted_posts), 1)
+        self.assertEqual(inserted_posts[0].urls, ['https://example.com/recent'])
+
+    def test_run_filters_denied_url_or_description_keywords_before_insert(self):
+        config = {'enabled': True, 'credential_location': '/tmp/bsky.json'}
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        auth_client = Mock()
+        auth_client.get_client.return_value = object()
+        feed_items = [
+            _timeline_item('https://example.com/story', created_at='2999-01-01T00:00:00.000Z', text='Politics story https://example.com/story'),
+            _timeline_item('https://example.com/recent', created_at='2999-01-01T00:00:00.000Z', text='Technology story https://example.com/recent'),
+        ]
+
+        with patch.object(bluesky_links, 'BlueskyAuth', return_value=auth_client), \
+             patch.object(bluesky_links.db_utils, 'db_get_bluesky_cursor', return_value=None), \
+             patch.object(bluesky_links, '_fetch_timeline_page', return_value=(feed_items, None)), \
+             patch.object(bluesky_links.db_utils, 'db_insert', return_value=1) as db_insert, \
+             patch.object(bluesky_links.db_utils, 'db_set_bluesky_cursor'):
+            bluesky_links.run(config, db_info, excluded_url_or_description_keywords=['politics'])
 
         inserted_posts = db_insert.call_args.args[0]
         self.assertEqual(len(inserted_posts), 1)

--- a/fetchlinks/tests/test_fetch_links.py
+++ b/fetchlinks/tests/test_fetch_links.py
@@ -24,10 +24,10 @@ class FetchLinksRoutingTests(unittest.TestCase):
              patch.object(fetch_links.mastodon_links, 'run') as mastodon_run:
             fetch_links.fetch_links(self.config, sources)
 
-        rss_run.assert_called_once_with(['https://feed.example/rss.xml'], self.config['db_info'], default_age, [])
-        reddit_run.assert_called_once_with(sources['reddit'], self.config['db_info'], default_age, [])
-        bluesky_run.assert_called_once_with(sources['bluesky'], self.config['db_info'], default_age, [])
-        mastodon_run.assert_called_once_with(sources['mastodon'], self.config['db_info'], default_age, [])
+        rss_run.assert_called_once_with(['https://feed.example/rss.xml'], self.config['db_info'], default_age, [], [])
+        reddit_run.assert_called_once_with(sources['reddit'], self.config['db_info'], default_age, [], [])
+        bluesky_run.assert_called_once_with(sources['bluesky'], self.config['db_info'], default_age, [], [])
+        mastodon_run.assert_called_once_with(sources['mastodon'], self.config['db_info'], default_age, [], [])
 
     def test_passes_configured_ingest_age_limit_to_sources(self):
         sources = {
@@ -38,7 +38,7 @@ class FetchLinksRoutingTests(unittest.TestCase):
         with patch.object(fetch_links.reddit_links, 'run') as reddit_run:
             fetch_links.fetch_links(self.config, sources)
 
-        reddit_run.assert_called_once_with(sources['reddit'], self.config['db_info'], 6, [])
+        reddit_run.assert_called_once_with(sources['reddit'], self.config['db_info'], 6, [], [])
 
     def test_passes_excluded_url_host_keywords_to_sources(self):
         sources = {
@@ -54,6 +54,24 @@ class FetchLinksRoutingTests(unittest.TestCase):
             self.config['db_info'],
             fetch_links.ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
             ['insider', 'businessinsider.com'],
+            [],
+        )
+
+    def test_passes_excluded_url_or_description_keywords_to_sources(self):
+        sources = {
+            'ingest': {'excluded_url_or_description_keywords': ['Politics', ' trump ']},
+            'rss': {'feeds': ['https://feed.example/rss.xml']},
+        }
+
+        with patch.object(fetch_links.rss_links, 'run') as rss_run:
+            fetch_links.fetch_links(self.config, sources)
+
+        rss_run.assert_called_once_with(
+            ['https://feed.example/rss.xml'],
+            self.config['db_info'],
+            fetch_links.ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
+            [],
+            ['politics', 'trump'],
         )
 
     def test_skips_disabled_sources(self):

--- a/fetchlinks/tests/test_mastodon_links.py
+++ b/fetchlinks/tests/test_mastodon_links.py
@@ -12,12 +12,13 @@ def _status(
     url='https://example.com/article',
     card_url='https://card.example/story',
     created_at='2026-04-26T12:00:00.000Z',
+    content=None,
 ):
     return {
         'id': status_id,
         'created_at': created_at,
         'url': f'https://infosec.exchange/@alice/{status_id}',
-        'content': f'<p>Read <a href="{url}">the article</a></p>',
+        'content': content or f'<p>Read <a href="{url}">the article</a></p>',
         'card': {'url': card_url} if card_url else None,
         'account': {
             'url': 'https://infosec.exchange/@alice',
@@ -295,6 +296,42 @@ class RunInstanceTests(unittest.TestCase):
         self.assertEqual(len(inserted_posts), 1)
         self.assertEqual(inserted_posts[0].urls, ['https://example.com/recent'])
 
+    def test_run_instance_filters_denied_url_or_description_keywords_before_insert(self):
+        instance_config = {
+            'name': 'infosec',
+            'instance_url': 'https://infosec.exchange/',
+            'credential_location': '/tmp/mastodon.json',
+        }
+        auth_client = Mock()
+        auth_client.headers = {'Authorization': 'Bearer tok'}
+        statuses = [
+            _status(
+                '11',
+                'https://example.com/story',
+                card_url='',
+                created_at='2999-01-01T00:00:00.000Z',
+                content='<p>Politics <a href="https://example.com/story">story</a></p>',
+            ),
+            _status('12', 'https://example.com/recent', card_url='', created_at='2999-01-01T00:00:00.000Z'),
+        ]
+        db_path = Path('/tmp/db/fetchlinks.db')
+
+        with patch.object(mastodon_links, 'MastodonAuth', return_value=auth_client), \
+             patch.object(mastodon_links.db_utils, 'db_get_mastodon_last_seen_id', return_value='10'), \
+             patch.object(mastodon_links, '_fetch_timeline_pages', return_value=statuses), \
+             patch.object(mastodon_links.db_utils, 'db_insert', return_value=1) as db_insert, \
+             patch.object(mastodon_links.db_utils, 'db_set_mastodon_last_seen_id'):
+            inserted = mastodon_links._run_instance(
+                instance_config,
+                db_path,
+                excluded_url_or_description_keywords=['politics'],
+            )
+
+        self.assertEqual(inserted, 1)
+        inserted_posts = db_insert.call_args.args[0]
+        self.assertEqual(len(inserted_posts), 1)
+        self.assertEqual(inserted_posts[0].urls, ['https://example.com/recent'])
+
 
 class RunTests(unittest.TestCase):
     def test_run_skips_when_disabled(self):
@@ -317,8 +354,8 @@ class RunTests(unittest.TestCase):
             mastodon_links.run(config, db_info)
 
         db_path = Path('/tmp/db') / 'fetchlinks.db'
-        self.assertEqual(run_instance.call_args_list[0].args, ({'name': 'infosec'}, db_path, 3, []))
-        self.assertEqual(run_instance.call_args_list[1].args, ({'name': 'hachyderm'}, db_path, 3, []))
+        self.assertEqual(run_instance.call_args_list[0].args, ({'name': 'infosec'}, db_path, 3, [], []))
+        self.assertEqual(run_instance.call_args_list[1].args, ({'name': 'hachyderm'}, db_path, 3, [], []))
 
 
 if __name__ == '__main__':

--- a/fetchlinks/tests/test_reddit_links.py
+++ b/fetchlinks/tests/test_reddit_links.py
@@ -255,6 +255,33 @@ class RedditRunTests(unittest.TestCase):
         inserted_posts = db_insert.call_args.args[0]
         self.assertEqual(inserted_posts[0].urls, ['https://example.com/allowed'])
 
+    def test_run_filters_denied_url_or_description_keywords_before_insert(self):
+        reddit_config = {'credential_location': '/tmp/reddit.json', 'subreddits': ['netsec']}
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        state_updates = [('netsec', 't3_new')]
+        blocked = Post()
+        blocked.date_created = '2999-01-01 00:00:00'
+        blocked.description = 'Politics story'
+        blocked.add_url('https://example.com/story')
+        blocked._generate_unique_url_string()
+        allowed = Post()
+        allowed.date_created = '2999-01-01 00:00:00'
+        allowed.description = 'Technology story'
+        allowed.add_url('https://example.com/allowed')
+        allowed._generate_unique_url_string()
+
+        with patch.object(reddit_links, 'get_subreddits', return_value=([], state_updates)), \
+             patch.object(reddit_links, 'parse_posts', return_value=[blocked, allowed]), \
+             patch.object(reddit_links.db_utils, 'db_insert', return_value=1) as db_insert, \
+             patch.object(reddit_links.db_utils, 'db_set_reddit_states'):
+            reddit_links.run(
+                reddit_config,
+                db_info,
+                excluded_url_or_description_keywords=['politics'],
+            )
+
+        db_insert.assert_called_once_with([allowed], reddit_links.Path('/tmp/db') / 'fetchlinks.db')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/fetchlinks/tests/test_rss_links.py
+++ b/fetchlinks/tests/test_rss_links.py
@@ -304,6 +304,32 @@ class RunTests(unittest.TestCase):
         inserted_posts = db_insert.call_args.args[0]
         self.assertEqual(inserted_posts[0].urls, ['https://example.com/allowed'])
 
+    def test_run_filters_denied_url_or_description_keywords_before_insert(self):
+        db_info = {'db_location': '/tmp/db', 'db_name': 'fetchlinks.db'}
+        blocked = Post()
+        blocked.date_created = '2999-01-01 00:00:00'
+        blocked.description = 'Politics story'
+        blocked.add_url('https://example.com/story')
+        blocked._generate_unique_url_string()
+        allowed = Post()
+        allowed.date_created = '2999-01-01 00:00:00'
+        allowed.description = 'Technology story'
+        allowed.add_url('https://example.com/allowed')
+        allowed._generate_unique_url_string()
+
+        with patch.object(rss_links.db_utils, 'db_get_rss_feed_states', return_value={}), \
+             patch.object(rss_links, 'fetch_feeds', return_value=[]), \
+             patch.object(rss_links.db_utils, 'db_set_rss_feed_states'), \
+             patch.object(rss_links, 'parse_posts', return_value=[blocked, allowed]), \
+             patch.object(rss_links.db_utils, 'db_insert', return_value=1) as db_insert:
+            rss_links.run(
+                ['https://feed.example/rss.xml'],
+                db_info,
+                excluded_url_or_description_keywords=['politics'],
+            )
+
+        db_insert.assert_called_once_with([allowed], rss_links.Path('/tmp/db') / 'fetchlinks.db')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/fetchlinks/tests/test_startup_and_validate.py
+++ b/fetchlinks/tests/test_startup_and_validate.py
@@ -195,6 +195,26 @@ class ParseSourcesTests(unittest.TestCase):
             _write(p, {'ingest': {'excluded_url_host_keywords': ['insider', 'businessinsider.com']}})
             sv.parse_sources(str(p))
 
+    def test_ingest_excluded_url_or_description_keywords_must_be_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'ingest': {'excluded_url_or_description_keywords': 'politics'}})
+            with self.assertRaises(ValueError):
+                sv.parse_sources(str(p))
+
+    def test_ingest_excluded_url_or_description_keywords_must_be_non_empty_strings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'ingest': {'excluded_url_or_description_keywords': ['politics', '']}})
+            with self.assertRaises(ValueError):
+                sv.parse_sources(str(p))
+
+    def test_ingest_excluded_url_or_description_keywords_accepts_strings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / 'sources.json'
+            _write(p, {'ingest': {'excluded_url_or_description_keywords': ['politics', 'trump']}})
+            sv.parse_sources(str(p))
+
     def test_reddit_enabled_without_creds_raises(self):
         with tempfile.TemporaryDirectory() as tmp:
             p = Path(tmp) / 'sources.json'

--- a/fetchlinks/tests/test_url_filters.py
+++ b/fetchlinks/tests/test_url_filters.py
@@ -4,11 +4,11 @@ import url_filters
 from utils import Post
 
 
-def _make_post(urls):
+def _make_post(urls, description='description'):
     post = Post()
     post.source = 'https://source.example'
     post.author = 'author'
-    post.description = 'description'
+    post.description = description
     post.direct_link = 'https://source.example/post'
     post.date_created = '2026-05-02 12:00:00'
     for url in urls:
@@ -102,6 +102,56 @@ class FilterPostsTests(unittest.TestCase):
         self.assertEqual(
             url_filters.excluded_url_host_keywords_from_sources(sources),
             ['insider', 'businessinsider.com'],
+        )
+
+    def test_full_url_keyword_skips_post(self):
+        blocked = _make_post(['https://example.com/news/politics/story'])
+        allowed = _make_post(['https://example.com/news/technology/story'])
+
+        filtered = url_filters.filter_posts_by_url_or_description_keywords(
+            [blocked, allowed],
+            ['politics'],
+            'test',
+        )
+
+        self.assertEqual(filtered, [allowed])
+
+    def test_description_keyword_skips_post_case_insensitive(self):
+        blocked = _make_post(['https://example.com/story'], description='A Politics story')
+        allowed = _make_post(['https://example.com/other'], description='A technology story')
+
+        filtered = url_filters.filter_posts_by_url_or_description_keywords(
+            [blocked, allowed],
+            ['politics'],
+            'test',
+        )
+
+        self.assertEqual(filtered, [allowed])
+
+    def test_description_keyword_uses_word_boundary(self):
+        post = _make_post(['https://example.com/story'], description='A trumpet lesson')
+
+        filtered = url_filters.filter_posts_by_url_or_description_keywords([post], ['trump'], 'test')
+
+        self.assertEqual(filtered, [post])
+
+    def test_empty_url_or_description_keywords_is_noop(self):
+        post = _make_post(['https://example.com/news/politics/story'], description='Politics')
+
+        filtered = url_filters.filter_posts_by_url_or_description_keywords([post], [], 'test')
+
+        self.assertEqual(filtered, [post])
+
+    def test_reads_url_or_description_keywords_from_sources(self):
+        sources = {
+            'ingest': {
+                'excluded_url_or_description_keywords': [' Politics ', '', 12, 'trump'],
+            },
+        }
+
+        self.assertEqual(
+            url_filters.excluded_url_or_description_keywords_from_sources(sources),
+            ['politics', 'trump'],
         )
 
 

--- a/fetchlinks/url_filters.py
+++ b/fetchlinks/url_filters.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
@@ -11,10 +12,21 @@ def excluded_url_host_keywords_from_sources(sources: dict) -> list[str]:
     return normalize_host_keywords(ingest_config.get('excluded_url_host_keywords', []))
 
 
-def normalize_host_keywords(keywords) -> list[str]:
+def excluded_url_or_description_keywords_from_sources(sources: dict) -> list[str]:
+    ingest_config = sources.get('ingest', {})
+    if not isinstance(ingest_config, dict):
+        return []
+    return normalize_keywords(ingest_config.get('excluded_url_or_description_keywords', []))
+
+
+def normalize_keywords(keywords) -> list[str]:
     if not keywords or not isinstance(keywords, list):
         return []
     return [keyword.strip().lower() for keyword in keywords if isinstance(keyword, str) and keyword.strip()]
+
+
+def normalize_host_keywords(keywords) -> list[str]:
+    return normalize_keywords(keywords)
 
 
 def url_matches_host_keyword(url: str, keywords: list[str]) -> bool:
@@ -71,6 +83,62 @@ def filter_posts_by_url_host_keywords(posts: list, keywords: list[str], source_n
             removed_url_count,
             source_name,
             skipped_post_count,
+        )
+
+    return filtered_posts
+
+
+def url_matches_keyword(url: str, keywords: list[str]) -> bool:
+    normalized_keywords = normalize_keywords(keywords)
+    if not normalized_keywords or not isinstance(url, str):
+        return False
+
+    normalized_url = url.lower()
+    return any(keyword in normalized_url for keyword in normalized_keywords)
+
+
+def description_matches_keyword(description: str, keywords: list[str]) -> bool:
+    normalized_keywords = normalize_keywords(keywords)
+    if not normalized_keywords or not isinstance(description, str):
+        return False
+
+    normalized_description = description.lower()
+    return any(
+        re.search(rf'(?<!\w){re.escape(keyword)}(?!\w)', normalized_description)
+        for keyword in normalized_keywords
+    )
+
+
+def post_matches_url_or_description_keyword(post, keywords: list[str]) -> bool:
+    normalized_keywords = normalize_keywords(keywords)
+    if not normalized_keywords:
+        return False
+
+    if description_matches_keyword(getattr(post, 'description', ''), normalized_keywords):
+        return True
+
+    return any(url_matches_keyword(url, normalized_keywords) for url in getattr(post, 'urls', []))
+
+
+def filter_posts_by_url_or_description_keywords(posts: list, keywords: list[str], source_name: str) -> list:
+    normalized_keywords = normalize_keywords(keywords)
+    if not normalized_keywords:
+        return posts
+
+    filtered_posts = []
+    skipped_post_count = 0
+
+    for post in posts:
+        if post_matches_url_or_description_keyword(post, normalized_keywords):
+            skipped_post_count += 1
+            continue
+        filtered_posts.append(post)
+
+    if skipped_post_count:
+        logger.info(
+            'Filtered %s %s post(s) matching excluded URL/description keyword(s)',
+            skipped_post_count,
+            source_name,
         )
 
     return filtered_posts


### PR DESCRIPTION
## Summary
- add ingest.excluded_url_or_description_keywords for post-level keyword filtering
- match keywords against full extracted URLs with case-insensitive substring matching
- match keywords against descriptions with case-insensitive whole-word matching
- skip entire posts before DB insertion when URL or description keywords match
- validate and document the new setting

## Validation
- /home/rich/DEV/fetchlinks_src/venv/bin/python -m unittest tests.test_url_filters tests.test_fetch_links tests.test_startup_and_validate tests.test_rss_links tests.test_reddit_links tests.test_bluesky_links tests.test_mastodon_links
- /home/rich/DEV/fetchlinks_src/venv/bin/python -m unittest discover -s tests
- git diff --check

Note: this PR intentionally leaves the branch unmerged for review.