### PR TITLE
Port web deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,10 @@ cd web
 npm run validate
 ```
 
+## Deployment Examples
+
+Example systemd and nginx files for running the web app on a VM live in
+`deploy/`. They are adapted for a single checkout at `/opt/fetchlinks` with the
+web app at `/opt/fetchlinks/web`.
+
 For detailed setup notes, see `ingest/SETUP.md` and `web/README.md`.

--- a/deploy/nginx/fetchlinks-web.conf.example
+++ b/deploy/nginx/fetchlinks-web.conf.example
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name fetchlinks.example.com;
+
+    access_log /var/log/nginx/fetchlinks-web.access.log;
+    error_log /var/log/nginx/fetchlinks-web.error.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+}

--- a/deploy/systemd/fetchlinks-web.env.example
+++ b/deploy/systemd/fetchlinks-web.env.example
@@ -1,0 +1,6 @@
+# Example: /etc/fetchlinks/web.env
+# The systemd service reads this file with EnvironmentFile=.
+
+NODE_ENV=production
+NEXT_TELEMETRY_DISABLED=1
+FETCHLINKS_DB=/var/lib/fetchlinks/fetchlinks.db

--- a/deploy/systemd/fetchlinks-web.service
+++ b/deploy/systemd/fetchlinks-web.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Fetchlinks Next.js web UI
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=fetchlinks
+Group=fetchlinks
+WorkingDirectory=/opt/fetchlinks/web
+EnvironmentFile=/etc/fetchlinks/web.env
+ExecStart=/usr/bin/npm run start -- --hostname 127.0.0.1 --port 3000
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=30
+SyslogIdentifier=fetchlinks-web
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add existing web systemd and nginx examples under deploy/
- update service paths for the monorepo layout at /opt/fetchlinks/web
- note deployment examples in the root README

## Validation
- systemd-analyze verify deploy/systemd/fetchlinks-web.service

No Docker, Postgres, or deployment architecture changes are included.