### PR TITLE
Add weekly retention timer (prune + threshold-gated VACUUM)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,7 +17,9 @@ deploy/
     ├── fetchlinks-web.service         Next.js web app
     ├── fetchlinks-web.env.example     env file template for the web service
     ├── fetchlinks-ingest.service      Python ingest one-shot
-    └── fetchlinks-ingest.timer        ingest schedule (every 30 min)
+    ├── fetchlinks-ingest.timer        ingest schedule (every 30 min)
+    ├── fetchlinks-retain.service      weekly DB retention one-shot
+    └── fetchlinks-retain.timer        retention schedule (Sun 03:30)
 ```
 
 ## First-time install
@@ -88,9 +90,11 @@ sudo FETCHLINKS_REPO_REF=v1.2.3 /opt/fetchlinks/deploy/bootstrap.sh
 ```bash
 systemctl status fetchlinks-web.service
 systemctl status fetchlinks-ingest.timer
-systemctl list-timers fetchlinks-ingest.timer
+systemctl status fetchlinks-retain.timer
+systemctl list-timers fetchlinks-ingest.timer fetchlinks-retain.timer
 journalctl -u fetchlinks-web.service -f
 journalctl -u fetchlinks-ingest.service --since '1 hour ago'
+journalctl -u fetchlinks-retain.service --since '7 days ago'
 ```
 
 ## Filesystem layout on the VM

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -159,10 +159,13 @@ log "Installing systemd units"
 install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-web.service"     /etc/systemd/system/
 install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-ingest.service"  /etc/systemd/system/
 install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-ingest.timer"    /etc/systemd/system/
+install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-retain.service"  /etc/systemd/system/
+install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-retain.timer"    /etc/systemd/system/
 systemctl daemon-reload
 
 systemctl enable --now fetchlinks-web.service
 systemctl enable --now fetchlinks-ingest.timer
+systemctl enable --now fetchlinks-retain.timer
 systemctl restart   fetchlinks-web.service
 
 # ---- nginx + tls (optional) -------------------------------------------------
@@ -196,6 +199,7 @@ fi
 log "Done. Status:"
 systemctl --no-pager --lines=0 status fetchlinks-web.service     || true
 systemctl --no-pager --lines=0 status fetchlinks-ingest.timer    || true
+systemctl --no-pager --lines=0 status fetchlinks-retain.timer    || true
 
 cat <<EOF
 

--- a/deploy/config/fetchlinks.toml
+++ b/deploy/config/fetchlinks.toml
@@ -14,6 +14,12 @@ max_post_age_months                  = 3
 excluded_url_host_keywords           = []
 excluded_url_or_description_keywords = []
 
+[retention]
+# Pruning weekly via fetchlinks-retain.timer.
+# max_post_age_months omitted => falls back to [ingest].max_post_age_months.
+enabled                 = true
+vacuum_threshold_pages  = 1000
+
 # --- Sources ---------------------------------------------------------------
 # Enable only the sources you have credentials for. The bootstrap script
 # leaves these disabled by default; flip `enabled = true` after dropping

--- a/deploy/systemd/fetchlinks-retain.service
+++ b/deploy/systemd/fetchlinks-retain.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Fetchlinks retention (prune old posts, optional VACUUM)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=fetchlinks
+Group=fetchlinks
+WorkingDirectory=/opt/fetchlinks/ingest/fetchlinks
+EnvironmentFile=-/etc/fetchlinks/ingest.env
+ExecStart=/opt/fetchlinks/.venv/bin/python /opt/fetchlinks/ingest/fetchlinks/retain.py --config /etc/fetchlinks/fetchlinks.toml
+Nice=10
+TimeoutStartSec=30min
+SyslogIdentifier=fetchlinks-retain
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/fetchlinks /var/log/fetchlinks
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/fetchlinks-retain.timer
+++ b/deploy/systemd/fetchlinks-retain.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run Fetchlinks retention weekly
+Requires=fetchlinks-retain.service
+
+[Timer]
+OnCalendar=Sun 03:30
+RandomizedDelaySec=10min
+Persistent=true
+Unit=fetchlinks-retain.service
+
+[Install]
+WantedBy=timers.target

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -42,3 +42,7 @@ without changing code.
 - Bluesky ingestion persists pagination cursor state in the database and
   resumes on later runs.
 - Log output is written to `[paths].log_file` from `fetchlinks.toml`.
+- A separate one-shot, `retain.py`, prunes posts older than
+  `[retention].max_post_age_months` (falling back to
+  `[ingest].max_post_age_months`) and VACUUMs when enough pages are freed.
+  In production it runs weekly via `fetchlinks-retain.timer`.

--- a/ingest/SETUP.md
+++ b/ingest/SETUP.md
@@ -97,6 +97,9 @@ or relative to the TOML file's directory. The schema is:
 - `[paths]` — `db`, `log_file`, `log_level` (`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`).
 - `[ingest]` — `max_post_age_months`, `excluded_url_host_keywords`,
   `excluded_url_or_description_keywords`.
+- `[retention]` — `enabled` (default `true`), optional `max_post_age_months`
+  (falls back to `[ingest].max_post_age_months`), `vacuum_threshold_pages`
+  (default `1000`). Drives the weekly retention job (`retain.py`).
 - `[sources.rss]` — `enabled`, `feeds_file` (path to a plain-text feed list).
 - `[sources.reddit]` — `enabled`, `credential_location`, `subreddits`,
   optional `listing_limit` (default 100) and `max_pages` (default 5).

--- a/ingest/fetchlinks/config.py
+++ b/ingest/fetchlinks/config.py
@@ -41,6 +41,13 @@ class IngestPolicy:
 
 
 @dataclass(frozen=True)
+class RetentionPolicy:
+    enabled: bool = True
+    # When None, retention.run() falls back to IngestPolicy.max_post_age_months.
+    max_post_age_months: int | None = None
+    vacuum_threshold_pages: int = 1000
+
+@dataclass(frozen=True)
 class RssSource:
     enabled: bool
     feeds_file: Path
@@ -92,6 +99,7 @@ class AppConfig:
     paths: PathsConfig
     ingest: IngestPolicy
     sources: Sources
+    retention: RetentionPolicy = field(default_factory=RetentionPolicy)
     source_path: Path = field(default_factory=Path)
 
 
@@ -109,12 +117,14 @@ def load_config(config_path: Path) -> AppConfig:
     base = config_path.resolve().parent
     paths = _build_paths(raw.get('paths', {}), base)
     ingest = _build_ingest(raw.get('ingest', {}))
+    retention = _build_retention(raw.get('retention', {}))
     sources = _build_sources(raw.get('sources', {}), base)
 
     # Ensure log directory exists; mirrors old behaviour.
     paths.log_file.parent.mkdir(parents=True, exist_ok=True)
 
-    return AppConfig(paths=paths, ingest=ingest, sources=sources, source_path=config_path)
+    return AppConfig(paths=paths, ingest=ingest, sources=sources,
+                     retention=retention, source_path=config_path)
 
 
 # --- Builders --------------------------------------------------------------
@@ -172,6 +182,28 @@ def _validate_keyword_list(name: str, value: Any) -> None:
     for kw in value:
         if not isinstance(kw, str) or not kw.strip():
             raise ValueError(f'[ingest] {name} must contain non-empty strings')
+
+
+def _build_retention(section: dict) -> RetentionPolicy:
+    if not isinstance(section, dict):
+        raise ValueError('[retention] must be a table')
+
+    enabled = bool(section.get('enabled', True))
+
+    max_age = section.get('max_post_age_months')
+    if max_age is not None:
+        if not isinstance(max_age, int) or isinstance(max_age, bool) or max_age < 1:
+            raise ValueError('[retention] max_post_age_months must be a positive integer')
+
+    threshold = section.get('vacuum_threshold_pages', 1000)
+    if not isinstance(threshold, int) or isinstance(threshold, bool) or threshold < 0:
+        raise ValueError('[retention] vacuum_threshold_pages must be a non-negative integer')
+
+    return RetentionPolicy(
+        enabled=enabled,
+        max_post_age_months=max_age,
+        vacuum_threshold_pages=threshold,
+    )
 
 
 def _build_sources(section: dict, base: Path) -> Sources:

--- a/ingest/fetchlinks/data/config/fetchlinks.toml
+++ b/ingest/fetchlinks/data/config/fetchlinks.toml
@@ -14,6 +14,12 @@ max_post_age_months                  = 3
 excluded_url_host_keywords           = ["businessinsider", "economist.com"]
 excluded_url_or_description_keywords = ["trump", "covid"]
 
+[retention]
+# Pruning weekly via fetchlinks-retain.timer.
+# max_post_age_months omitted => falls back to [ingest].max_post_age_months.
+enabled                 = true
+vacuum_threshold_pages  = 1000
+
 # --- Sources ---------------------------------------------------------------
 # Credentials are read from the JSON files referenced by `credential_location`
 # (paths starting with ~ are expanded).

--- a/ingest/fetchlinks/retain.py
+++ b/ingest/fetchlinks/retain.py
@@ -1,0 +1,110 @@
+"""Retention job: prune old posts and (optionally) VACUUM the SQLite DB.
+
+Runs as a oneshot, typically on a weekly systemd timer. Deletes posts whose
+``date_created`` is older than ``retention.max_post_age_months`` (falling back
+to ``ingest.max_post_age_months``). If the number of freelist pages grows by
+more than ``retention.vacuum_threshold_pages`` as a result, the DB is
+VACUUMed to reclaim disk space.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from logging import StreamHandler
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+import config as app_config
+
+logger = logging.getLogger(__name__)
+
+_LOG_LEVEL_VALUES = {"CRITICAL": 50, "ERROR": 40, "WARNING": 30, "INFO": 20, "DEBUG": 10}
+
+
+def configure_logging(cfg: app_config.AppConfig) -> None:
+    """Mirror fetch_links.configure_logging so retention runs share the log file."""
+    log_level = _LOG_LEVEL_VALUES.get(cfg.paths.log_level, logging.INFO)
+    logging.basicConfig(
+        handlers=[
+            RotatingFileHandler(cfg.paths.log_file, maxBytes=1_000_000, backupCount=5, encoding="utf8"),
+            StreamHandler(),
+        ],
+        level=log_level,
+        format="%(asctime)s (%(module)s) %(levelname)s - %(message)s",
+        datefmt="%d/%m/%Y %I:%M:%S %p",
+    )
+
+
+def _resolve_max_age(cfg: app_config.AppConfig) -> int:
+    if cfg.retention.max_post_age_months is not None:
+        return cfg.retention.max_post_age_months
+    return cfg.ingest.max_post_age_months
+
+
+def _freelist_count(conn: sqlite3.Connection) -> int:
+    return conn.execute('PRAGMA freelist_count').fetchone()[0]
+
+
+def run_retention(db_path: Path, max_age_months: int, vacuum_threshold_pages: int) -> dict:
+    """Delete posts older than the cutoff; VACUUM if enough pages were freed.
+
+    Returns a stats dict (``deleted``, ``freelist_before``, ``freelist_after``,
+    ``vacuumed``) for callers / tests.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute('PRAGMA foreign_keys=ON')
+        freelist_before = _freelist_count(conn)
+
+        cutoff_expr = f"datetime('now','-{int(max_age_months)} months')"
+        cur = conn.execute(f'DELETE FROM posts WHERE date_created < {cutoff_expr}')
+        deleted = cur.rowcount
+        conn.commit()
+
+        freelist_after = _freelist_count(conn)
+        delta = freelist_after - freelist_before
+
+        vacuumed = False
+        if vacuum_threshold_pages > 0 and delta >= vacuum_threshold_pages:
+            logger.info('Freed %d pages (>= threshold %d); VACUUMing',
+                        delta, vacuum_threshold_pages)
+            conn.execute('VACUUM')
+            vacuumed = True
+        else:
+            logger.info('Freed %d pages (< threshold %d); skipping VACUUM',
+                        delta, vacuum_threshold_pages)
+
+        return {
+            'deleted': deleted,
+            'freelist_before': freelist_before,
+            'freelist_after': freelist_after,
+            'vacuumed': vacuumed,
+        }
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    try:
+        args = app_config.parse_arguments()
+        cfg = app_config.load_config(args.config)
+        configure_logging(cfg)
+
+        if not cfg.retention.enabled:
+            logger.info('Retention disabled in config; nothing to do.')
+            return
+
+        max_age = _resolve_max_age(cfg)
+        logger.info('Running retention against %s (max_post_age_months=%d, vacuum_threshold_pages=%d)',
+                    cfg.paths.db, max_age, cfg.retention.vacuum_threshold_pages)
+        stats = run_retention(cfg.paths.db, max_age, cfg.retention.vacuum_threshold_pages)
+        logger.info('Retention complete: deleted=%d freelist_before=%d freelist_after=%d vacuumed=%s',
+                    stats['deleted'], stats['freelist_before'], stats['freelist_after'], stats['vacuumed'])
+    except Exception as exc:
+        logging.exception('Retention failed: %s', exc)
+        raise SystemExit(1) from exc
+
+
+if __name__ == '__main__':
+    main()

--- a/ingest/fetchlinks/tests/test_config.py
+++ b/ingest/fetchlinks/tests/test_config.py
@@ -142,5 +142,37 @@ class LoadConfigTests(unittest.TestCase):
                 app_config.load_config(cfg)
 
 
+class RetentionConfigTests(unittest.TestCase):
+    def test_defaults_when_section_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = app_config.load_config(_toml(Path(tmp)))
+            self.assertTrue(cfg.retention.enabled)
+            self.assertIsNone(cfg.retention.max_post_age_months)
+            self.assertEqual(cfg.retention.vacuum_threshold_pages, 1000)
+
+    def test_explicit_values_are_loaded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_path = _toml(
+                Path(tmp),
+                extra='\n[retention]\nenabled = false\nmax_post_age_months = 6\nvacuum_threshold_pages = 250\n',
+            )
+            cfg = app_config.load_config(cfg_path)
+            self.assertFalse(cfg.retention.enabled)
+            self.assertEqual(cfg.retention.max_post_age_months, 6)
+            self.assertEqual(cfg.retention.vacuum_threshold_pages, 250)
+
+    def test_invalid_max_age_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _toml(Path(tmp), extra='\n[retention]\nmax_post_age_months = 0\n')
+            with self.assertRaises(ValueError):
+                app_config.load_config(cfg)
+
+    def test_negative_threshold_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = _toml(Path(tmp), extra='\n[retention]\nvacuum_threshold_pages = -1\n')
+            with self.assertRaises(ValueError):
+                app_config.load_config(cfg)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/ingest/fetchlinks/tests/test_retain.py
+++ b/ingest/fetchlinks/tests/test_retain.py
@@ -1,0 +1,173 @@
+import sqlite3
+import tempfile
+import unittest
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import db_setup
+import retain
+
+
+def _seed_posts(db_path: Path, ages_days: list[int]) -> None:
+    """Insert a row per entry in ``ages_days``. Each value is the row's age in days."""
+    now = datetime.now(UTC)
+    conn = sqlite3.connect(db_path)
+    try:
+        for i, age in enumerate(ages_days):
+            ts = (now - timedelta(days=age)).strftime('%Y-%m-%d %H:%M:%S')
+            conn.execute(
+                'INSERT INTO posts (source, author, description, direct_link, date_created, unique_id_string) '
+                'VALUES (?, ?, ?, ?, ?, ?)',
+                ('rss', 'a', 'd', 'https://example/', ts, f'uid-{i}'),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _row_count(db_path: Path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute('SELECT COUNT(*) FROM posts').fetchone()[0]
+    finally:
+        conn.close()
+
+
+class RunRetentionTests(unittest.TestCase):
+    def test_deletes_rows_older_than_cutoff_keeps_recent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / 'fetchlinks.db'
+            db_setup.db_initial_setup(db)
+            # 1 month = ~30 days. Use 200 days old (well past 3 months) vs 5 days old.
+            _seed_posts(db, [200, 200, 200, 5, 5])
+
+            stats = retain.run_retention(db, max_age_months=3, vacuum_threshold_pages=0)
+
+            self.assertEqual(stats['deleted'], 3)
+            self.assertEqual(_row_count(db), 2)
+
+    def test_skips_vacuum_when_below_threshold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / 'fetchlinks.db'
+            db_setup.db_initial_setup(db)
+            _seed_posts(db, [200])
+
+            # Threshold is huge; even if a real delete frees pages it won't trip.
+            with patch.object(retain, '_freelist_count', side_effect=[0, 3]):
+                stats = retain.run_retention(db, max_age_months=3, vacuum_threshold_pages=10_000)
+
+            self.assertFalse(stats['vacuumed'])
+            self.assertEqual(stats['freelist_before'], 0)
+            self.assertEqual(stats['freelist_after'], 3)
+
+    def test_runs_vacuum_when_threshold_met(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / 'fetchlinks.db'
+            db_setup.db_initial_setup(db)
+            _seed_posts(db, [200])
+
+            with patch.object(retain, '_freelist_count', side_effect=[0, 5]):
+                stats = retain.run_retention(db, max_age_months=3, vacuum_threshold_pages=1)
+
+            self.assertTrue(stats['vacuumed'])
+            self.assertEqual(stats['freelist_before'], 0)
+            self.assertEqual(stats['freelist_after'], 5)
+
+    def test_zero_threshold_skips_vacuum_even_with_delta(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = Path(tmp) / 'fetchlinks.db'
+            db_setup.db_initial_setup(db)
+            _seed_posts(db, [200])
+
+            with patch.object(retain, '_freelist_count', side_effect=[0, 99]):
+                stats = retain.run_retention(db, max_age_months=3, vacuum_threshold_pages=0)
+
+            self.assertFalse(stats['vacuumed'])
+
+
+class MainFlowTests(unittest.TestCase):
+    def _make_cfg(self, tmp: Path, *, retention_enabled=True, max_age=None, threshold=1000, ingest_age=3):
+        from config import (
+            AppConfig, IngestPolicy, PathsConfig, RetentionPolicy, Sources,
+        )
+        return AppConfig(
+            paths=PathsConfig(db=tmp / 'x.db', log_file=tmp / 'x.log'),
+            ingest=IngestPolicy(max_post_age_months=ingest_age),
+            sources=Sources(),
+            retention=RetentionPolicy(
+                enabled=retention_enabled,
+                max_post_age_months=max_age,
+                vacuum_threshold_pages=threshold,
+            ),
+            source_path=tmp / 'fetchlinks.toml',
+        )
+
+    def test_main_runs_when_enabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cfg = self._make_cfg(tmp_path, max_age=6, threshold=500)
+
+            class _Args:
+                config = tmp_path / 'fetchlinks.toml'
+
+            with patch.object(retain.app_config, 'parse_arguments', return_value=_Args()), \
+                 patch.object(retain.app_config, 'load_config', return_value=cfg), \
+                 patch.object(retain, 'configure_logging'), \
+                 patch.object(retain, 'run_retention', return_value={
+                     'deleted': 7, 'freelist_before': 0, 'freelist_after': 0, 'vacuumed': False,
+                 }) as run:
+                retain.main()
+
+            run.assert_called_once_with(cfg.paths.db, 6, 500)
+
+    def test_main_falls_back_to_ingest_age_when_unset(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cfg = self._make_cfg(tmp_path, max_age=None, ingest_age=4)
+
+            class _Args:
+                config = tmp_path / 'fetchlinks.toml'
+
+            with patch.object(retain.app_config, 'parse_arguments', return_value=_Args()), \
+                 patch.object(retain.app_config, 'load_config', return_value=cfg), \
+                 patch.object(retain, 'configure_logging'), \
+                 patch.object(retain, 'run_retention', return_value={
+                     'deleted': 0, 'freelist_before': 0, 'freelist_after': 0, 'vacuumed': False,
+                 }) as run:
+                retain.main()
+
+            run.assert_called_once_with(cfg.paths.db, 4, 1000)
+
+    def test_main_skips_when_disabled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cfg = self._make_cfg(tmp_path, retention_enabled=False)
+
+            class _Args:
+                config = tmp_path / 'fetchlinks.toml'
+
+            with patch.object(retain.app_config, 'parse_arguments', return_value=_Args()), \
+                 patch.object(retain.app_config, 'load_config', return_value=cfg), \
+                 patch.object(retain, 'configure_logging'), \
+                 patch.object(retain, 'run_retention') as run:
+                retain.main()
+
+            run.assert_not_called()
+
+    def test_main_exits_one_on_exception(self):
+        class _Args:
+            config = Path('/tmp/bad.toml')
+
+        with patch.object(retain.app_config, 'parse_arguments', return_value=_Args()), \
+             patch.object(retain.app_config, 'load_config', side_effect=ValueError('bad')), \
+             patch.object(retain.logging, 'exception') as log_exception:
+            with self.assertRaises(SystemExit) as exc:
+                retain.main()
+
+        self.assertEqual(exc.exception.code, 1)
+        log_exception.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a weekly oneshot that prunes old posts from the SQLite DB and reclaims disk space when worthwhile.

## Config

New `[retention]` block in `fetchlinks.toml`:

```toml
[retention]
enabled                 = true
# max_post_age_months   = 6   # optional; falls back to [ingest].max_post_age_months
vacuum_threshold_pages  = 1000
```

## Behavior

`ingest/fetchlinks/retain.py`:
1. Resolves cutoff: `retention.max_post_age_months` or `ingest.max_post_age_months`.
2. Snapshots `PRAGMA freelist_count`.
3. `DELETE FROM posts WHERE date_created < datetime('now','-N months')`.
4. Re-snapshots freelist; runs `VACUUM` only if delta >= `vacuum_threshold_pages`.
5. Logs `{deleted, freelist_before, freelist_after, vacuumed}`.

## Systemd

- `fetchlinks-retain.service` — oneshot, same hardening as ingest unit.
- `fetchlinks-retain.timer` — `OnCalendar=Sun 03:30`, `Persistent=true`, 10min randomized delay.
- `bootstrap.sh` installs both and runs `systemctl enable --now fetchlinks-retain.timer`.

## Tests

- `tests/test_retain.py` (8): cutoff correctness, VACUUM gating in both directions, zero-threshold skip, full `main()` flow including disabled, fallback age, and exception exit.
- `tests/test_config.py` (4): `RetentionConfigTests` for defaults, explicit values, invalid age, negative threshold.
- **253 tests passing.**

## Smoke

Against a copy of the real dev DB (~8.5k posts):
```
before: total=8497 eligible-for-delete=607
stats : {'deleted': 607, 'freelist_before': 0, 'freelist_after': 15, 'vacuumed': False}
after : total=7890
```
Deletes correct, VACUUM correctly skipped (15 < 1000).