### PR TITLE
Admin UI refresh

### DIFF
--- a/web/src/app/admin/feeds/actions.ts
+++ b/web/src/app/admin/feeds/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
 
 import { loadAppConfig } from "../../../server/config";
 import {
@@ -23,8 +24,24 @@ function parseFeedId(value: FormDataEntryValue | null): number {
 export async function addFeedAction(formData: FormData): Promise<void> {
   const url = String(formData.get("feed_url") ?? "");
   const config = loadAppConfig(process.env);
-  withWritableFetchlinksDatabase(config, (db) => addRssFeed(db, url));
+  const result = withWritableFetchlinksDatabase(config, (db) =>
+    addRssFeed(db, url),
+  );
   revalidatePath(ADMIN_PATH);
+
+  const params = new URLSearchParams();
+  if (result.status === "added") {
+    params.set("added", "ok");
+    params.set("url", result.feed.feedUrl);
+  } else if (result.status === "exists") {
+    params.set("added", "exists");
+    params.set("url", result.feed.feedUrl);
+  } else {
+    params.set("added", "invalid");
+    params.set("reason", result.reason);
+    if (url.trim()) params.set("url", url.trim());
+  }
+  redirect(`${ADMIN_PATH}?${params.toString()}`);
 }
 
 export async function deleteFeedAction(formData: FormData): Promise<void> {

--- a/web/src/app/admin/feeds/actions.ts
+++ b/web/src/app/admin/feeds/actions.ts
@@ -6,7 +6,6 @@ import { loadAppConfig } from "../../../server/config";
 import {
   addRssFeed,
   restoreRssFeed,
-  setRssFeedEnabled,
   softDeleteRssFeed,
   withWritableFetchlinksDatabase,
 } from "../../../server/feeds";
@@ -25,24 +24,6 @@ export async function addFeedAction(formData: FormData): Promise<void> {
   const url = String(formData.get("feed_url") ?? "");
   const config = loadAppConfig(process.env);
   withWritableFetchlinksDatabase(config, (db) => addRssFeed(db, url));
-  revalidatePath(ADMIN_PATH);
-}
-
-export async function enableFeedAction(formData: FormData): Promise<void> {
-  const feedId = parseFeedId(formData.get("feed_id"));
-  const config = loadAppConfig(process.env);
-  withWritableFetchlinksDatabase(config, (db) =>
-    setRssFeedEnabled(db, feedId, true),
-  );
-  revalidatePath(ADMIN_PATH);
-}
-
-export async function disableFeedAction(formData: FormData): Promise<void> {
-  const feedId = parseFeedId(formData.get("feed_id"));
-  const config = loadAppConfig(process.env);
-  withWritableFetchlinksDatabase(config, (db) =>
-    setRssFeedEnabled(db, feedId, false),
-  );
   revalidatePath(ADMIN_PATH);
 }
 

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -35,13 +35,6 @@ type ActiveFilters = {
 
 export const dynamic = "force-dynamic";
 
-const STATUS_OPTIONS: { value: ActiveFilters["status"]; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "active", label: "Active" },
-  { value: "disabled", label: "Disabled" },
-  { value: "removed", label: "Removed" },
-];
-
 export default async function AdminFeedsPage({
   searchParams,
 }: AdminFeedsPageProps = {}) {
@@ -125,18 +118,8 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
         </button>
       </form>
 
-      <form action="/admin/feeds" aria-label="Filter feeds" className="filter-bar" method="get">
-        <label>
-          <span>Status</span>
-          <select defaultValue={filters.status} name="status">
-            {STATUS_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
+      <form action="/admin/feeds" aria-label="Search feeds" className="search-form" method="get">
+        <label className="search-form-field">
           <span>Search</span>
           <input
             defaultValue={filters.q ?? ""}
@@ -145,14 +128,18 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
             type="search"
           />
         </label>
-        <div className="filter-actions">
-          <button type="submit">Apply</button>
-          {filters.status !== "all" || filters.q || filters.errors ? (
-            <Link className="clear-filters" href="/admin/feeds">
-              Clear
-            </Link>
-          ) : null}
-        </div>
+        {filters.status !== "all" ? (
+          <input name="status" type="hidden" value={filters.status} />
+        ) : null}
+        {filters.errors ? <input name="errors" type="hidden" value="1" /> : null}
+        <button className="search-form-btn" type="submit">
+          Search
+        </button>
+        {filters.status !== "all" || filters.q || filters.errors ? (
+          <Link className="clear-filters" href="/admin/feeds">
+            Clear
+          </Link>
+        ) : null}
       </form>
 
       {feeds.length === 0 ? (

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -162,7 +162,6 @@ function FeedRow({ feed }: { feed: RssFeed }) {
   return (
     <article className="post-item feed-row">
       <header className="feed-row-header">
-        <FeedHealthIcon status={feed.lastStatus} />
         <a
           className="post-source feed-row-url"
           href={feed.feedUrl}
@@ -172,7 +171,7 @@ function FeedRow({ feed }: { feed: RssFeed }) {
         >
           <FeedUrlLabel url={feed.feedUrl} />
         </a>
-        <FeedStatusPill status={feed.status} />
+        <FeedStatusPill feed={feed} />
       </header>
       <FeedStats feed={feed} />
       {feed.lastError ? (
@@ -260,16 +259,30 @@ function FeedStats({ feed }: { feed: RssFeed }) {
   return <div className="feed-stats">{items}</div>;
 }
 
-const STATUS_PILL_LABEL: Record<RssFeedStatus, string> = {
-  active: "Active",
-  disabled: "Disabled",
-  removed: "Removed",
+type FeedHealth = "healthy" | "unhealthy" | "removed";
+
+const HEALTH_PILL_LABEL: Record<FeedHealth, string> = {
+  healthy: "Feed: healthy",
+  unhealthy: "Feed: unhealthy",
+  removed: "Feed: removed",
 };
 
-export function FeedStatusPill({ status }: { status: RssFeedStatus }) {
+function getFeedHealth(feed: RssFeed): FeedHealth {
+  if (feed.status === "removed") return "removed";
+  if (feed.consecutiveFailures > 0) return "unhealthy";
+  if (feed.lastStatus !== null && feed.lastStatus >= 400) return "unhealthy";
+  return "healthy";
+}
+
+export function FeedStatusPill({ feed }: { feed: RssFeed }) {
+  const health = getFeedHealth(feed);
+  const title =
+    health === "unhealthy" && feed.lastStatus !== null
+      ? `HTTP ${feed.lastStatus}`
+      : undefined;
   return (
-    <span className={`status-pill status-pill-${status}`}>
-      {STATUS_PILL_LABEL[status]}
+    <span className={`status-pill status-pill-${health}`} title={title}>
+      {HEALTH_PILL_LABEL[health]}
     </span>
   );
 }
@@ -309,30 +322,6 @@ function FeedUrlLabel({ url }: { url: string }) {
       <span className="feed-url-host">{host}</span>
       {tail ? <span className="feed-url-path">{tail}</span> : null}
     </>
-  );
-}
-
-function FeedHealthIcon({ status }: { status: number | null }) {
-  if (status === null) {
-    return (
-      <span
-        aria-label="Not fetched yet"
-        className="feed-health-icon feed-health-icon-unknown"
-        title="Not fetched yet"
-      >
-        &middot;
-      </span>
-    );
-  }
-  const ok = status < 400;
-  return (
-    <span
-      aria-label={ok ? `HTTP ${status} OK` : `HTTP ${status} error`}
-      className={`feed-health-icon feed-health-icon-${ok ? "ok" : "err"}`}
-      title={`HTTP ${status}`}
-    >
-      {ok ? "\u2713" : "\u2715"}
-    </span>
   );
 }
 

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -183,6 +183,8 @@ function FeedRow({ feed }: { feed: RssFeed }) {
               action={deleteFeedAction}
               feedId={feed.id}
               label="Remove feed"
+              iconOnly
+              icon={<TrashIcon />}
             />
           ) : null}
           {feed.status === "removed" ? (
@@ -355,18 +357,52 @@ function FeedAction({
   action,
   feedId,
   label,
+  icon,
+  iconOnly = false,
 }: {
   action: (formData: FormData) => Promise<void>;
   feedId: number;
   label: string;
+  icon?: ReactNode;
+  iconOnly?: boolean;
 }) {
+  const className = `feed-action-btn${iconOnly ? " feed-action-btn-icon" : ""}`;
   return (
     <form action={action} className="feed-action">
       <input name="feed_id" type="hidden" value={feedId} />
-      <button className="feed-action-btn" type="submit">
-        {label}
+      <button
+        aria-label={iconOnly ? label : undefined}
+        className={className}
+        title={iconOnly ? label : undefined}
+        type="submit"
+      >
+        {icon}
+        {iconOnly ? null : label}
       </button>
     </form>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      focusable="false"
+      height="16"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.75"
+      viewBox="0 0 24 24"
+      width="16"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
   );
 }
 

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -173,19 +173,21 @@ function FeedRow({ feed }: { feed: RssFeed }) {
         </a>
         <FeedStatusPill feed={feed} />
       </header>
-      <FeedStats feed={feed} />
-      <nav aria-label="Feed actions" className="post-links">
-        {feed.status !== "removed" ? (
-          <FeedAction
-            action={deleteFeedAction}
-            feedId={feed.id}
-            label="Remove feed"
-          />
-        ) : null}
-        {feed.status === "removed" ? (
-          <FeedAction action={restoreFeedAction} feedId={feed.id} label="Restore" />
-        ) : null}
-      </nav>
+      <div className="feed-row-footer">
+        <FeedStats feed={feed} />
+        <nav aria-label="Feed actions" className="post-links feed-row-actions">
+          {feed.status !== "removed" ? (
+            <FeedAction
+              action={deleteFeedAction}
+              feedId={feed.id}
+              label="Remove feed"
+            />
+          ) : null}
+          {feed.status === "removed" ? (
+            <FeedAction action={restoreFeedAction} feedId={feed.id} label="Restore" />
+          ) : null}
+        </nav>
+      </div>
     </article>
   );
 }

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -181,7 +181,12 @@ function FeedRow({ feed }: { feed: RssFeed }) {
         <FeedStatusPill status={feed.status} />
       </header>
       <FeedStats feed={feed} />
-      {feed.lastError ? <p>{feed.lastError}</p> : null}
+      {feed.lastError ? (
+        <p className="feed-error" role="status">
+          <span className="feed-error-label">Last error</span>
+          <span className="feed-error-body">{feed.lastError}</span>
+        </p>
+      ) : null}
       <nav aria-label="Feed actions" className="post-links">
         {feed.status === "active" ? (
           <FeedAction action={disableFeedAction} feedId={feed.id} label="disable" />

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -159,8 +159,10 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
 }
 
 function FeedRow({ feed }: { feed: RssFeed }) {
+  const health = getFeedHealth(feed);
+  const rowClass = `post-item feed-row feed-row-${health}`;
   return (
-    <article className="post-item feed-row">
+    <article className={rowClass}>
       <header className="feed-row-header">
         <a
           className="post-source feed-row-url"
@@ -242,11 +244,27 @@ function FeedStats({ feed }: { feed: RssFeed }) {
     );
   }
 
-  if (feed.consecutiveFailures > 0) {
+  if (feed.consecutiveFailures > 0 || (feed.lastStatus !== null && feed.lastStatus >= 400)) {
+    const failureLabel =
+      feed.consecutiveFailures > 0
+        ? `${feed.consecutiveFailures} consecutive ${
+            feed.consecutiveFailures === 1 ? "failure" : "failures"
+          }`
+        : `HTTP ${feed.lastStatus}`;
+    const tip = buildUnhealthyTip(feed);
     items.push(
-      <span key="fail" className="feed-stat feed-stat-danger">
-        <strong>{feed.consecutiveFailures}</strong>{" "}
-        consecutive {feed.consecutiveFailures === 1 ? "failure" : "failures"}
+      <span
+        key="fail"
+        className="feed-stat feed-stat-danger feed-stat-has-tip"
+        tabIndex={tip ? 0 : undefined}
+        title={tip}
+      >
+        {failureLabel}
+        {tip ? (
+          <span className="feed-stat-tip" role="tooltip">
+            {tip}
+          </span>
+        ) : null}
       </span>,
     );
   }
@@ -259,7 +277,7 @@ type FeedHealth = "healthy" | "unhealthy" | "removed";
 
 const HEALTH_PILL_LABEL: Record<FeedHealth, string | null> = {
   healthy: null,
-  unhealthy: "Unhealthy",
+  unhealthy: null,
   removed: "Removed",
 };
 
@@ -270,7 +288,7 @@ function getFeedHealth(feed: RssFeed): FeedHealth {
   return "healthy";
 }
 
-function buildUnhealthyTitle(feed: RssFeed): string | undefined {
+function buildUnhealthyTip(feed: RssFeed): string | undefined {
   const parts: string[] = [];
   if (feed.lastStatus !== null) parts.push(`HTTP ${feed.lastStatus}`);
   if (feed.consecutiveFailures > 0) {
@@ -288,15 +306,9 @@ export function FeedStatusPill({ feed }: { feed: RssFeed }) {
   const health = getFeedHealth(feed);
   const label = HEALTH_PILL_LABEL[health];
   if (!label) return null;
-  const tip = health === "unhealthy" ? buildUnhealthyTitle(feed) : undefined;
   return (
-    <span
-      className={`status-pill status-pill-${health}${tip ? " status-pill-has-tip" : ""}`}
-      tabIndex={tip ? 0 : undefined}
-      title={tip}
-    >
+    <span className={`status-pill status-pill-${health}`}>
       {label}
-      {tip ? <span className="status-pill-tip" role="tooltip">{tip}</span> : null}
     </span>
   );
 }

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -182,7 +182,7 @@ function FeedRow({ feed }: { feed: RssFeed }) {
             {feed.feedUrl}
           </a>
           <span aria-hidden="true" className="post-meta-separator">/</span>
-          <span>{feed.status}</span>
+          <FeedStatusPill status={feed.status} />
           {feed.consecutiveFailures > 0 ? (
             <>
               <span aria-hidden="true" className="post-meta-separator">/</span>
@@ -215,6 +215,20 @@ function FeedRow({ feed }: { feed: RssFeed }) {
         ) : null}
       </nav>
     </article>
+  );
+}
+
+const STATUS_PILL_LABEL: Record<RssFeedStatus, string> = {
+  active: "Active",
+  disabled: "Disabled",
+  removed: "Removed",
+};
+
+export function FeedStatusPill({ status }: { status: RssFeedStatus }) {
+  return (
+    <span className={`status-pill status-pill-${status}`}>
+      {STATUS_PILL_LABEL[status]}
+    </span>
   );
 }
 

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -174,12 +174,6 @@ function FeedRow({ feed }: { feed: RssFeed }) {
         <FeedStatusPill feed={feed} />
       </header>
       <FeedStats feed={feed} />
-      {feed.lastError ? (
-        <p className="feed-error" role="status">
-          <span className="feed-error-label">Last error</span>
-          <span className="feed-error-body">{feed.lastError}</span>
-        </p>
-      ) : null}
       <nav aria-label="Feed actions" className="post-links">
         {feed.status !== "removed" ? (
           <FeedAction
@@ -261,10 +255,10 @@ function FeedStats({ feed }: { feed: RssFeed }) {
 
 type FeedHealth = "healthy" | "unhealthy" | "removed";
 
-const HEALTH_PILL_LABEL: Record<FeedHealth, string> = {
-  healthy: "Feed: healthy",
-  unhealthy: "Feed: unhealthy",
-  removed: "Feed: removed",
+const HEALTH_PILL_LABEL: Record<FeedHealth, string | null> = {
+  healthy: null,
+  unhealthy: "Unhealthy",
+  removed: "Removed",
 };
 
 function getFeedHealth(feed: RssFeed): FeedHealth {
@@ -274,15 +268,28 @@ function getFeedHealth(feed: RssFeed): FeedHealth {
   return "healthy";
 }
 
+function buildUnhealthyTitle(feed: RssFeed): string | undefined {
+  const parts: string[] = [];
+  if (feed.lastStatus !== null) parts.push(`HTTP ${feed.lastStatus}`);
+  if (feed.consecutiveFailures > 0) {
+    parts.push(
+      `${feed.consecutiveFailures} consecutive ${
+        feed.consecutiveFailures === 1 ? "failure" : "failures"
+      }`,
+    );
+  }
+  if (feed.lastError) parts.push(feed.lastError);
+  return parts.length ? parts.join(" \u2022 ") : undefined;
+}
+
 export function FeedStatusPill({ feed }: { feed: RssFeed }) {
   const health = getFeedHealth(feed);
-  const title =
-    health === "unhealthy" && feed.lastStatus !== null
-      ? `HTTP ${feed.lastStatus}`
-      : undefined;
+  const label = HEALTH_PILL_LABEL[health];
+  if (!label) return null;
+  const title = health === "unhealthy" ? buildUnhealthyTitle(feed) : undefined;
   return (
     <span className={`status-pill status-pill-${health}`} title={title}>
-      {HEALTH_PILL_LABEL[health]}
+      {label}
     </span>
   );
 }

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -162,6 +162,7 @@ function FeedRow({ feed }: { feed: RssFeed }) {
   return (
     <article className="post-item feed-row">
       <header className="feed-row-header">
+        <FeedHealthIcon status={feed.lastStatus} />
         <a
           className="post-source feed-row-url"
           href={feed.feedUrl}
@@ -246,15 +247,6 @@ function FeedStats({ feed }: { feed: RssFeed }) {
     );
   }
 
-  if (feed.lastStatus !== null) {
-    const tone = feed.lastStatus >= 400 ? "danger" : "ok";
-    items.push(
-      <span key="status" className={`feed-stat feed-stat-${tone}`}>
-        HTTP <strong>{feed.lastStatus}</strong>
-      </span>,
-    );
-  }
-
   if (feed.consecutiveFailures > 0) {
     items.push(
       <span key="fail" className="feed-stat feed-stat-danger">
@@ -317,6 +309,30 @@ function FeedUrlLabel({ url }: { url: string }) {
       <span className="feed-url-host">{host}</span>
       {tail ? <span className="feed-url-path">{tail}</span> : null}
     </>
+  );
+}
+
+function FeedHealthIcon({ status }: { status: number | null }) {
+  if (status === null) {
+    return (
+      <span
+        aria-label="Not fetched yet"
+        className="feed-health-icon feed-health-icon-unknown"
+        title="Not fetched yet"
+      >
+        &middot;
+      </span>
+    );
+  }
+  const ok = status < 400;
+  return (
+    <span
+      aria-label={ok ? `HTTP ${status} OK` : `HTTP ${status} error`}
+      className={`feed-health-icon feed-health-icon-${ok ? "ok" : "err"}`}
+      title={`HTTP ${status}`}
+    >
+      {ok ? "\u2713" : "\u2715"}
+    </span>
   );
 }
 

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -208,7 +208,12 @@ function FeedRow({ feed }: { feed: RssFeed }) {
           <FeedAction action={enableFeedAction} feedId={feed.id} label="enable" />
         ) : null}
         {feed.status !== "removed" ? (
-          <FeedAction action={deleteFeedAction} feedId={feed.id} label="remove" />
+          <FeedAction
+            action={deleteFeedAction}
+            feedId={feed.id}
+            label="remove"
+            tone="danger"
+          />
         ) : null}
         {feed.status === "removed" ? (
           <FeedAction action={restoreFeedAction} feedId={feed.id} label="restore" />
@@ -236,15 +241,20 @@ function FeedAction({
   action,
   feedId,
   label,
+  tone = "default",
 }: {
   action: (formData: FormData) => Promise<void>;
   feedId: number;
   label: string;
+  tone?: "default" | "danger";
 }) {
+  const toneClass = tone === "danger" ? " feed-action-btn-danger" : "";
   return (
-    <form action={action} className="post-link-action" style={{ display: "inline" }}>
+    <form action={action} className="feed-action">
       <input name="feed_id" type="hidden" value={feedId} />
-      <button type="submit">{label}</button>
+      <button className={`feed-action-btn${toneClass}`} type="submit">
+        {label}
+      </button>
     </form>
   );
 }

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -104,22 +104,20 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
         </p>
       </header>
 
-      <section aria-label="Add feed" className="filter-bar">
-        <form action={addFeedAction} className="filter-bar">
-          <label>
-            <span>Add feed</span>
-            <input
-              name="feed_url"
-              placeholder="https://example.com/feed.xml"
-              required
-              type="url"
-            />
-          </label>
-          <div className="filter-actions">
-            <button type="submit">Add</button>
-          </div>
-        </form>
-      </section>
+      <form action={addFeedAction} aria-label="Add feed" className="add-form">
+        <label className="add-form-field">
+          <span>Add feed</span>
+          <input
+            name="feed_url"
+            placeholder="https://example.com/feed.xml"
+            required
+            type="url"
+          />
+        </label>
+        <button className="add-form-btn" type="submit">
+          Add feed
+        </button>
+      </form>
 
       <form action="/admin/feeds" aria-label="Filter feeds" className="filter-bar" method="get">
         <label>

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -24,7 +24,13 @@ type AdminFeedsPageProps = {
 };
 
 type LoadResult =
-  | { status: "ready"; feeds: RssFeed[]; counts: RssFeedCounts; filters: ActiveFilters }
+  | {
+      status: "ready";
+      feeds: RssFeed[];
+      counts: RssFeedCounts;
+      filters: ActiveFilters;
+      addFeedback: AddFeedback | null;
+    }
   | { status: "error" };
 
 type ActiveFilters = {
@@ -33,6 +39,11 @@ type ActiveFilters = {
   errors: boolean;
 };
 
+type AddFeedback =
+  | { kind: "ok"; url: string }
+  | { kind: "exists"; url: string }
+  | { kind: "invalid"; reason: string; url?: string };
+
 export const dynamic = "force-dynamic";
 
 export default async function AdminFeedsPage({
@@ -40,11 +51,15 @@ export default async function AdminFeedsPage({
 }: AdminFeedsPageProps = {}) {
   const resolved = await searchParams;
   const filters = parseFilters(resolved);
-  const result = loadFeeds(filters);
+  const addFeedback = parseAddFeedback(resolved);
+  const result = loadFeeds(filters, addFeedback);
   return <AdminFeedsView result={result} />;
 }
 
-function loadFeeds(filters: ActiveFilters): LoadResult {
+function loadFeeds(
+  filters: ActiveFilters,
+  addFeedback: AddFeedback | null,
+): LoadResult {
   try {
     const config = loadAppConfig(process.env);
     return withWritableFetchlinksDatabase(config, (db) => ({
@@ -52,6 +67,7 @@ function loadFeeds(filters: ActiveFilters): LoadResult {
       feeds: listRssFeeds(db, filters),
       counts: countRssFeedsByStatus(db),
       filters,
+      addFeedback,
     }));
   } catch {
     return { status: "error" };
@@ -76,7 +92,7 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
     );
   }
 
-  const { feeds, counts, filters } = result;
+  const { feeds, counts, filters, addFeedback } = result;
 
   return (
     <main className="shell">
@@ -117,6 +133,8 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
           Add feed
         </button>
       </form>
+
+      {addFeedback ? <AddFeedbackBanner feedback={addFeedback} /> : null}
 
       <form action="/admin/feeds" aria-label="Search feeds" className="search-form" method="get">
         <label className="search-form-field">
@@ -411,6 +429,58 @@ function parseFilters(searchParams: PageSearchParams | undefined): ActiveFilters
   const q = getSingleSearchParam(searchParams, "q")?.trim() || undefined;
   const errors = getSingleSearchParam(searchParams, "errors") === "1";
   return { status, q, errors };
+}
+
+function parseAddFeedback(
+  searchParams: PageSearchParams | undefined,
+): AddFeedback | null {
+  const added = getSingleSearchParam(searchParams, "added");
+  const url = getSingleSearchParam(searchParams, "url");
+  if (added === "ok" && url) return { kind: "ok", url };
+  if (added === "exists" && url) return { kind: "exists", url };
+  if (added === "invalid") {
+    const reason =
+      getSingleSearchParam(searchParams, "reason") || "Could not add feed.";
+    return { kind: "invalid", reason, url };
+  }
+  return null;
+}
+
+function AddFeedbackBanner({ feedback }: { feedback: AddFeedback }) {
+  if (feedback.kind === "ok") {
+    return (
+      <p className="add-feedback add-feedback-ok" role="status">
+        <span className="add-feedback-label">Added</span>
+        <span className="add-feedback-body">
+          <code>{feedback.url}</code> is now being fetched.
+        </span>
+      </p>
+    );
+  }
+  if (feedback.kind === "exists") {
+    return (
+      <p className="add-feedback add-feedback-warn" role="status">
+        <span className="add-feedback-label">Already added</span>
+        <span className="add-feedback-body">
+          <code>{feedback.url}</code> is already in the list.
+        </span>
+      </p>
+    );
+  }
+  return (
+    <p className="add-feedback add-feedback-error" role="alert">
+      <span className="add-feedback-label">Not added</span>
+      <span className="add-feedback-body">
+        {feedback.reason}
+        {feedback.url ? (
+          <>
+            {" "}
+            <code>{feedback.url}</code>
+          </>
+        ) : null}
+      </span>
+    </p>
+  );
 }
 
 function pickStatus(value: string | undefined): ActiveFilters["status"] {

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import Link from "next/link";
 
 import type { RssFeed, RssFeedStatus } from "../../../models/rss-feeds";
@@ -8,6 +10,7 @@ import {
   type RssFeedCounts,
 } from "../../../server/feeds";
 import { loadAppConfig } from "../../../server/config";
+import { formatRelative } from "../../../lib/format-relative";
 import {
   addFeedAction,
   deleteFeedAction,
@@ -164,36 +167,20 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
 
 function FeedRow({ feed }: { feed: RssFeed }) {
   return (
-    <article className="post-item">
-      <header className="post-heading">
-        <div className="post-meta">
-          <a
-            className="post-source"
-            href={feed.feedUrl}
-            rel="noreferrer"
-            target="_blank"
-            title={feed.feedUrl}
-          >
-            {feed.feedUrl}
-          </a>
-          <span aria-hidden="true" className="post-meta-separator">/</span>
-          <FeedStatusPill status={feed.status} />
-          {feed.consecutiveFailures > 0 ? (
-            <>
-              <span aria-hidden="true" className="post-meta-separator">/</span>
-              <span title={feed.lastError ?? ""}>
-                failures={feed.consecutiveFailures}
-              </span>
-            </>
-          ) : null}
-          {feed.lastSuccessAt ? (
-            <>
-              <span aria-hidden="true" className="post-meta-separator">/</span>
-              <span>last success {feed.lastSuccessAt}</span>
-            </>
-          ) : null}
-        </div>
+    <article className="post-item feed-row">
+      <header className="feed-row-header">
+        <a
+          className="post-source feed-row-url"
+          href={feed.feedUrl}
+          rel="noreferrer"
+          target="_blank"
+          title={feed.feedUrl}
+        >
+          {feed.feedUrl}
+        </a>
+        <FeedStatusPill status={feed.status} />
       </header>
+      <FeedStats feed={feed} />
       {feed.lastError ? <p>{feed.lastError}</p> : null}
       <nav aria-label="Feed actions" className="post-links">
         {feed.status === "active" ? (
@@ -216,6 +203,78 @@ function FeedRow({ feed }: { feed: RssFeed }) {
       </nav>
     </article>
   );
+}
+
+function FeedStats({ feed }: { feed: RssFeed }) {
+  const items: ReactNode[] = [];
+
+  const fetchedLabel = formatRelative(feed.lastFetchedAt);
+  if (fetchedLabel) {
+    items.push(
+      <span
+        key="fetched"
+        className="feed-stat"
+        title={feed.lastFetchedAt ?? undefined}
+      >
+        Fetched <strong>{fetchedLabel}</strong>
+      </span>,
+    );
+  }
+
+  // Only surface last-success when it differs from last-fetched
+  // (i.e., the most recent attempt failed).
+  const fetchedAndSuccessDiffer =
+    feed.lastSuccessAt != null &&
+    feed.lastFetchedAt != null &&
+    feed.lastSuccessAt !== feed.lastFetchedAt;
+  const successLabel = fetchedAndSuccessDiffer
+    ? formatRelative(feed.lastSuccessAt)
+    : null;
+  if (successLabel) {
+    items.push(
+      <span
+        key="success"
+        className="feed-stat"
+        title={feed.lastSuccessAt ?? undefined}
+      >
+        Last ok <strong>{successLabel}</strong>
+      </span>,
+    );
+  }
+
+  const entryLabel = formatRelative(feed.latestEntryAt);
+  if (entryLabel) {
+    items.push(
+      <span
+        key="entry"
+        className="feed-stat"
+        title={feed.latestEntryAt ?? undefined}
+      >
+        Newest entry <strong>{entryLabel}</strong>
+      </span>,
+    );
+  }
+
+  if (feed.lastStatus !== null) {
+    const tone = feed.lastStatus >= 400 ? "danger" : "ok";
+    items.push(
+      <span key="status" className={`feed-stat feed-stat-${tone}`}>
+        HTTP <strong>{feed.lastStatus}</strong>
+      </span>,
+    );
+  }
+
+  if (feed.consecutiveFailures > 0) {
+    items.push(
+      <span key="fail" className="feed-stat feed-stat-danger">
+        <strong>{feed.consecutiveFailures}</strong>{" "}
+        consecutive {feed.consecutiveFailures === 1 ? "failure" : "failures"}
+      </span>,
+    );
+  }
+
+  if (items.length === 0) return null;
+  return <div className="feed-stats">{items}</div>;
 }
 
 const STATUS_PILL_LABEL: Record<RssFeedStatus, string> = {

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -14,8 +14,6 @@ import { formatRelative } from "../../../lib/format-relative";
 import {
   addFeedAction,
   deleteFeedAction,
-  disableFeedAction,
-  enableFeedAction,
   restoreFeedAction,
 } from "./actions";
 
@@ -188,12 +186,6 @@ function FeedRow({ feed }: { feed: RssFeed }) {
         </p>
       ) : null}
       <nav aria-label="Feed actions" className="post-links">
-        {feed.status === "active" ? (
-          <FeedAction action={disableFeedAction} feedId={feed.id} label="disable" />
-        ) : null}
-        {feed.status === "disabled" ? (
-          <FeedAction action={enableFeedAction} feedId={feed.id} label="enable" />
-        ) : null}
         {feed.status !== "removed" ? (
           <FeedAction
             action={deleteFeedAction}

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -288,10 +288,15 @@ export function FeedStatusPill({ feed }: { feed: RssFeed }) {
   const health = getFeedHealth(feed);
   const label = HEALTH_PILL_LABEL[health];
   if (!label) return null;
-  const title = health === "unhealthy" ? buildUnhealthyTitle(feed) : undefined;
+  const tip = health === "unhealthy" ? buildUnhealthyTitle(feed) : undefined;
   return (
-    <span className={`status-pill status-pill-${health}`} title={title}>
+    <span
+      className={`status-pill status-pill-${health}${tip ? " status-pill-has-tip" : ""}`}
+      tabIndex={tip ? 0 : undefined}
+      title={tip}
+    >
       {label}
+      {tip ? <span className="status-pill-tip" role="tooltip">{tip}</span> : null}
     </span>
   );
 }

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -93,14 +93,11 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
           <h1>RSS feeds</h1>
         </div>
         <p className="page-summary">
-          <strong>{counts.active.toLocaleString("en-US")}</strong>{" "}
-          <span>active</span>
+          <CountLink count={counts.active} label="active" status="active" />
           {" / "}
-          <strong>{counts.disabled.toLocaleString("en-US")}</strong>{" "}
-          <span>disabled</span>
+          <CountLink count={counts.disabled} label="disabled" status="disabled" />
           {" / "}
-          <strong>{counts.removed.toLocaleString("en-US")}</strong>{" "}
-          <span>removed</span>
+          <CountLink count={counts.removed} label="removed" status="removed" />
         </p>
       </header>
 
@@ -232,6 +229,22 @@ export function FeedStatusPill({ status }: { status: RssFeedStatus }) {
     <span className={`status-pill status-pill-${status}`}>
       {STATUS_PILL_LABEL[status]}
     </span>
+  );
+}
+
+function CountLink({
+  count,
+  label,
+  status,
+}: {
+  count: number;
+  label: string;
+  status: RssFeedStatus;
+}) {
+  return (
+    <Link className="count-link" href={`/admin/feeds?status=${status}`}>
+      <strong>{count.toLocaleString("en-US")}</strong> <span>{label}</span>
+    </Link>
   );
 }
 

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -30,6 +30,7 @@ type LoadResult =
 type ActiveFilters = {
   status: RssFeedStatus | "all";
   q?: string;
+  errors: boolean;
 };
 
 export const dynamic = "force-dynamic";
@@ -89,17 +90,24 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
       <header className="page-header">
         <div className="page-title">
           <p className="eyebrow">
-            <Link href="/">&larr; Fetchlinks</Link> &middot; admin
+            <Link href="/admin">&larr; Admin</Link>
           </p>
           <h1>RSS feeds</h1>
         </div>
-        <p className="page-summary">
-          <CountLink count={counts.active} label="active" status="active" />
-          {" / "}
-          <CountLink count={counts.disabled} label="disabled" status="disabled" />
-          {" / "}
-          <CountLink count={counts.removed} label="removed" status="removed" />
-        </p>
+        <div className="feed-counts-tile" aria-label="Feed totals">
+          <CountTile
+            count={counts.active}
+            label={counts.active === 1 ? "active" : "active"}
+            href="/admin/feeds?status=active"
+            tone="ok"
+          />
+          <CountTile
+            count={counts.errors}
+            label={counts.errors === 1 ? "error" : "errors"}
+            href="/admin/feeds?errors=1"
+            tone={counts.errors > 0 ? "error" : "muted"}
+          />
+        </div>
       </header>
 
       <form action={addFeedAction} aria-label="Add feed" className="add-form">
@@ -139,7 +147,7 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
         </label>
         <div className="filter-actions">
           <button type="submit">Apply</button>
-          {filters.status !== "all" || filters.q ? (
+          {filters.status !== "all" || filters.q || filters.errors ? (
             <Link className="clear-filters" href="/admin/feeds">
               Clear
             </Link>
@@ -288,18 +296,21 @@ export function FeedStatusPill({ status }: { status: RssFeedStatus }) {
   );
 }
 
-function CountLink({
+function CountTile({
   count,
   label,
-  status,
+  href,
+  tone,
 }: {
   count: number;
   label: string;
-  status: RssFeedStatus;
+  href: string;
+  tone: "ok" | "error" | "muted";
 }) {
   return (
-    <Link className="count-link" href={`/admin/feeds?status=${status}`}>
-      <strong>{count.toLocaleString("en-US")}</strong> <span>{label}</span>
+    <Link className={`count-tile count-tile-${tone}`} href={href}>
+      <strong>{count.toLocaleString("en-US")}</strong>
+      <span>{label}</span>
     </Link>
   );
 }
@@ -348,7 +359,8 @@ function FeedAction({
 function parseFilters(searchParams: PageSearchParams | undefined): ActiveFilters {
   const status = pickStatus(getSingleSearchParam(searchParams, "status"));
   const q = getSingleSearchParam(searchParams, "q")?.trim() || undefined;
-  return { status, q };
+  const errors = getSingleSearchParam(searchParams, "errors") === "1";
+  return { status, q, errors };
 }
 
 function pickStatus(value: string | undefined): ActiveFilters["status"] {

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -185,12 +185,11 @@ function FeedRow({ feed }: { feed: RssFeed }) {
           <FeedAction
             action={deleteFeedAction}
             feedId={feed.id}
-            label="remove"
-            tone="danger"
+            label="Remove feed"
           />
         ) : null}
         {feed.status === "removed" ? (
-          <FeedAction action={restoreFeedAction} feedId={feed.id} label="restore" />
+          <FeedAction action={restoreFeedAction} feedId={feed.id} label="Restore" />
         ) : null}
       </nav>
     </article>
@@ -325,18 +324,15 @@ function FeedAction({
   action,
   feedId,
   label,
-  tone = "default",
 }: {
   action: (formData: FormData) => Promise<void>;
   feedId: number;
   label: string;
-  tone?: "default" | "danger";
 }) {
-  const toneClass = tone === "danger" ? " feed-action-btn-danger" : "";
   return (
     <form action={action} className="feed-action">
       <input name="feed_id" type="hidden" value={feedId} />
-      <button className={`feed-action-btn${toneClass}`} type="submit">
+      <button className="feed-action-btn" type="submit">
         {label}
       </button>
     </form>

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -176,7 +176,7 @@ function FeedRow({ feed }: { feed: RssFeed }) {
           target="_blank"
           title={feed.feedUrl}
         >
-          {feed.feedUrl}
+          <FeedUrlLabel url={feed.feedUrl} />
         </a>
         <FeedStatusPill status={feed.status} />
       </header>
@@ -309,6 +309,25 @@ function CountLink({
     <Link className="count-link" href={`/admin/feeds?status=${status}`}>
       <strong>{count.toLocaleString("en-US")}</strong> <span>{label}</span>
     </Link>
+  );
+}
+
+function FeedUrlLabel({ url }: { url: string }) {
+  let host: string | null = null;
+  let tail = "";
+  try {
+    const parsed = new URL(url);
+    host = parsed.hostname.replace(/^www\./, "");
+    tail = parsed.pathname + parsed.search + parsed.hash;
+    if (tail === "/") tail = "";
+  } catch {
+    return <>{url}</>;
+  }
+  return (
+    <>
+      <span className="feed-url-host">{host}</span>
+      {tail ? <span className="feed-url-path">{tail}</span> : null}
+    </>
   );
 }
 

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -30,6 +30,7 @@ type LoadResult =
       counts: RssFeedCounts;
       filters: ActiveFilters;
       addFeedback: AddFeedback | null;
+      confirmRemoveId: number | null;
     }
   | { status: "error" };
 
@@ -52,13 +53,15 @@ export default async function AdminFeedsPage({
   const resolved = await searchParams;
   const filters = parseFilters(resolved);
   const addFeedback = parseAddFeedback(resolved);
-  const result = loadFeeds(filters, addFeedback);
+  const confirmRemoveId = parseConfirmRemoveId(resolved);
+  const result = loadFeeds(filters, addFeedback, confirmRemoveId);
   return <AdminFeedsView result={result} />;
 }
 
 function loadFeeds(
   filters: ActiveFilters,
   addFeedback: AddFeedback | null,
+  confirmRemoveId: number | null,
 ): LoadResult {
   try {
     const config = loadAppConfig(process.env);
@@ -68,6 +71,7 @@ function loadFeeds(
       counts: countRssFeedsByStatus(db),
       filters,
       addFeedback,
+      confirmRemoveId,
     }));
   } catch {
     return { status: "error" };
@@ -92,7 +96,7 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
     );
   }
 
-  const { feeds, counts, filters, addFeedback } = result;
+  const { feeds, counts, filters, addFeedback, confirmRemoveId } = result;
 
   return (
     <main className="shell">
@@ -168,7 +172,12 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
       ) : (
         <section className="post-list" aria-label="RSS feeds">
           {feeds.map((feed) => (
-            <FeedRow key={feed.id} feed={feed} />
+            <FeedRow
+              key={feed.id}
+              feed={feed}
+              filters={filters}
+              confirmRemove={confirmRemoveId === feed.id}
+            />
           ))}
         </section>
       )}
@@ -176,9 +185,19 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
   );
 }
 
-function FeedRow({ feed }: { feed: RssFeed }) {
+function FeedRow({
+  feed,
+  filters,
+  confirmRemove,
+}: {
+  feed: RssFeed;
+  filters: ActiveFilters;
+  confirmRemove: boolean;
+}) {
   const health = getFeedHealth(feed);
-  const rowClass = `post-item feed-row feed-row-${health}`;
+  const rowClass = `post-item feed-row feed-row-${health}${
+    confirmRemove ? " feed-row-confirming" : ""
+  }`;
   return (
     <article className={rowClass}>
       <header className="feed-row-header">
@@ -197,13 +216,18 @@ function FeedRow({ feed }: { feed: RssFeed }) {
         <FeedStats feed={feed} />
         <nav aria-label="Feed actions" className="post-links feed-row-actions">
           {feed.status !== "removed" ? (
-            <FeedAction
-              action={deleteFeedAction}
-              feedId={feed.id}
-              label="Remove feed"
-              iconOnly
-              icon={<TrashIcon />}
-            />
+            confirmRemove ? (
+              <ConfirmRemove feedId={feed.id} filters={filters} />
+            ) : (
+              <Link
+                aria-label="Remove feed"
+                className="feed-action-btn feed-action-btn-icon"
+                href={buildFeedsHref(filters, { confirm_remove: String(feed.id) })}
+                title="Remove feed"
+              >
+                <TrashIcon />
+              </Link>
+            )
           ) : null}
           {feed.status === "removed" ? (
             <FeedAction action={restoreFeedAction} feedId={feed.id} label="Restore" />
@@ -211,6 +235,29 @@ function FeedRow({ feed }: { feed: RssFeed }) {
         </nav>
       </div>
     </article>
+  );
+}
+
+function ConfirmRemove({
+  feedId,
+  filters,
+}: {
+  feedId: number;
+  filters: ActiveFilters;
+}) {
+  return (
+    <span className="feed-confirm" role="group" aria-label="Confirm remove">
+      <span className="feed-confirm-prompt">Remove this feed?</span>
+      <form action={deleteFeedAction} className="feed-action">
+        <input name="feed_id" type="hidden" value={feedId} />
+        <button className="feed-action-btn feed-action-btn-danger" type="submit">
+          Remove
+        </button>
+      </form>
+      <Link className="feed-action-btn feed-action-btn-ghost" href={buildFeedsHref(filters)}>
+        Cancel
+      </Link>
+    </span>
   );
 }
 
@@ -444,6 +491,30 @@ function parseAddFeedback(
     return { kind: "invalid", reason, url };
   }
   return null;
+}
+
+function parseConfirmRemoveId(
+  searchParams: PageSearchParams | undefined,
+): number | null {
+  const raw = getSingleSearchParam(searchParams, "confirm_remove");
+  if (!raw) return null;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 1 ? parsed : null;
+}
+
+function buildFeedsHref(
+  filters: ActiveFilters,
+  extra: Record<string, string> = {},
+): string {
+  const params = new URLSearchParams();
+  if (filters.status !== "all") params.set("status", filters.status);
+  if (filters.q) params.set("q", filters.q);
+  if (filters.errors) params.set("errors", "1");
+  for (const [key, value] of Object.entries(extra)) {
+    params.set(key, value);
+  }
+  const query = params.toString();
+  return query ? `/admin/feeds?${query}` : "/admin/feeds";
 }
 
 function AddFeedbackBanner({ feedback }: { feedback: AddFeedback }) {

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+
+export const dynamic = "force-static";
+
+type AdminSection = {
+  href: string;
+  title: string;
+  description: string;
+  status: "available" | "planned";
+};
+
+const SECTIONS: AdminSection[] = [
+  {
+    href: "/admin/feeds",
+    title: "RSS feeds",
+    description: "Add, search, and remove RSS feed subscriptions.",
+    status: "available",
+  },
+  {
+    href: "/admin/reddit",
+    title: "Reddit",
+    description: "Manage subreddit list and credentials. (planned)",
+    status: "planned",
+  },
+  {
+    href: "/admin/bluesky",
+    title: "Bluesky",
+    description: "Manage handles to follow and credentials. (planned)",
+    status: "planned",
+  },
+  {
+    href: "/admin/mastodon",
+    title: "Mastodon",
+    description: "Manage instances, handles, and credentials. (planned)",
+    status: "planned",
+  },
+];
+
+export default function AdminIndexPage() {
+  return (
+    <main className="shell">
+      <header className="page-header">
+        <div className="page-title">
+          <p className="eyebrow">
+            <Link href="/">&larr; Fetchlinks</Link>
+          </p>
+          <h1>Admin</h1>
+        </div>
+      </header>
+
+      <section aria-label="Admin sections" className="admin-section-grid">
+        {SECTIONS.map((section) => (
+          <AdminSectionCard key={section.href} section={section} />
+        ))}
+      </section>
+    </main>
+  );
+}
+
+function AdminSectionCard({ section }: { section: AdminSection }) {
+  const isPlanned = section.status === "planned";
+  const className = `admin-section-card${isPlanned ? " admin-section-card-planned" : ""}`;
+
+  if (isPlanned) {
+    return (
+      <article className={className} aria-disabled="true">
+        <h2>{section.title}</h2>
+        <p>{section.description}</p>
+      </article>
+    );
+  }
+
+  return (
+    <Link className={className} href={section.href}>
+      <h2>{section.title}</h2>
+      <p>{section.description}</p>
+    </Link>
+  );
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -341,6 +341,7 @@ p {
 }
 
 .status-pill {
+  position: relative;
   display: inline-flex;
   align-items: center;
   padding: 1px 8px;
@@ -351,6 +352,38 @@ p {
   line-height: 1.5;
   text-transform: uppercase;
   letter-spacing: 0.02em;
+}
+
+.status-pill-has-tip {
+  cursor: help;
+}
+
+.status-pill-tip {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 10;
+  display: none;
+  max-width: min(420px, 90vw);
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.45;
+  letter-spacing: normal;
+  text-transform: none;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.status-pill-has-tip:hover .status-pill-tip,
+.status-pill-has-tip:focus-visible .status-pill-tip,
+.status-pill-has-tip:focus-within .status-pill-tip {
+  display: block;
 }
 
 .status-pill-healthy {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -444,6 +444,37 @@ p {
   color: var(--danger);
 }
 
+.feed-error {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  align-items: baseline;
+  padding: 8px 12px;
+  border: 1px solid color-mix(in srgb, var(--danger) 35%, var(--border));
+  border-left-width: 3px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--danger) 6%, var(--panel));
+  color: var(--foreground);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.feed-error-label {
+  flex-shrink: 0;
+  color: var(--danger);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.feed-error-body {
+  min-width: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  word-break: break-word;
+}
+
 .post-source {
   max-width: min(560px, 100%);
   overflow: hidden;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -246,6 +246,37 @@ p {
   color: var(--border);
 }
 
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.5;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.status-pill-active {
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.status-pill-disabled {
+  border-color: var(--border-strong);
+  background: var(--subtle);
+  color: var(--muted);
+}
+
+.status-pill-removed {
+  border-color: color-mix(in srgb, var(--danger) 35%, transparent);
+  background: color-mix(in srgb, var(--danger) 10%, var(--panel));
+  color: var(--danger);
+}
+
 .post-source {
   max-width: min(560px, 100%);
   overflow: hidden;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -409,6 +409,54 @@ p {
   font-weight: 400;
 }
 
+.admin-section-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.admin-section-card {
+  display: block;
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 8px;
+  background: var(--panel);
+  color: inherit;
+}
+
+.admin-section-card:hover,
+.admin-section-card:focus-visible {
+  background: var(--panel-alt);
+  border-left-color: var(--accent-strong);
+}
+
+.admin-section-card h2 {
+  margin-bottom: 4px;
+  color: var(--accent-strong);
+  font-size: 18px;
+}
+
+.admin-section-card p {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.admin-section-card-planned {
+  border-left-color: var(--border-strong);
+  background: var(--subtle);
+  cursor: not-allowed;
+}
+
+.admin-section-card-planned:hover {
+  background: var(--subtle);
+}
+
+.admin-section-card-planned h2 {
+  color: var(--muted);
+}
+
 .feed-stats {
   display: flex;
   flex-wrap: wrap;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -411,6 +411,34 @@ p {
   font-size: 15px;
 }
 
+.feed-health-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.feed-health-icon-ok {
+  background: color-mix(in srgb, var(--accent) 18%, var(--panel));
+  color: var(--accent-strong);
+}
+
+.feed-health-icon-err {
+  background: color-mix(in srgb, var(--danger) 18%, var(--panel));
+  color: var(--danger);
+}
+
+.feed-health-icon-unknown {
+  background: var(--panel-alt);
+  color: var(--muted);
+}
+
 .feed-url-host {
   font-weight: 700;
 }
@@ -491,15 +519,6 @@ p {
 .feed-stat strong {
   color: var(--foreground);
   font-weight: 700;
-}
-
-.feed-stat-ok {
-  border-color: color-mix(in srgb, var(--accent) 25%, var(--border));
-  color: var(--accent-strong);
-}
-
-.feed-stat-ok strong {
-  color: var(--accent-strong);
 }
 
 .feed-stat-danger {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -277,6 +277,43 @@ p {
   color: var(--danger);
 }
 
+.feed-action {
+  display: inline-flex;
+}
+
+.feed-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 0 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.feed-action-btn:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.feed-action-btn-danger {
+  border-color: color-mix(in srgb, var(--danger) 45%, var(--border));
+  color: var(--danger);
+}
+
+.feed-action-btn-danger:hover {
+  border-color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 10%, var(--panel));
+  color: var(--danger);
+}
+
 .post-source {
   max-width: min(560px, 100%);
   overflow: hidden;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -400,6 +400,15 @@ p {
   font-size: 15px;
 }
 
+.feed-url-host {
+  font-weight: 700;
+}
+
+.feed-url-path {
+  color: var(--muted);
+  font-weight: 400;
+}
+
 .feed-stats {
   display: flex;
   flex-wrap: wrap;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -167,13 +167,8 @@ p {
   color: var(--success, var(--accent-strong));
 }
 
-.count-tile-error {
-  border-color: var(--danger-border, #b04848);
-  background: var(--danger-bg, #2a1717);
-}
-
 .count-tile-error strong {
-  color: var(--danger, #e07878);
+  color: var(--danger, #b04848);
 }
 
 .count-tile-muted strong {
@@ -400,17 +395,6 @@ p {
   border-color: var(--accent);
   background: var(--accent-soft);
   color: var(--accent-strong);
-}
-
-.feed-action-btn-danger {
-  border-color: color-mix(in srgb, var(--danger) 45%, var(--border));
-  color: var(--danger);
-}
-
-.feed-action-btn-danger:hover {
-  border-color: var(--danger);
-  background: color-mix(in srgb, var(--danger) 10%, var(--panel));
-  color: var(--danger);
 }
 
 .feed-row-header {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -503,37 +503,6 @@ p {
   color: var(--danger);
 }
 
-.feed-error {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 10px;
-  align-items: baseline;
-  padding: 8px 12px;
-  border: 1px solid color-mix(in srgb, var(--danger) 35%, var(--border));
-  border-left-width: 3px;
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--danger) 6%, var(--panel));
-  color: var(--foreground);
-  font-size: 13px;
-  line-height: 1.5;
-}
-
-.feed-error-label {
-  flex-shrink: 0;
-  color: var(--danger);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.feed-error-body {
-  min-width: 0;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 12px;
-  word-break: break-word;
-}
-
 .post-source {
   max-width: min(560px, 100%);
   overflow: hidden;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -391,6 +391,23 @@ p {
   color: var(--accent-strong);
 }
 
+.feed-action-btn-icon {
+  min-height: 28px;
+  width: 28px;
+  padding: 0;
+  color: var(--muted);
+}
+
+.feed-action-btn-icon:hover {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 40%, var(--border));
+  background: color-mix(in srgb, var(--danger) 10%, var(--panel));
+}
+
+.feed-action-btn-icon svg {
+  display: block;
+}
+
 .feed-row {
   transition: background-color 120ms ease, border-color 120ms ease;
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -341,7 +341,6 @@ p {
 }
 
 .status-pill {
-  position: relative;
   display: inline-flex;
   align-items: center;
   padding: 1px 8px;
@@ -354,48 +353,10 @@ p {
   letter-spacing: 0.02em;
 }
 
-.status-pill-has-tip {
-  cursor: help;
-}
-
-.status-pill-tip {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 10;
-  display: none;
-  max-width: min(420px, 90vw);
-  padding: 8px 10px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--panel);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
-  color: var(--foreground);
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 1.45;
-  letter-spacing: normal;
-  text-transform: none;
-  white-space: normal;
-  word-break: break-word;
-}
-
-.status-pill-has-tip:hover .status-pill-tip,
-.status-pill-has-tip:focus-visible .status-pill-tip,
-.status-pill-has-tip:focus-within .status-pill-tip {
-  display: block;
-}
-
 .status-pill-healthy {
   border-color: color-mix(in srgb, var(--accent) 35%, transparent);
   background: var(--accent-soft);
   color: var(--accent-strong);
-}
-
-.status-pill-unhealthy {
-  border-color: color-mix(in srgb, var(--danger) 40%, transparent);
-  background: color-mix(in srgb, var(--danger) 12%, var(--panel));
-  color: var(--danger);
 }
 
 .status-pill-removed {
@@ -428,6 +389,15 @@ p {
   border-color: var(--accent);
   background: var(--accent-soft);
   color: var(--accent-strong);
+}
+
+.feed-row {
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.feed-row-unhealthy {
+  border-color: color-mix(in srgb, var(--danger) 40%, var(--border));
+  background: color-mix(in srgb, var(--danger) 8%, var(--panel));
 }
 
 .feed-row-header {
@@ -521,6 +491,7 @@ p {
 }
 
 .feed-stat {
+  position: relative;
   display: inline-flex;
   align-items: baseline;
   gap: 4px;
@@ -531,6 +502,38 @@ p {
   color: var(--muted);
   font-size: 12px;
   line-height: 1.4;
+}
+
+.feed-stat-has-tip {
+  cursor: help;
+}
+
+.feed-stat-tip {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 10;
+  display: none;
+  max-width: min(420px, 90vw);
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.45;
+  letter-spacing: normal;
+  text-transform: none;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.feed-stat-has-tip:hover .feed-stat-tip,
+.feed-stat-has-tip:focus-visible .feed-stat-tip,
+.feed-stat-has-tip:focus-within .feed-stat-tip {
+  display: block;
 }
 
 .feed-stat strong {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -123,21 +123,61 @@ p {
   line-height: 1;
 }
 
-.count-link {
+.feed-counts-tile {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.count-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  min-width: 96px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
   color: inherit;
-  border-radius: 4px;
+  line-height: 1.1;
+  text-align: right;
 }
 
-.count-link:hover strong,
-.count-link:focus-visible strong {
-  color: var(--accent-strong);
+.count-tile strong {
+  color: var(--foreground);
+  font-size: 24px;
+  font-weight: 600;
 }
 
-.count-link:hover span,
-.count-link:focus-visible span {
-  color: var(--accent);
-  text-decoration: underline;
-  text-underline-offset: 3px;
+.count-tile span {
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.count-tile:hover,
+.count-tile:focus-visible {
+  border-color: var(--accent);
+}
+
+.count-tile-ok strong {
+  color: var(--success, var(--accent-strong));
+}
+
+.count-tile-error {
+  border-color: var(--danger-border, #b04848);
+  background: var(--danger-bg, #2a1717);
+}
+
+.count-tile-error strong {
+  color: var(--danger, #e07878);
+}
+
+.count-tile-muted strong {
+  color: var(--muted);
 }
 
 .filter-bar {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -470,6 +470,39 @@ p {
   display: block;
 }
 
+.feed-action-btn-danger {
+  border-color: color-mix(in srgb, var(--danger) 50%, var(--border));
+  background: color-mix(in srgb, var(--danger) 12%, var(--panel));
+  color: var(--danger);
+}
+
+.feed-action-btn-danger:hover {
+  border-color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 20%, var(--panel));
+  color: var(--danger);
+}
+
+.feed-action-btn-ghost {
+  color: var(--muted);
+}
+
+.feed-confirm {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: center;
+}
+
+.feed-confirm-prompt {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.feed-row-confirming {
+  border-color: color-mix(in srgb, var(--danger) 55%, var(--border));
+  background: color-mix(in srgb, var(--danger) 6%, var(--panel));
+}
+
 .feed-row {
   transition: background-color 120ms ease, border-color 120ms ease;
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -123,6 +123,23 @@ p {
   line-height: 1;
 }
 
+.count-link {
+  color: inherit;
+  border-radius: 4px;
+}
+
+.count-link:hover strong,
+.count-link:focus-visible strong {
+  color: var(--accent-strong);
+}
+
+.count-link:hover span,
+.count-link:focus-visible span {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .filter-bar {
   display: grid;
   grid-template-columns: minmax(240px, 2fr) minmax(180px, 1fr) minmax(180px, 1fr) auto;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -180,16 +180,69 @@ p {
   color: var(--muted);
 }
 
-.filter-bar {
-  display: grid;
-  grid-template-columns: minmax(240px, 2fr) minmax(180px, 1fr) minmax(180px, 1fr) auto;
-  gap: 12px;
+.search-form {
+  display: flex;
+  gap: 10px;
   align-items: end;
   margin-bottom: 16px;
-  padding: 12px;
+  padding: 10px 12px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--panel);
+}
+
+.search-form-field {
+  display: grid;
+  flex: 1;
+  min-width: 0;
+  gap: 6px;
+}
+
+.search-form-field span {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.search-form-field input {
+  width: 100%;
+  min-height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #ffffff;
+  color: var(--foreground);
+  text-overflow: ellipsis;
+}
+
+.search-form-btn,
+.clear-filters {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.search-form-btn {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.search-form-btn:hover {
+  background: var(--accent-strong);
+}
+
+.clear-filters {
+  border: 1px solid var(--border);
+  background: var(--subtle);
+  color: var(--muted);
 }
 
 .add-form {
@@ -245,72 +298,6 @@ p {
 
 .add-form-btn:hover {
   background: var(--accent-strong);
-}
-
-.filter-bar label {
-  display: grid;
-  min-width: 0;
-  gap: 6px;
-}
-
-.filter-bar label span {
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.filter-bar input,
-.filter-bar select {
-  width: 100%;
-  min-height: 36px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: #ffffff;
-  color: var(--foreground);
-  text-overflow: ellipsis;
-}
-
-.filter-bar input {
-  padding: 0 10px;
-}
-
-.filter-bar select {
-  padding: 0 8px;
-}
-
-.filter-actions {
-  display: flex;
-  gap: 8px;
-}
-
-.filter-bar button,
-.clear-filters {
-  display: inline-flex;
-  min-height: 36px;
-  align-items: center;
-  justify-content: center;
-  padding: 0 14px;
-  border-radius: 6px;
-  font: inherit;
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.filter-bar button {
-  border: 1px solid var(--accent);
-  background: var(--accent);
-  color: #ffffff;
-  cursor: pointer;
-}
-
-.filter-bar button:hover {
-  background: var(--accent-strong);
-}
-
-.clear-filters {
-  border: 1px solid var(--border);
-  background: var(--subtle);
-  color: var(--muted);
 }
 
 .post-list {
@@ -694,12 +681,8 @@ p {
 }
 
 @media (max-width: 900px) {
-  .filter-bar {
-    grid-template-columns: minmax(220px, 1fr) minmax(180px, 1fr);
-  }
-
-  .filter-actions {
-    grid-column: 1 / -1;
+  .search-form {
+    flex-wrap: wrap;
   }
 }
 
@@ -722,15 +705,12 @@ p {
     font-size: 26px;
   }
 
-  .filter-bar {
-    grid-template-columns: 1fr;
-  }
-
-  .filter-actions {
-    grid-column: auto;
-  }
-
   .add-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-form {
     flex-direction: column;
     align-items: stretch;
   }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -411,6 +411,18 @@ p {
   font-size: 15px;
 }
 
+.feed-row-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.feed-row-actions {
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+
 .feed-url-host {
   font-weight: 700;
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -353,22 +353,22 @@ p {
   letter-spacing: 0.02em;
 }
 
-.status-pill-active {
+.status-pill-healthy {
   border-color: color-mix(in srgb, var(--accent) 35%, transparent);
   background: var(--accent-soft);
   color: var(--accent-strong);
 }
 
-.status-pill-disabled {
-  border-color: var(--border-strong);
-  background: var(--subtle);
-  color: var(--muted);
+.status-pill-unhealthy {
+  border-color: color-mix(in srgb, var(--danger) 40%, transparent);
+  background: color-mix(in srgb, var(--danger) 12%, var(--panel));
+  color: var(--danger);
 }
 
 .status-pill-removed {
-  border-color: color-mix(in srgb, var(--danger) 35%, transparent);
-  background: color-mix(in srgb, var(--danger) 10%, var(--panel));
-  color: var(--danger);
+  border-color: var(--border-strong);
+  background: var(--subtle);
+  color: var(--muted);
 }
 
 .feed-action {
@@ -409,34 +409,6 @@ p {
   flex: 1;
   min-width: 0;
   font-size: 15px;
-}
-
-.feed-health-icon {
-  display: inline-flex;
-  flex: 0 0 auto;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  font-size: 12px;
-  font-weight: 700;
-  line-height: 1;
-}
-
-.feed-health-icon-ok {
-  background: color-mix(in srgb, var(--accent) 18%, var(--panel));
-  color: var(--accent-strong);
-}
-
-.feed-health-icon-err {
-  background: color-mix(in srgb, var(--danger) 18%, var(--panel));
-  color: var(--danger);
-}
-
-.feed-health-icon-unknown {
-  background: var(--panel-alt);
-  color: var(--muted);
 }
 
 .feed-url-host {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -386,6 +386,64 @@ p {
   color: var(--danger);
 }
 
+.feed-row-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.feed-row-url {
+  flex: 1;
+  min-width: 0;
+  font-size: 15px;
+}
+
+.feed-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: center;
+}
+
+.feed-stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--panel-alt);
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.feed-stat strong {
+  color: var(--foreground);
+  font-weight: 700;
+}
+
+.feed-stat-ok {
+  border-color: color-mix(in srgb, var(--accent) 25%, var(--border));
+  color: var(--accent-strong);
+}
+
+.feed-stat-ok strong {
+  color: var(--accent-strong);
+}
+
+.feed-stat-danger {
+  border-color: color-mix(in srgb, var(--danger) 35%, var(--border));
+  background: color-mix(in srgb, var(--danger) 6%, var(--panel));
+  color: var(--danger);
+}
+
+.feed-stat-danger strong {
+  color: var(--danger);
+}
+
 .post-source {
   max-width: min(560px, 100%);
   overflow: hidden;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -135,6 +135,61 @@ p {
   background: var(--panel);
 }
 
+.add-form {
+  display: flex;
+  gap: 10px;
+  align-items: end;
+  margin-bottom: 10px;
+  padding: 10px 12px;
+  border: 1px dashed color-mix(in srgb, var(--accent) 45%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent-soft) 55%, var(--panel));
+}
+
+.add-form-field {
+  display: grid;
+  flex: 1;
+  min-width: 0;
+  gap: 6px;
+}
+
+.add-form-field span {
+  color: var(--accent-strong);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.add-form-field input {
+  width: 100%;
+  min-height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #ffffff;
+  color: var(--foreground);
+  text-overflow: ellipsis;
+}
+
+.add-form-btn {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--accent);
+  color: #ffffff;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.add-form-btn:hover {
+  background: var(--accent-strong);
+}
+
 .filter-bar label {
   display: grid;
   min-width: 0;
@@ -470,6 +525,11 @@ p {
 
   .filter-actions {
     grid-column: auto;
+  }
+
+  .add-form {
+    flex-direction: column;
+    align-items: stretch;
   }
 
   .post-item,

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -251,6 +251,68 @@ p {
   background: color-mix(in srgb, var(--accent-soft) 55%, var(--panel));
 }
 
+.add-feedback {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: baseline;
+  margin: -4px 0 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-left-width: 3px;
+  border-radius: 6px;
+  background: var(--panel);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.add-feedback-label {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.add-feedback-body {
+  min-width: 0;
+  word-break: break-word;
+}
+
+.add-feedback-body code {
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--panel-alt);
+  font-size: 12px;
+}
+
+.add-feedback-ok {
+  border-left-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, var(--panel));
+}
+
+.add-feedback-ok .add-feedback-label {
+  color: var(--accent-strong);
+}
+
+.add-feedback-warn {
+  border-left-color: var(--border-strong);
+  background: var(--subtle);
+}
+
+.add-feedback-warn .add-feedback-label {
+  color: var(--muted);
+}
+
+.add-feedback-error {
+  border-left-color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 8%, var(--panel));
+}
+
+.add-feedback-error .add-feedback-label {
+  color: var(--danger);
+}
+
 .add-form-field {
   display: grid;
   flex: 1;

--- a/web/src/lib/format-relative.test.ts
+++ b/web/src/lib/format-relative.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRelative } from "./format-relative";
+
+const NOW = new Date("2026-05-26T12:00:00Z");
+
+describe("formatRelative", () => {
+  it("returns null for null/undefined", () => {
+    expect(formatRelative(null, NOW)).toBeNull();
+    expect(formatRelative(undefined, NOW)).toBeNull();
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(formatRelative("not a date", NOW)).toBeNull();
+  });
+
+  it("formats past times with 'ago'", () => {
+    expect(formatRelative("2026-05-26T11:59:30Z", NOW)).toBe("30s ago");
+    expect(formatRelative("2026-05-26T11:55:00Z", NOW)).toBe("5m ago");
+    expect(formatRelative("2026-05-26T09:00:00Z", NOW)).toBe("3h ago");
+    expect(formatRelative("2026-05-23T12:00:00Z", NOW)).toBe("3d ago");
+    expect(formatRelative("2026-05-12T12:00:00Z", NOW)).toBe("2w ago");
+    expect(formatRelative("2026-02-25T12:00:00Z", NOW)).toBe("3mo ago");
+    expect(formatRelative("2024-05-26T12:00:00Z", NOW)).toBe("2y ago");
+  });
+
+  it("formats future times with 'in'", () => {
+    expect(formatRelative("2026-05-26T12:05:00Z", NOW)).toBe("in 5m");
+    expect(formatRelative("2027-05-26T12:00:00Z", NOW)).toBe("in 1y");
+  });
+
+  it("uses Date.now() by default", () => {
+    expect(formatRelative(new Date().toISOString())).toMatch(/^\d+s ago$/);
+  });
+});

--- a/web/src/lib/format-relative.ts
+++ b/web/src/lib/format-relative.ts
@@ -1,0 +1,41 @@
+/**
+ * Format an ISO-8601 timestamp as a short human-readable relative time
+ * ("3m ago", "2h ago", "5d ago", "3w ago", "2mo ago", "1y ago").
+ *
+ * Future times return "in 3m" / "in 2h" / etc.
+ *
+ * Returns null when the input is null, undefined, or not parseable.
+ */
+export function formatRelative(
+  iso: string | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (iso == null) return null;
+  const then = new Date(iso);
+  const ms = then.getTime();
+  if (Number.isNaN(ms)) return null;
+
+  const diffSec = Math.round((now.getTime() - ms) / 1000);
+  const past = diffSec >= 0;
+  const seconds = Math.abs(diffSec);
+
+  const value = pickUnit(seconds);
+  return past ? `${value} ago` : `in ${value}`;
+}
+
+const MINUTE = 60;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+const MONTH = 30 * DAY;
+const YEAR = 365 * DAY;
+
+function pickUnit(seconds: number): string {
+  if (seconds < MINUTE) return `${seconds}s`;
+  if (seconds < HOUR) return `${Math.floor(seconds / MINUTE)}m`;
+  if (seconds < DAY) return `${Math.floor(seconds / HOUR)}h`;
+  if (seconds < WEEK) return `${Math.floor(seconds / DAY)}d`;
+  if (seconds < MONTH) return `${Math.floor(seconds / WEEK)}w`;
+  if (seconds < YEAR) return `${Math.floor(seconds / MONTH)}mo`;
+  return `${Math.floor(seconds / YEAR)}y`;
+}

--- a/web/src/models/rss-feeds.ts
+++ b/web/src/models/rss-feeds.ts
@@ -21,4 +21,5 @@ export type RssFeed = {
 export type RssFeedListFilters = {
   status?: RssFeedStatus | "all";
   q?: string;
+  errors?: boolean;
 };

--- a/web/src/server/feeds.test.ts
+++ b/web/src/server/feeds.test.ts
@@ -118,9 +118,72 @@ describe("countRssFeedsByStatus", () => {
         { fetchlinksDbPath: fixture.dbPath },
         (db) => countRssFeedsByStatus(db),
       );
-      expect(counts).toEqual({ active: 1, disabled: 1, removed: 1, total: 3 });
+      expect(counts).toEqual({
+        active: 1,
+        disabled: 1,
+        removed: 1,
+        errors: 0,
+        total: 3,
+      });
     } finally {
       fixture.cleanup();
+    }
+  });
+
+  it("counts active feeds with failures or HTTP errors as errors", () => {
+    const directory = mkdtempSync(path.join(tmpdir(), "fetchlinks-feeds-err-"));
+    const dbPath = path.join(directory, "fetchlinks.db");
+    const database = new DatabaseSync(dbPath);
+    database.exec(`
+      CREATE TABLE rss_feeds (
+        feed_id              INTEGER PRIMARY KEY,
+        feed_url             TEXT NOT NULL,
+        normalized_url       TEXT NOT NULL UNIQUE,
+        enabled              INTEGER NOT NULL DEFAULT 1,
+        added_at             TEXT NOT NULL,
+        deleted_at           TEXT,
+        last_fetched_at      TEXT,
+        last_success_at      TEXT,
+        last_status          INTEGER,
+        last_error           TEXT,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0,
+        etag                 TEXT,
+        last_modified        TEXT,
+        latest_entry_at      TEXT
+      );
+      INSERT INTO rss_feeds
+        (feed_id, feed_url, normalized_url, enabled, added_at,
+         last_status, consecutive_failures)
+      VALUES
+        (1, 'https://ok.example/feed',     'https://ok.example/feed',     1, 'x', 200, 0),
+        (2, 'https://fails.example/feed',  'https://fails.example/feed',  1, 'x', 200, 3),
+        (3, 'https://http500.example/feed','https://http500.example/feed',1, 'x', 500, 0),
+        (4, 'https://disabled.example/feed','https://disabled.example/feed',0,'x',500, 5);
+    `);
+    database.close();
+    try {
+      const counts = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: dbPath },
+        (db) => countRssFeedsByStatus(db),
+      );
+      expect(counts).toEqual({
+        active: 3,
+        disabled: 1,
+        removed: 0,
+        errors: 2,
+        total: 4,
+      });
+
+      const onlyErrors = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: dbPath },
+        (db) => listRssFeeds(db, { errors: true }),
+      );
+      expect(onlyErrors.map((f) => f.feedUrl).sort()).toEqual([
+        "https://fails.example/feed",
+        "https://http500.example/feed",
+      ]);
+    } finally {
+      rmSync(directory, { force: true, recursive: true });
     }
   });
 });

--- a/web/src/server/feeds.ts
+++ b/web/src/server/feeds.ts
@@ -121,6 +121,12 @@ export function listRssFeeds(
     clauses.push("deleted_at IS NOT NULL");
   }
 
+  if (filters.errors) {
+    clauses.push(
+      "enabled = 1 AND deleted_at IS NULL AND (consecutive_failures > 0 OR last_status >= 400)",
+    );
+  }
+
   const q = filters.q?.trim();
   if (q) {
     const pattern = `%${escapeLikeValue(q.toLowerCase())}%`;
@@ -143,6 +149,7 @@ export type RssFeedCounts = {
   active: number;
   disabled: number;
   removed: number;
+  errors: number;
   total: number;
 };
 
@@ -153,6 +160,12 @@ export function countRssFeedsByStatus(database: DatabaseSync): RssFeedCounts {
         SUM(CASE WHEN deleted_at IS NULL AND enabled = 1 THEN 1 ELSE 0 END) AS active,
         SUM(CASE WHEN deleted_at IS NULL AND enabled = 0 THEN 1 ELSE 0 END) AS disabled,
         SUM(CASE WHEN deleted_at IS NOT NULL THEN 1 ELSE 0 END) AS removed,
+        SUM(CASE
+              WHEN deleted_at IS NULL
+                AND enabled = 1
+                AND (consecutive_failures > 0 OR last_status >= 400)
+              THEN 1 ELSE 0
+            END) AS errors,
         COUNT(*) AS total
       FROM rss_feeds`,
     )
@@ -160,12 +173,14 @@ export function countRssFeedsByStatus(database: DatabaseSync): RssFeedCounts {
       active: number | null;
       disabled: number | null;
       removed: number | null;
+      errors: number | null;
       total: number | null;
     };
   return {
     active: row.active ?? 0,
     disabled: row.disabled ?? 0,
     removed: row.removed ?? 0,
+    errors: row.errors ?? 0,
     total: row.total ?? 0,
   };
 }


### PR DESCRIPTION
Refresh of the /admin/feeds page plus a new /admin index.

Changes:
- New /admin index page linking to admin sub-pages (RSS live; Reddit/Bluesky/Mastodon planned)
- Header tile shows 'active' + 'errors' counts (errors = consecutive_failures > 0 || last_status >= 400), each links to that filter
- Distinct Add-feed bar separate from the search bar
- Search-only filter (status dropdown dropped)
- Per-row stats: pill, fetched, last-ok (when differs), newest entry, failure chip with hover/focus tooltip showing HTTP code / failure count / last error
- Unhealthy rows get a subtle red card background
- Disable/enable actions removed; remove is now a single trash icon, restore stays a text button
- Add-feed feedback banner (ok / already exists / invalid)
- Remove confirmation: clicking trash adds ?confirm_remove=<id> and the row swaps to a 'Remove / Cancel' prompt; no client JS
- formatRelative() helper + vitest

All forms-only, no client JS. 51 vitest pass, lint + typecheck + build clean.