### PR TITLE
docs: clarify dev venv location and rss_feeds seed step

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ creating and updating the database; the web app opens it read-only via the
 
 ## Quick Start
 
-Install and run the ingest app:
+Install and run the ingest app. Create the virtualenv at `.venv` in the
+repo root — that's the path the VS Code workspace (`.vscode/settings.json`,
+`.vscode/tasks.json`) and the production layout (`/opt/fetchlinks/.venv`)
+both expect:
 
 ```bash
-python3 -m venv ../venv
-source ../venv/bin/activate
-cd ingest
-pip install -r requirements.txt
-cd fetchlinks
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r ingest/requirements.txt
+cd ingest/fetchlinks
 python3 fetch_links.py
 ```
 

--- a/ingest/SETUP.md
+++ b/ingest/SETUP.md
@@ -4,18 +4,20 @@ These instructions configure and run the Fetchlinks ingest app on Linux.
 
 ## 1) Create and activate virtual environment
 
-From the monorepo root:
+From the monorepo root. The venv MUST live at `.venv` in the repo root
+(not a sibling `../venv`): VS Code (`.vscode/settings.json`,
+`.vscode/tasks.json`) and the production install at `/opt/fetchlinks/.venv`
+both assume this path. `.venv/` is already in `.gitignore`.
 
 ```bash
-python3 -m venv ../venv
-source ../venv/bin/activate
-cd ingest
+python3 -m venv .venv
+source .venv/bin/activate
 ```
 
 ## 2) Install dependencies
 
 ```bash
-pip install -r requirements.txt
+pip install -r ingest/requirements.txt
 ```
 
 ## 3) Configure credentials
@@ -154,7 +156,25 @@ A daily snapshot of the table is written by `export_rss_feeds.py` to
 disabled feeds with their failure reason, commented tombstoned feeds).
 The snapshot is for backup/diffing only — do not hand-edit it.
 
-## 5) Run the backend
+## 5) Seed the rss_feeds table (first run only)
+
+`fetch_links.py` does **not** read `rss_feeds.txt` directly — RSS feeds live
+in the `rss_feeds` SQLite table, and `[sources.rss].seed_file` in the TOML
+is only consumed by `rss_feed_import.py --seed-if-empty`. If you skip this
+step, ingest will still run, but RSS will contribute zero posts because the
+table is empty. On production this is run once by `deploy/bootstrap.sh`; in
+dev you do it by hand:
+
+```bash
+cd fetchlinks
+python3 rss_feed_import.py --seed-if-empty data/config/rss_feeds.txt
+```
+
+The command is a no-op once the table has any rows, so it's safe to re-run.
+See section 4's "RSS feeds" subsection for the other `rss_feed_import.py`
+workflows (validated add / dry-run / pruned import).
+
+## 6) Run the backend
 
 ```bash
 cd fetchlinks
@@ -167,7 +187,7 @@ file, pass `--config /path/to/fetchlinks.toml`.
 On first run, the backend initializes the SQLite database automatically if it
 does not exist.
 
-## 6) Validate output
+## 7) Validate output
 
 - Database location is controlled by `[paths].db` in `fetchlinks.toml`.
 - Logs are written to `[paths].log_file` at `[paths].log_level`.


### PR DESCRIPTION
## What

Two doc-only fixes uncovered while bootstrapping the project on a fresh dev VM.

### 1. Align dev venv location on `.venv` in the repo root

Previously `README.md` and `ingest/SETUP.md` told readers to create the venv as a sibling (`python3 -m venv ../venv`), but every other piece of the project assumes `.venv` inside the workspace:

- `.vscode/settings.json` sets `python.defaultInterpreterPath` to `${workspaceFolder}/.venv/bin/python`.
- Every Python entry in `.vscode/tasks.json` and `.vscode/launch.json` uses the same path.
- Production (`deploy/bootstrap.sh`, `deploy/README.md`, systemd units) uses `/opt/fetchlinks/.venv` — i.e. `.venv` inside the checkout.

`.venv/` is already gitignored, so following the new instructions doesn't leak anything into commits. Dev now matches prod.

### 2. Document the rss_feeds seed step

`fetch_links.py` does not read `rss_feeds.txt` directly — RSS feeds live in the `rss_feeds` SQLite table, and `[sources.rss].seed_file` in the TOML is only consumed by `rss_feed_import.py --seed-if-empty`. On production this is done once by `deploy/bootstrap.sh`; on a dev box this step was previously undocumented, so first-run ingest would silently return zero RSS posts.

Added an explicit numbered step in `ingest/SETUP.md` between 'Configure runtime' and 'Run the backend' that calls this out and gives the exact one-liner. Renumbered the following steps.

## Why

Caught both gaps doing a from-scratch dev environment setup. PLAN.md item #1 of the roadmap is the cold-start bootstrap drill on a fresh prod VM — same spirit, dev edition.

## Risk

Docs only. No code or config changes.