### PR TITLE
deploy: split TLS/nginx provisioning into tls.sh

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,6 +8,7 @@ Ubuntu 24.04 VM.
 ```
 deploy/
 ├── bootstrap.sh                       one-shot installer / updater (run on VM)
+├── tls.sh                             nginx + Let's Encrypt provisioner (run after bootstrap)
 ├── config/
 │   ├── fetchlinks.toml                production ingest config (paths, ingest, sources)
 │   └── rss_feeds.txt                  seed RSS feed list (one URL per line, used only on first install)
@@ -34,13 +35,11 @@ deploy/
     ```bash
     sudo apt-get update && sudo apt-get install -y git
     sudo git clone https://github.com/poptart-sommelier/fetchlinks.git /opt/fetchlinks
-    sudo FETCHLINKS_DOMAIN=fetchlinks.example.com \
-         FETCHLINKS_EMAIL=you@example.com \
-         /opt/fetchlinks/deploy/bootstrap.sh
+    sudo /opt/fetchlinks/deploy/bootstrap.sh
     ```
 
-    Omit `FETCHLINKS_DOMAIN`/`FETCHLINKS_EMAIL` if you don't want nginx + TLS
-    on this run; you can re-run the script later with them set.
+    `bootstrap.sh` installs the app, services, and firewall rules. It does
+    **not** touch nginx or TLS — see step 7 for that.
 
 4. Drop your API credential files into `/etc/fetchlinks/credentials/` and
    enable the matching sources in `/etc/fetchlinks/fetchlinks.toml`:
@@ -85,6 +84,18 @@ deploy/
     sudo systemctl start fetchlinks-ingest.service
     sudo journalctl -u fetchlinks-ingest.service -n 50 --no-pager
     ```
+
+7. (Optional) point a DNS record at the VM, then provision nginx + Let's
+   Encrypt TLS with the dedicated script:
+
+    ```bash
+    sudo FETCHLINKS_DOMAIN=fetchlinks.example.com \
+         FETCHLINKS_EMAIL=you@example.com \
+         /opt/fetchlinks/deploy/tls.sh
+    ```
+
+    `tls.sh` is idempotent — re-run it to rotate cert metadata or after
+    changing the domain. Renewals happen automatically via `certbot.timer`.
 
 ## Updating an existing VM
 

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -10,9 +10,10 @@
 # Re-running this script later is safe; it acts as the upgrade path
 # (pulls latest from git, rebuilds web, restarts services).
 #
+# Public TLS / nginx is provisioned by a separate script, deploy/tls.sh.
+# Run it once you have a DNS record pointing at this VM.
+#
 # Optional environment variables:
-#   FETCHLINKS_DOMAIN   FQDN for the public site (enables nginx + TLS)
-#   FETCHLINKS_EMAIL    contact email for certbot
 #   FETCHLINKS_REPO_URL git URL to clone/pull (default: poptart-sommelier/fetchlinks)
 #   FETCHLINKS_REPO_REF branch/tag to deploy   (default: master)
 
@@ -32,8 +33,6 @@ PYTHON_BIN="/usr/bin/python3.12"
 
 REPO_URL="${FETCHLINKS_REPO_URL:-https://github.com/poptart-sommelier/fetchlinks.git}"
 REPO_REF="${FETCHLINKS_REPO_REF:-master}"
-DOMAIN="${FETCHLINKS_DOMAIN:-}"
-EMAIL="${FETCHLINKS_EMAIL:-}"
 
 log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
 warn() { printf '\n\033[1;33m!!\033[0m %s\n' "$*" >&2; }
@@ -57,8 +56,7 @@ apt-get update -y
 apt-get install -y \
     git curl ca-certificates sqlite3 ufw unattended-upgrades \
     python3.12 python3.12-venv python3.12-dev \
-    build-essential libffi-dev libssl-dev \
-    nginx
+    build-essential libffi-dev libssl-dev
 
 # NodeSource for current Node major
 if ! command -v node >/dev/null || [[ "$(node -v 2>/dev/null)" != v${NODE_MAJOR}.* ]]; then
@@ -180,31 +178,7 @@ sudo -u "${APP_USER}" "${VENV_DIR}/bin/python" \
     --seed-if-empty "${ETC_DIR}/rss_feeds.txt" || \
     warn "rss_feeds seed step reported a failure; check the output above."
 
-# ---- nginx + tls (optional) -------------------------------------------------
-
-if [[ -n "${DOMAIN}" ]]; then
-    log "Installing nginx site for ${DOMAIN}"
-    apt-get install -y python3-certbot-nginx
-    sed "s/fetchlinks.example.com/${DOMAIN}/g" \
-        "${APP_DIR}/deploy/nginx/fetchlinks-web.conf.example" \
-        > "/etc/nginx/sites-available/fetchlinks-web.conf"
-    ln -sf /etc/nginx/sites-available/fetchlinks-web.conf \
-           /etc/nginx/sites-enabled/fetchlinks-web.conf
-    rm -f /etc/nginx/sites-enabled/default
-    nginx -t
-    systemctl reload nginx
-
-    if [[ -n "${EMAIL}" ]]; then
-        log "Requesting certificate via certbot"
-        certbot --nginx --non-interactive --agree-tos \
-            -m "${EMAIL}" -d "${DOMAIN}" --redirect || \
-            warn "certbot failed; you can re-run it manually."
-    else
-        warn "FETCHLINKS_EMAIL not set; skipping certbot. Run it manually when ready."
-    fi
-else
-    warn "FETCHLINKS_DOMAIN not set; nginx site not installed."
-fi
+# nginx + TLS are provisioned separately by deploy/tls.sh.
 
 # ---- final summary ----------------------------------------------------------
 
@@ -232,5 +206,9 @@ Manual steps still required:
   5. Trigger an ingest run to verify:
        sudo systemctl start fetchlinks-ingest.service
        sudo journalctl -u fetchlinks-ingest.service -n 50 --no-pager
+  6. (Optional) provision nginx + TLS once DNS points at this VM:
+       sudo FETCHLINKS_DOMAIN=fetchlinks.example.com \
+            FETCHLINKS_EMAIL=you@example.com \
+            ${APP_DIR}/deploy/tls.sh
 ------------------------------------------------------------
 EOF

--- a/deploy/tls.sh
+++ b/deploy/tls.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Fetchlinks TLS / nginx provisioner.
+#
+# Installs nginx, drops in the fetchlinks-web reverse-proxy site for the
+# given domain, and obtains a Let's Encrypt certificate via certbot.
+#
+# Decoupled from bootstrap.sh so you can:
+#   * stand the box up first and add TLS later, or
+#   * re-run only the TLS step when changing domain / rotating cert.
+#
+# Run on the VM, as root, AFTER bootstrap.sh has succeeded at least once.
+#
+# Usage:
+#   sudo FETCHLINKS_DOMAIN=fetchlinks.example.com \
+#        FETCHLINKS_EMAIL=you@example.com \
+#        /opt/fetchlinks/deploy/tls.sh
+#
+# Or positionally:
+#   sudo /opt/fetchlinks/deploy/tls.sh fetchlinks.example.com you@example.com
+#
+# Re-running is safe; certbot will renew rather than re-issue when the cert
+# is still valid.
+
+set -euo pipefail
+
+APP_DIR="/opt/fetchlinks"
+SITE_TEMPLATE="${APP_DIR}/deploy/nginx/fetchlinks-web.conf.example"
+SITE_AVAILABLE="/etc/nginx/sites-available/fetchlinks-web.conf"
+SITE_ENABLED="/etc/nginx/sites-enabled/fetchlinks-web.conf"
+
+DOMAIN="${FETCHLINKS_DOMAIN:-${1:-}}"
+EMAIL="${FETCHLINKS_EMAIL:-${2:-}}"
+
+log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\n\033[1;33m!!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\n\033[1;31m!!\033[0m %s\n' "$*" >&2; exit 1; }
+
+if [[ $EUID -ne 0 ]]; then
+    die "Run as root (sudo $0)."
+fi
+
+if [[ -z "${DOMAIN}" ]]; then
+    die "FETCHLINKS_DOMAIN is required (env var or first positional arg)."
+fi
+if [[ -z "${EMAIL}" ]]; then
+    die "FETCHLINKS_EMAIL is required (env var or second positional arg)."
+fi
+
+if [[ ! -f "${SITE_TEMPLATE}" ]]; then
+    die "Missing nginx site template at ${SITE_TEMPLATE}. Run bootstrap.sh first."
+fi
+
+if ! systemctl is-active --quiet fetchlinks-web.service; then
+    warn "fetchlinks-web.service is not active; nginx will proxy to a down upstream."
+fi
+
+# ---- packages ---------------------------------------------------------------
+
+log "Installing nginx and certbot"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y nginx python3-certbot-nginx
+
+# ---- nginx site -------------------------------------------------------------
+
+log "Rendering nginx site for ${DOMAIN}"
+sed "s/fetchlinks.example.com/${DOMAIN}/g" "${SITE_TEMPLATE}" > "${SITE_AVAILABLE}"
+ln -sf "${SITE_AVAILABLE}" "${SITE_ENABLED}"
+rm -f /etc/nginx/sites-enabled/default
+nginx -t
+systemctl enable --now nginx
+systemctl reload nginx
+
+# ---- certbot ----------------------------------------------------------------
+
+log "Requesting / renewing certificate for ${DOMAIN}"
+certbot --nginx --non-interactive --agree-tos \
+    -m "${EMAIL}" -d "${DOMAIN}" --redirect
+
+# certbot installs its own systemd timer (certbot.timer) on Ubuntu; make sure
+# it's enabled so renewals happen unattended.
+if systemctl list-unit-files certbot.timer >/dev/null 2>&1; then
+    systemctl enable --now certbot.timer
+fi
+
+log "Done. nginx + TLS configured for https://${DOMAIN}"


### PR DESCRIPTION
Pulls the nginx + Let's Encrypt provisioning out of bootstrap.sh into a dedicated, idempotent deploy/tls.sh so the two concerns can be re-run independently.

- bootstrap.sh: app + services + firewall only. No nginx, no certbot, no DOMAIN/EMAIL env vars.
- tls.sh: nginx + certbot. Takes FETCHLINKS_DOMAIN and FETCHLINKS_EMAIL (env or positional). Refuses to run before bootstrap.sh. Enables certbot.timer for unattended renewals.
- deploy/README.md updated; install flow is now bootstrap then (optional) tls.

bash -n clean on both scripts.