### PR TITLE
2b: web admin UI for rss_feeds (HTTP Basic, soft-delete)

### DIFF
--- a/deploy/systemd/fetchlinks-web.env.example
+++ b/deploy/systemd/fetchlinks-web.env.example
@@ -4,3 +4,7 @@
 NODE_ENV=production
 NEXT_TELEMETRY_DISABLED=1
 FETCHLINKS_DB=/var/lib/fetchlinks/fetchlinks.db
+
+# Credentials for the /admin/* routes (HTTP Basic). Leave unset to disable.
+FETCHLINKS_ADMIN_USER=admin
+FETCHLINKS_ADMIN_PASS=change-me

--- a/web/README.md
+++ b/web/README.md
@@ -8,7 +8,9 @@ The scaffold targets Node 24.15 or newer with npm 11.12 or newer.
 
 ## Environment
 
-Copy `.env.example` to `.env.local` for local development and set `FETCHLINKS_DB` to the absolute path of the SQLite database written by the fetchlinks ingestion app. The web app treats this database as read-only.
+Copy `.env.example` to `.env.local` for local development and set `FETCHLINKS_DB` to the absolute path of the SQLite database written by the fetchlinks ingestion app. The public pages treat this database as read-only; the `/admin/feeds` route opens it read-write to manage the `rss_feeds` table.
+
+To enable the admin UI, also set `FETCHLINKS_ADMIN_USER` and `FETCHLINKS_ADMIN_PASS`. Requests to `/admin/*` are gated by HTTP Basic auth against those values. If either is unset, the admin route returns HTTP 503.
 
 SQLite access uses Node's built-in `node:sqlite` module, so no external SQLite npm package or native build step is required.
 

--- a/web/src/app/admin/feeds/actions.ts
+++ b/web/src/app/admin/feeds/actions.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { loadAppConfig } from "../../../server/config";
+import {
+  addRssFeed,
+  restoreRssFeed,
+  setRssFeedEnabled,
+  softDeleteRssFeed,
+  withWritableFetchlinksDatabase,
+} from "../../../server/feeds";
+
+const ADMIN_PATH = "/admin/feeds";
+
+function parseFeedId(value: FormDataEntryValue | null): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error("Invalid feed id.");
+  }
+  return parsed;
+}
+
+export async function addFeedAction(formData: FormData): Promise<void> {
+  const url = String(formData.get("feed_url") ?? "");
+  const config = loadAppConfig(process.env);
+  withWritableFetchlinksDatabase(config, (db) => addRssFeed(db, url));
+  revalidatePath(ADMIN_PATH);
+}
+
+export async function enableFeedAction(formData: FormData): Promise<void> {
+  const feedId = parseFeedId(formData.get("feed_id"));
+  const config = loadAppConfig(process.env);
+  withWritableFetchlinksDatabase(config, (db) =>
+    setRssFeedEnabled(db, feedId, true),
+  );
+  revalidatePath(ADMIN_PATH);
+}
+
+export async function disableFeedAction(formData: FormData): Promise<void> {
+  const feedId = parseFeedId(formData.get("feed_id"));
+  const config = loadAppConfig(process.env);
+  withWritableFetchlinksDatabase(config, (db) =>
+    setRssFeedEnabled(db, feedId, false),
+  );
+  revalidatePath(ADMIN_PATH);
+}
+
+export async function deleteFeedAction(formData: FormData): Promise<void> {
+  const feedId = parseFeedId(formData.get("feed_id"));
+  const config = loadAppConfig(process.env);
+  withWritableFetchlinksDatabase(config, (db) => softDeleteRssFeed(db, feedId));
+  revalidatePath(ADMIN_PATH);
+}
+
+export async function restoreFeedAction(formData: FormData): Promise<void> {
+  const feedId = parseFeedId(formData.get("feed_id"));
+  const config = loadAppConfig(process.env);
+  withWritableFetchlinksDatabase(config, (db) => restoreRssFeed(db, feedId));
+  revalidatePath(ADMIN_PATH);
+}

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -1,0 +1,257 @@
+import Link from "next/link";
+
+import type { RssFeed, RssFeedStatus } from "../../../models/rss-feeds";
+import {
+  countRssFeedsByStatus,
+  listRssFeeds,
+  withWritableFetchlinksDatabase,
+  type RssFeedCounts,
+} from "../../../server/feeds";
+import { loadAppConfig } from "../../../server/config";
+import {
+  addFeedAction,
+  deleteFeedAction,
+  disableFeedAction,
+  enableFeedAction,
+  restoreFeedAction,
+} from "./actions";
+
+type PageSearchParams = Record<string, string | string[] | undefined>;
+
+type AdminFeedsPageProps = {
+  searchParams?: Promise<PageSearchParams>;
+};
+
+type LoadResult =
+  | { status: "ready"; feeds: RssFeed[]; counts: RssFeedCounts; filters: ActiveFilters }
+  | { status: "error" };
+
+type ActiveFilters = {
+  status: RssFeedStatus | "all";
+  q?: string;
+};
+
+export const dynamic = "force-dynamic";
+
+const STATUS_OPTIONS: { value: ActiveFilters["status"]; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "disabled", label: "Disabled" },
+  { value: "removed", label: "Removed" },
+];
+
+export default async function AdminFeedsPage({
+  searchParams,
+}: AdminFeedsPageProps = {}) {
+  const resolved = await searchParams;
+  const filters = parseFilters(resolved);
+  const result = loadFeeds(filters);
+  return <AdminFeedsView result={result} />;
+}
+
+function loadFeeds(filters: ActiveFilters): LoadResult {
+  try {
+    const config = loadAppConfig(process.env);
+    return withWritableFetchlinksDatabase(config, (db) => ({
+      status: "ready" as const,
+      feeds: listRssFeeds(db, filters),
+      counts: countRssFeedsByStatus(db),
+      filters,
+    }));
+  } catch {
+    return { status: "error" };
+  }
+}
+
+export function AdminFeedsView({ result }: { result: LoadResult }) {
+  if (result.status === "error") {
+    return (
+      <main className="shell">
+        <header className="page-header">
+          <div className="page-title">
+            <p className="eyebrow">Fetchlinks admin</p>
+            <h1>RSS feeds</h1>
+          </div>
+        </header>
+        <section className="state state-error" role="alert">
+          <h2>Feeds are unavailable</h2>
+          <p>The database could not be opened. Check the server configuration.</p>
+        </section>
+      </main>
+    );
+  }
+
+  const { feeds, counts, filters } = result;
+
+  return (
+    <main className="shell">
+      <header className="page-header">
+        <div className="page-title">
+          <p className="eyebrow">
+            <Link href="/">&larr; Fetchlinks</Link> &middot; admin
+          </p>
+          <h1>RSS feeds</h1>
+        </div>
+        <p className="page-summary">
+          <strong>{counts.active.toLocaleString("en-US")}</strong>{" "}
+          <span>active</span>
+          {" / "}
+          <strong>{counts.disabled.toLocaleString("en-US")}</strong>{" "}
+          <span>disabled</span>
+          {" / "}
+          <strong>{counts.removed.toLocaleString("en-US")}</strong>{" "}
+          <span>removed</span>
+        </p>
+      </header>
+
+      <section aria-label="Add feed" className="filter-bar">
+        <form action={addFeedAction} className="filter-bar">
+          <label>
+            <span>Add feed</span>
+            <input
+              name="feed_url"
+              placeholder="https://example.com/feed.xml"
+              required
+              type="url"
+            />
+          </label>
+          <div className="filter-actions">
+            <button type="submit">Add</button>
+          </div>
+        </form>
+      </section>
+
+      <form action="/admin/feeds" aria-label="Filter feeds" className="filter-bar" method="get">
+        <label>
+          <span>Status</span>
+          <select defaultValue={filters.status} name="status">
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span>Search</span>
+          <input
+            defaultValue={filters.q ?? ""}
+            name="q"
+            placeholder="Feed URL substring"
+            type="search"
+          />
+        </label>
+        <div className="filter-actions">
+          <button type="submit">Apply</button>
+          {filters.status !== "all" || filters.q ? (
+            <Link className="clear-filters" href="/admin/feeds">
+              Clear
+            </Link>
+          ) : null}
+        </div>
+      </form>
+
+      {feeds.length === 0 ? (
+        <section className="state">
+          <h2>No feeds</h2>
+          <p>No rows match the current filters.</p>
+        </section>
+      ) : (
+        <section className="post-list" aria-label="RSS feeds">
+          {feeds.map((feed) => (
+            <FeedRow key={feed.id} feed={feed} />
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}
+
+function FeedRow({ feed }: { feed: RssFeed }) {
+  return (
+    <article className="post-item">
+      <header className="post-heading">
+        <div className="post-meta">
+          <a
+            className="post-source"
+            href={feed.feedUrl}
+            rel="noreferrer"
+            target="_blank"
+            title={feed.feedUrl}
+          >
+            {feed.feedUrl}
+          </a>
+          <span aria-hidden="true" className="post-meta-separator">/</span>
+          <span>{feed.status}</span>
+          {feed.consecutiveFailures > 0 ? (
+            <>
+              <span aria-hidden="true" className="post-meta-separator">/</span>
+              <span title={feed.lastError ?? ""}>
+                failures={feed.consecutiveFailures}
+              </span>
+            </>
+          ) : null}
+          {feed.lastSuccessAt ? (
+            <>
+              <span aria-hidden="true" className="post-meta-separator">/</span>
+              <span>last success {feed.lastSuccessAt}</span>
+            </>
+          ) : null}
+        </div>
+      </header>
+      {feed.lastError ? <p>{feed.lastError}</p> : null}
+      <nav aria-label="Feed actions" className="post-links">
+        {feed.status === "active" ? (
+          <FeedAction action={disableFeedAction} feedId={feed.id} label="disable" />
+        ) : null}
+        {feed.status === "disabled" ? (
+          <FeedAction action={enableFeedAction} feedId={feed.id} label="enable" />
+        ) : null}
+        {feed.status !== "removed" ? (
+          <FeedAction action={deleteFeedAction} feedId={feed.id} label="remove" />
+        ) : null}
+        {feed.status === "removed" ? (
+          <FeedAction action={restoreFeedAction} feedId={feed.id} label="restore" />
+        ) : null}
+      </nav>
+    </article>
+  );
+}
+
+function FeedAction({
+  action,
+  feedId,
+  label,
+}: {
+  action: (formData: FormData) => Promise<void>;
+  feedId: number;
+  label: string;
+}) {
+  return (
+    <form action={action} className="post-link-action" style={{ display: "inline" }}>
+      <input name="feed_id" type="hidden" value={feedId} />
+      <button type="submit">{label}</button>
+    </form>
+  );
+}
+
+function parseFilters(searchParams: PageSearchParams | undefined): ActiveFilters {
+  const status = pickStatus(getSingleSearchParam(searchParams, "status"));
+  const q = getSingleSearchParam(searchParams, "q")?.trim() || undefined;
+  return { status, q };
+}
+
+function pickStatus(value: string | undefined): ActiveFilters["status"] {
+  if (value === "active" || value === "disabled" || value === "removed") {
+    return value;
+  }
+  return "all";
+}
+
+function getSingleSearchParam(
+  searchParams: PageSearchParams | undefined,
+  name: string,
+): string | undefined {
+  const value = searchParams?.[name];
+  return Array.isArray(value) ? value[0] : value;
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -153,7 +153,9 @@ function PageHeader({
   return (
     <header className="page-header">
       <div className="page-title">
-        <p className="eyebrow">Fetchlinks</p>
+        <p className="eyebrow">
+          Fetchlinks &middot; <Link href="/admin/feeds">admin</Link>
+        </p>
         <h1>Latest posts</h1>
       </div>
       {page ? (

--- a/web/src/models/rss-feeds.ts
+++ b/web/src/models/rss-feeds.ts
@@ -1,0 +1,24 @@
+export type RssFeedStatus = "active" | "disabled" | "removed";
+
+export type RssFeed = {
+  id: number;
+  feedUrl: string;
+  normalizedUrl: string;
+  enabled: boolean;
+  addedAt: string;
+  deletedAt: string | null;
+  lastFetchedAt: string | null;
+  lastSuccessAt: string | null;
+  lastStatus: number | null;
+  lastError: string | null;
+  consecutiveFailures: number;
+  etag: string | null;
+  lastModified: string | null;
+  latestEntryAt: string | null;
+  status: RssFeedStatus;
+};
+
+export type RssFeedListFilters = {
+  status?: RssFeedStatus | "all";
+  q?: string;
+};

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -1,0 +1,69 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export const config = {
+  matcher: ["/admin/:path*"],
+};
+
+const REALM = "Fetchlinks admin";
+
+export function proxy(request: NextRequest): NextResponse {
+  const expectedUser = process.env.FETCHLINKS_ADMIN_USER?.trim();
+  const expectedPass = process.env.FETCHLINKS_ADMIN_PASS;
+
+  if (!expectedUser || !expectedPass) {
+    return new NextResponse(
+      "Admin UI is not configured. Set FETCHLINKS_ADMIN_USER and FETCHLINKS_ADMIN_PASS.",
+      { status: 503, headers: { "Content-Type": "text/plain; charset=utf-8" } },
+    );
+  }
+
+  const header = request.headers.get("authorization") ?? "";
+  if (!header.toLowerCase().startsWith("basic ")) {
+    return unauthorized();
+  }
+
+  let decoded: string;
+  try {
+    decoded = atob(header.slice("basic ".length).trim());
+  } catch {
+    return unauthorized();
+  }
+
+  const separator = decoded.indexOf(":");
+  if (separator < 0) {
+    return unauthorized();
+  }
+
+  const providedUser = decoded.slice(0, separator);
+  const providedPass = decoded.slice(separator + 1);
+
+  if (
+    !safeEqual(providedUser, expectedUser) ||
+    !safeEqual(providedPass, expectedPass)
+  ) {
+    return unauthorized();
+  }
+
+  return NextResponse.next();
+}
+
+function unauthorized(): NextResponse {
+  return new NextResponse("Authentication required.", {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": `Basic realm="${REALM}", charset="UTF-8"`,
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let result = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}

--- a/web/src/server/feeds.test.ts
+++ b/web/src/server/feeds.test.ts
@@ -1,0 +1,320 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import {
+  addRssFeed,
+  countRssFeedsByStatus,
+  listRssFeeds,
+  normalizeFeedUrl,
+  openWritableFetchlinksDatabase,
+  restoreRssFeed,
+  setRssFeedEnabled,
+  softDeleteRssFeed,
+  withWritableFetchlinksDatabase,
+} from "./feeds";
+
+type Fixture = {
+  dbPath: string;
+  cleanup: () => void;
+};
+
+function createFeedsFixture(): Fixture {
+  const directory = mkdtempSync(path.join(tmpdir(), "fetchlinks-feeds-"));
+  const dbPath = path.join(directory, "fetchlinks.db");
+  const database = new DatabaseSync(dbPath);
+  database.exec(`
+    CREATE TABLE rss_feeds (
+      feed_id              INTEGER PRIMARY KEY,
+      feed_url             TEXT NOT NULL,
+      normalized_url       TEXT NOT NULL UNIQUE,
+      enabled              INTEGER NOT NULL DEFAULT 1,
+      added_at             TEXT NOT NULL,
+      deleted_at           TEXT,
+      last_fetched_at      TEXT,
+      last_success_at      TEXT,
+      last_status          INTEGER,
+      last_error           TEXT,
+      consecutive_failures INTEGER NOT NULL DEFAULT 0,
+      etag                 TEXT,
+      last_modified        TEXT,
+      latest_entry_at      TEXT
+    );
+
+    INSERT INTO rss_feeds
+      (feed_id, feed_url, normalized_url, enabled, added_at, deleted_at,
+       last_error, consecutive_failures)
+    VALUES
+      (1, 'https://a.example/feed', 'https://a.example/feed', 1, '2026-01-01 00:00:00', NULL, NULL, 0),
+      (2, 'https://b.example/feed', 'https://b.example/feed', 0, '2026-01-02 00:00:00', NULL, 'HTTP 500', 10),
+      (3, 'https://c.example/feed', 'https://c.example/feed', 0, '2026-01-03 00:00:00', '2026-02-01 00:00:00', NULL, 0);
+  `);
+  database.close();
+  return {
+    dbPath,
+    cleanup: () => rmSync(directory, { force: true, recursive: true }),
+  };
+}
+
+describe("listRssFeeds", () => {
+  it("returns all feeds with computed status by default", () => {
+    const fixture = createFeedsFixture();
+    try {
+      const feeds = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => listRssFeeds(db),
+      );
+      const byUrl = Object.fromEntries(feeds.map((f) => [f.feedUrl, f.status]));
+      expect(byUrl).toEqual({
+        "https://a.example/feed": "active",
+        "https://b.example/feed": "disabled",
+        "https://c.example/feed": "removed",
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("filters by status", () => {
+    const fixture = createFeedsFixture();
+    try {
+      const active = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => listRssFeeds(db, { status: "active" }),
+      );
+      expect(active.map((f) => f.feedUrl)).toEqual(["https://a.example/feed"]);
+
+      const removed = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => listRssFeeds(db, { status: "removed" }),
+      );
+      expect(removed.map((f) => f.feedUrl)).toEqual(["https://c.example/feed"]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("filters by search substring against feed_url and normalized_url", () => {
+    const fixture = createFeedsFixture();
+    try {
+      const matches = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => listRssFeeds(db, { q: "B.EXAMPLE" }),
+      );
+      expect(matches.map((f) => f.feedUrl)).toEqual(["https://b.example/feed"]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("countRssFeedsByStatus", () => {
+  it("returns counts across the three buckets", () => {
+    const fixture = createFeedsFixture();
+    try {
+      const counts = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => countRssFeedsByStatus(db),
+      );
+      expect(counts).toEqual({ active: 1, disabled: 1, removed: 1, total: 3 });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("normalizeFeedUrl", () => {
+  it("rejects non-http(s) and unparseable URLs", () => {
+    expect(normalizeFeedUrl("")).toBe("");
+    expect(normalizeFeedUrl("ftp://example/")).toBe("");
+    expect(normalizeFeedUrl("not a url")).toBe("");
+  });
+
+  it("lowercases the hostname and drops the fragment", () => {
+    expect(normalizeFeedUrl("HTTPS://Example.Com/Feed#anchor")).toBe(
+      "https://example.com/Feed",
+    );
+  });
+});
+
+describe("addRssFeed", () => {
+  it("inserts a new feed and returns the inserted row", () => {
+    const fixture = createFeedsFixture();
+    try {
+      const result = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => addRssFeed(db, "https://new.example/feed"),
+      );
+      expect(result.status).toBe("added");
+      if (result.status === "added") {
+        expect(result.feed.feedUrl).toBe("https://new.example/feed");
+        expect(result.feed.status).toBe("active");
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("returns 'exists' when the normalized URL is already present", () => {
+    const fixture = createFeedsFixture();
+    try {
+      const result = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => addRssFeed(db, "HTTPS://A.example/feed"),
+      );
+      expect(result.status).toBe("exists");
+      if (result.status === "exists") {
+        expect(result.feed.feedUrl).toBe("https://a.example/feed");
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("returns 'invalid' for empty or non-URL input", () => {
+    const fixture = createFeedsFixture();
+    try {
+      const empty = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => addRssFeed(db, "   "),
+      );
+      expect(empty.status).toBe("invalid");
+
+      const bad = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => addRssFeed(db, "ftp://example/"),
+      );
+      expect(bad.status).toBe("invalid");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("setRssFeedEnabled", () => {
+  it("enables a disabled feed and resets the failure counter", () => {
+    const fixture = createFeedsFixture();
+    try {
+      withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => {
+          expect(setRssFeedEnabled(db, 2, true)).toBe(true);
+          const [feed] = listRssFeeds(db, { q: "b.example" });
+          expect(feed.status).toBe("active");
+          expect(feed.consecutiveFailures).toBe(0);
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("does not touch tombstoned rows", () => {
+    const fixture = createFeedsFixture();
+    try {
+      withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => {
+          expect(setRssFeedEnabled(db, 3, true)).toBe(false);
+          const [feed] = listRssFeeds(db, { q: "c.example" });
+          expect(feed.status).toBe("removed");
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("softDeleteRssFeed", () => {
+  it("tombstones a live row", () => {
+    const fixture = createFeedsFixture();
+    try {
+      withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => {
+          expect(softDeleteRssFeed(db, 1)).toBe(true);
+          const [feed] = listRssFeeds(db, { q: "a.example" });
+          expect(feed.status).toBe("removed");
+          expect(feed.deletedAt).toBeTruthy();
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("is a no-op when the row is already tombstoned", () => {
+    const fixture = createFeedsFixture();
+    try {
+      withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => {
+          expect(softDeleteRssFeed(db, 3)).toBe(false);
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("restoreRssFeed", () => {
+  it("restores a tombstoned row and re-enables it", () => {
+    const fixture = createFeedsFixture();
+    try {
+      withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => {
+          expect(restoreRssFeed(db, 3)).toBe(true);
+          const [feed] = listRssFeeds(db, { q: "c.example" });
+          expect(feed.status).toBe("active");
+          expect(feed.deletedAt).toBeNull();
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("does nothing for a live row", () => {
+    const fixture = createFeedsFixture();
+    try {
+      withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => {
+          expect(restoreRssFeed(db, 1)).toBe(false);
+        },
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("openWritableFetchlinksDatabase", () => {
+  it("opens the DB read-write so admin actions can mutate", () => {
+    const fixture = createFeedsFixture();
+    try {
+      const database = openWritableFetchlinksDatabase({
+        fetchlinksDbPath: fixture.dbPath,
+      });
+      try {
+        expect(database.isOpen).toBe(true);
+        database.exec(
+          `INSERT INTO rss_feeds (feed_url, normalized_url, enabled, added_at)
+           VALUES ('https://d.example/feed', 'https://d.example/feed', 1, '2026-03-01 00:00:00')`,
+        );
+        expect(listRssFeeds(database).map((f) => f.feedUrl)).toContain(
+          "https://d.example/feed",
+        );
+      } finally {
+        database.close();
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/web/src/server/feeds.ts
+++ b/web/src/server/feeds.ts
@@ -1,0 +1,296 @@
+import { DatabaseSync } from "node:sqlite";
+
+import type { AppConfig } from "./config";
+import { loadAppConfig } from "./config";
+import type {
+  RssFeed,
+  RssFeedListFilters,
+  RssFeedStatus,
+} from "../models/rss-feeds";
+
+type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
+
+type Env = Partial<Record<string, string | undefined>>;
+
+type RssFeedRow = {
+  id: number;
+  feedUrl: string;
+  normalizedUrl: string;
+  enabled: number;
+  addedAt: string;
+  deletedAt: string | null;
+  lastFetchedAt: string | null;
+  lastSuccessAt: string | null;
+  lastStatus: number | null;
+  lastError: string | null;
+  consecutiveFailures: number;
+  etag: string | null;
+  lastModified: string | null;
+  latestEntryAt: string | null;
+};
+
+export type WritableFetchlinksDatabase = DatabaseSync;
+
+const SELECT_COLUMNS = `
+  feed_id              AS id,
+  feed_url             AS feedUrl,
+  normalized_url       AS normalizedUrl,
+  enabled              AS enabled,
+  added_at             AS addedAt,
+  deleted_at           AS deletedAt,
+  last_fetched_at      AS lastFetchedAt,
+  last_success_at      AS lastSuccessAt,
+  last_status          AS lastStatus,
+  last_error           AS lastError,
+  consecutive_failures AS consecutiveFailures,
+  etag                 AS etag,
+  last_modified        AS lastModified,
+  latest_entry_at      AS latestEntryAt
+`;
+
+export function openWritableFetchlinksDatabase(
+  config: DbConfig,
+): WritableFetchlinksDatabase {
+  const database = new DatabaseSync(config.fetchlinksDbPath, {
+    timeout: 5000,
+  });
+  // Make sure we honour foreign keys and don't block forever on a writer.
+  database.exec("PRAGMA foreign_keys = ON");
+  database.exec("PRAGMA busy_timeout = 5000");
+  return database;
+}
+
+export function openConfiguredWritableFetchlinksDatabase(
+  env: Env = process.env,
+): WritableFetchlinksDatabase {
+  return openWritableFetchlinksDatabase(loadAppConfig(env));
+}
+
+export function withWritableFetchlinksDatabase<T>(
+  config: DbConfig,
+  callback: (database: WritableFetchlinksDatabase) => T,
+): T {
+  const database = openWritableFetchlinksDatabase(config);
+  try {
+    return callback(database);
+  } finally {
+    if (database.isOpen) {
+      database.close();
+    }
+  }
+}
+
+function rowToFeed(row: RssFeedRow): RssFeed {
+  const status: RssFeedStatus = row.deletedAt
+    ? "removed"
+    : row.enabled
+      ? "active"
+      : "disabled";
+  return {
+    id: row.id,
+    feedUrl: row.feedUrl,
+    normalizedUrl: row.normalizedUrl,
+    enabled: row.enabled === 1,
+    addedAt: row.addedAt,
+    deletedAt: row.deletedAt,
+    lastFetchedAt: row.lastFetchedAt,
+    lastSuccessAt: row.lastSuccessAt,
+    lastStatus: row.lastStatus,
+    lastError: row.lastError,
+    consecutiveFailures: row.consecutiveFailures,
+    etag: row.etag,
+    lastModified: row.lastModified,
+    latestEntryAt: row.latestEntryAt,
+    status,
+  };
+}
+
+export function listRssFeeds(
+  database: DatabaseSync,
+  filters: RssFeedListFilters = {},
+): RssFeed[] {
+  const clauses: string[] = [];
+  const params: (string | number)[] = [];
+  const status = filters.status ?? "all";
+
+  if (status === "active") {
+    clauses.push("enabled = 1 AND deleted_at IS NULL");
+  } else if (status === "disabled") {
+    clauses.push("enabled = 0 AND deleted_at IS NULL");
+  } else if (status === "removed") {
+    clauses.push("deleted_at IS NOT NULL");
+  }
+
+  const q = filters.q?.trim();
+  if (q) {
+    const pattern = `%${escapeLikeValue(q.toLowerCase())}%`;
+    clauses.push(
+      "(LOWER(feed_url) LIKE ? ESCAPE '\\' OR LOWER(normalized_url) LIKE ? ESCAPE '\\')",
+    );
+    params.push(pattern, pattern);
+  }
+
+  const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+  const rows = database
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM rss_feeds ${where} ORDER BY enabled DESC, deleted_at IS NOT NULL ASC, feed_url ASC`,
+    )
+    .all(...params) as RssFeedRow[];
+  return rows.map(rowToFeed);
+}
+
+export type RssFeedCounts = {
+  active: number;
+  disabled: number;
+  removed: number;
+  total: number;
+};
+
+export function countRssFeedsByStatus(database: DatabaseSync): RssFeedCounts {
+  const row = database
+    .prepare(
+      `SELECT
+        SUM(CASE WHEN deleted_at IS NULL AND enabled = 1 THEN 1 ELSE 0 END) AS active,
+        SUM(CASE WHEN deleted_at IS NULL AND enabled = 0 THEN 1 ELSE 0 END) AS disabled,
+        SUM(CASE WHEN deleted_at IS NOT NULL THEN 1 ELSE 0 END) AS removed,
+        COUNT(*) AS total
+      FROM rss_feeds`,
+    )
+    .get() as {
+      active: number | null;
+      disabled: number | null;
+      removed: number | null;
+      total: number | null;
+    };
+  return {
+    active: row.active ?? 0,
+    disabled: row.disabled ?? 0,
+    removed: row.removed ?? 0,
+    total: row.total ?? 0,
+  };
+}
+
+export type AddFeedResult =
+  | { status: "added"; feed: RssFeed }
+  | { status: "exists"; feed: RssFeed }
+  | { status: "invalid"; reason: string };
+
+export function normalizeFeedUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return "";
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return "";
+    }
+    url.hash = "";
+    // Lowercase the host. Preserve path/query exactly so different feed
+    // paths on the same host remain distinct.
+    url.hostname = url.hostname.toLowerCase();
+    return url.toString();
+  } catch {
+    return "";
+  }
+}
+
+export function addRssFeed(
+  database: WritableFetchlinksDatabase,
+  rawUrl: string,
+  now: Date = new Date(),
+): AddFeedResult {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    return { status: "invalid", reason: "URL is required." };
+  }
+  const normalized = normalizeFeedUrl(trimmed);
+  if (!normalized) {
+    return {
+      status: "invalid",
+      reason: "URL must be an absolute http(s) URL.",
+    };
+  }
+
+  const existing = database
+    .prepare(`SELECT ${SELECT_COLUMNS} FROM rss_feeds WHERE normalized_url = ?`)
+    .get(normalized) as RssFeedRow | undefined;
+  if (existing) {
+    return { status: "exists", feed: rowToFeed(existing) };
+  }
+
+  const addedAt = formatTimestamp(now);
+  database
+    .prepare(
+      `INSERT INTO rss_feeds
+        (feed_url, normalized_url, enabled, added_at)
+       VALUES (?, ?, 1, ?)`,
+    )
+    .run(trimmed, normalized, addedAt);
+
+  const inserted = database
+    .prepare(`SELECT ${SELECT_COLUMNS} FROM rss_feeds WHERE normalized_url = ?`)
+    .get(normalized) as RssFeedRow;
+  return { status: "added", feed: rowToFeed(inserted) };
+}
+
+export function setRssFeedEnabled(
+  database: WritableFetchlinksDatabase,
+  feedId: number,
+  enabled: boolean,
+): boolean {
+  const result = database
+    .prepare(
+      `UPDATE rss_feeds
+       SET enabled = ?,
+           consecutive_failures = CASE WHEN ? = 1 THEN 0 ELSE consecutive_failures END
+       WHERE feed_id = ?
+         AND deleted_at IS NULL`,
+    )
+    .run(enabled ? 1 : 0, enabled ? 1 : 0, feedId);
+  return Number(result.changes) > 0;
+}
+
+export function softDeleteRssFeed(
+  database: WritableFetchlinksDatabase,
+  feedId: number,
+  now: Date = new Date(),
+): boolean {
+  const result = database
+    .prepare(
+      `UPDATE rss_feeds
+       SET deleted_at = ?, enabled = 0
+       WHERE feed_id = ? AND deleted_at IS NULL`,
+    )
+    .run(formatTimestamp(now), feedId);
+  return Number(result.changes) > 0;
+}
+
+export function restoreRssFeed(
+  database: WritableFetchlinksDatabase,
+  feedId: number,
+): boolean {
+  const result = database
+    .prepare(
+      `UPDATE rss_feeds
+       SET deleted_at = NULL,
+           enabled = 1,
+           consecutive_failures = 0
+       WHERE feed_id = ? AND deleted_at IS NOT NULL`,
+    )
+    .run(feedId);
+  return Number(result.changes) > 0;
+}
+
+function formatTimestamp(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ` +
+    `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`
+  );
+}
+
+function escapeLikeValue(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
+}


### PR DESCRIPTION
Adds a /admin/feeds Next.js admin UI for managing the rss_feeds table, gated by HTTP Basic auth.

## What

- **/admin/feeds** server-rendered page: list/filter feeds by status (active/disabled/removed) and search by URL substring; per-row enable/disable/remove/restore via Next.js server actions; single-URL add form (INSERT OR IGNORE, no network validation).
- **HTTP Basic auth** on /admin/* via src/proxy.ts (Next 16 proxy convention) using FETCHLINKS_ADMIN_USER / FETCHLINKS_ADMIN_PASS env vars. 503 when either is unset; constant-time credential compare.
- **src/server/feeds.ts**: writable DatabaseSync opener, listRssFeeds, countRssFeedsByStatus, addRssFeed (normalize + dedup), setRssFeedEnabled, softDeleteRssFeed, restoreRssFeed. Types in src/models/rss-feeds.ts.
- Home page eyebrow now links to /admin/feeds.
- deploy/systemd/fetchlinks-web.env.example and web/README.md document FETCHLINKS_ADMIN_USER / FETCHLINKS_ADMIN_PASS.

## Validation

- 16 new vitest cases covering CRUD, status classification, and the writable DB opener.
- Full web suite: 46 passing.
- `npm run validate` (lint + typecheck + test + build) clean.
- Live smoke test against `next start`: unauthenticated /admin/feeds returns 401 with WWW-Authenticate; with -u admin:secret returns 200 and renders the page.

Completes item 2b of the RSS-in-DB plan.