### PR TITLE
Clamp future post dates + normalise feed dates to UTC

### DIFF
--- a/ingest/fetchlinks/tests/test_utils.py
+++ b/ingest/fetchlinks/tests/test_utils.py
@@ -8,6 +8,7 @@ from utils import (
     RedditPost,
     RssPost,
     build_hash,
+    clamp_date_not_in_future,
     convert_date_string_for_mysql,
     convert_epoch_to_mysql,
     extract_urls_from_text,
@@ -51,6 +52,20 @@ class ConvertDateStringTests(unittest.TestCase):
     def test_iso_string_round_trips_to_mysql_format(self):
         self.assertEqual(
             convert_date_string_for_mysql('2026-04-19T12:34:56Z'),
+            '2026-04-19 12:34:56',
+        )
+
+    def test_tz_aware_string_is_converted_to_utc(self):
+        # +09:00 offset should subtract 9 hours when normalised to UTC.
+        self.assertEqual(
+            convert_date_string_for_mysql('2026-05-22T20:00:00+09:00'),
+            '2026-05-22 11:00:00',
+        )
+
+    def test_naive_string_is_assumed_utc(self):
+        # No tz offset: leave the wall-clock values as-is.
+        self.assertEqual(
+            convert_date_string_for_mysql('2026-04-19 12:34:56'),
             '2026-04-19 12:34:56',
         )
 
@@ -210,6 +225,51 @@ class BlueskyPostTests(unittest.TestCase):
         )
         self.assertEqual(post.urls, ['https://example.com/a', 'https://example.com/b'])
         self.assertEqual(post.date_created, '2026-04-19 12:34:56')
+
+
+class ClampDateNotInFutureTests(unittest.TestCase):
+    def _now_str(self, offset_seconds: int = 0) -> str:
+        when = dt.datetime.now(dt.UTC).replace(tzinfo=None) + dt.timedelta(seconds=offset_seconds)
+        return when.strftime('%Y-%m-%d %H:%M:%S')
+
+    def test_past_date_passes_through_unchanged(self):
+        self.assertEqual(
+            clamp_date_not_in_future('2000-01-01 00:00:00'),
+            '2000-01-01 00:00:00',
+        )
+
+    def test_empty_string_passes_through_unchanged(self):
+        self.assertEqual(clamp_date_not_in_future(''), '')
+
+    def test_unparseable_string_passes_through_unchanged(self):
+        self.assertEqual(clamp_date_not_in_future('not-a-date'), 'not-a-date')
+
+    def test_small_skew_within_tolerance_passes_through(self):
+        candidate = self._now_str(offset_seconds=10)
+        self.assertEqual(clamp_date_not_in_future(candidate), candidate)
+
+    def test_far_future_date_is_clamped(self):
+        clamped = clamp_date_not_in_future('2999-12-31 23:59:59')
+        # Result is a valid timestamp that is no longer in the future.
+        parsed = dt.datetime.strptime(clamped, '%Y-%m-%d %H:%M:%S')
+        self.assertLessEqual(parsed, dt.datetime.now(dt.UTC).replace(tzinfo=None) + dt.timedelta(seconds=1))
+
+    def test_get_post_row_clamps_future_date(self):
+        post = Post()
+        post.source = 'https://x/'
+        post.author = 'a'
+        post.description = 'd'
+        post.direct_link = 'https://x/1'
+        post.date_created = '2999-12-31 23:59:59'
+        post.add_url('https://example.com/x')
+        post._generate_unique_url_string()
+
+        row = post.get_post_row()
+        clamped_date = row[4]
+        parsed = dt.datetime.strptime(clamped_date, '%Y-%m-%d %H:%M:%S')
+        self.assertLess(parsed.year, 2999)
+        # In-memory value is untouched; only the persisted column changes.
+        self.assertEqual(post.date_created, '2999-12-31 23:59:59')
 
 
 if __name__ == '__main__':

--- a/ingest/fetchlinks/utils.py
+++ b/ingest/fetchlinks/utils.py
@@ -19,6 +19,11 @@ def build_hash(link: str) -> str:
 def convert_date_string_for_mysql(rss_date: str) -> str:
     try:
         date_object = dateutil.parser.parse(rss_date)
+        # If the source includes a tz offset, convert to UTC before dropping
+        # tzinfo. Otherwise a feed dated "2026-05-22T20:00:00+09:00" would be
+        # stored as "2026-05-22 20:00:00" and sort 9 hours into our future.
+        if date_object.tzinfo is not None:
+            date_object = date_object.astimezone(UTC).replace(tzinfo=None)
         date_created = datetime.datetime.strftime(date_object, '%Y-%m-%d %H:%M:%S')
     except dateutil.parser.ParserError as e:
         # We couldn't parse the date for some reason. Make it "now" (UTC)
@@ -30,6 +35,35 @@ def convert_date_string_for_mysql(rss_date: str) -> str:
 def convert_epoch_to_mysql(epoch: float) -> str:
     date_object = datetime.datetime.fromtimestamp(int(epoch), tz=UTC)
     return date_object.strftime('%Y-%m-%d %H:%M:%S')
+
+
+# Allow a small clock-skew tolerance so legitimately-just-published items
+# don't trigger a warning every time the publisher's clock is a couple of
+# seconds ahead of ours.
+_FUTURE_DATE_TOLERANCE_SECONDS = 60
+
+
+def clamp_date_not_in_future(date_str: str) -> str:
+    """Return ``date_str`` clamped to ``now()`` if it is in the future.
+
+    Some sources legitimately stamp posts with future dates (scheduled
+    webinars, conference announcements, publisher clock skew). Those rows
+    sort wrong in any "most recent" view, so we cap the stored timestamp
+    at the ingest time. The original date is preserved in the post body /
+    description; only the sortable column changes.
+    """
+    if not date_str:
+        return date_str
+    try:
+        parsed = datetime.datetime.strptime(date_str, '%Y-%m-%d %H:%M:%S')
+    except ValueError:
+        return date_str
+    now = datetime.datetime.now(UTC).replace(tzinfo=None)
+    if parsed <= now + datetime.timedelta(seconds=_FUTURE_DATE_TOLERANCE_SECONDS):
+        return date_str
+    logger.warning('Clamped future post date %s -> %s',
+                   date_str, now.strftime('%Y-%m-%d %H:%M:%S'))
+    return now.strftime('%Y-%m-%d %H:%M:%S')
 
 
 def extract_urls_from_text(text: str) -> List[str]:
@@ -92,7 +126,7 @@ class Post:
             self.author,
             self.description,
             self.direct_link,
-            self.date_created,
+            clamp_date_not_in_future(self.date_created),
             self.unique_id_string,
         )
 


### PR DESCRIPTION
Some sources publish posts with future-dated timestamps. Two root causes were observed in the dev DB:

1. **Genuinely scheduled future content** \u2014 BrightTALK webinars, virtual events, conference announcements. Publishers stamp the `<published>` date with the *event* date.
2. **Timezone-offset stripping** \u2014 `convert_date_string_for_mysql` called `strftime` on a tz-aware datetime without first converting to UTC, so e.g. `2026-05-22T20:00:00+09:00` was stored as `2026-05-22 20:00:00`, sorting 9 hours into our future.

## Fix

- **`convert_date_string_for_mysql`** now `.astimezone(UTC).replace(tzinfo=None)` before formatting when the parsed datetime is tz-aware. Naive strings continue to be treated as UTC.
- **`clamp_date_not_in_future`** new helper that caps any `YYYY-MM-DD HH:MM:SS` string greater than `now()` at the current UTC time, with a 60s tolerance for normal publisher clock skew. Warns on clamp so the symptom remains visible in logs.
- **`Post.get_post_row`** applies the clamp; single chokepoint covers every source (RSS / Reddit / Bluesky / Mastodon).
- In-memory `Post.date_created` is left untouched so any caller doing post-parse age filtering still sees the original.

## Tests

8 new assertions in two new `test_utils.py` classes (TZ-aware conversion, naive baseline, clamp tolerance, far-future clamp, get_post_row integration). 284 passing total.

## Backfill

11 pre-existing future-dated rows in the dev DB were clamped to `now()` out-of-band:
`UPDATE posts SET date_created = strftime('%Y-%m-%d %H:%M:%S','now') WHERE date_created > datetime('now');`