### PR TITLE
web: security hardening (safe hrefs, headers, query cap)

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,39 @@
 import type { NextConfig } from "next";
 
+const SECURITY_HEADERS = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "img-src 'self' data:",
+      "style-src 'self' 'unsafe-inline'",
+      "script-src 'self'",
+      "connect-src 'self'",
+      "font-src 'self'",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+    ].join("; "),
+  },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: SECURITY_HEADERS,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 
 import Link from "next/link";
 
+import { formatRelative } from "../../../lib/format-relative";
+import { safeExternalHref } from "../../../lib/safe-external-href";
 import type { RssFeed, RssFeedStatus } from "../../../models/rss-feeds";
 import {
   countRssFeedsByStatus,
@@ -10,7 +12,6 @@ import {
   type RssFeedCounts,
 } from "../../../server/feeds";
 import { loadAppConfig } from "../../../server/config";
-import { formatRelative } from "../../../lib/format-relative";
 import {
   addFeedAction,
   deleteFeedAction,
@@ -201,15 +202,7 @@ function FeedRow({
   return (
     <article className={rowClass}>
       <header className="feed-row-header">
-        <a
-          className="post-source feed-row-url"
-          href={feed.feedUrl}
-          rel="noreferrer"
-          target="_blank"
-          title={feed.feedUrl}
-        >
-          <FeedUrlLabel url={feed.feedUrl} />
-        </a>
+        <FeedUrlLink feed={feed} />
         <FeedStatusPill feed={feed} />
       </header>
       <div className="feed-row-footer">
@@ -418,6 +411,28 @@ function FeedUrlLabel({ url }: { url: string }) {
   );
 }
 
+function FeedUrlLink({ feed }: { feed: RssFeed }) {
+  const href = safeExternalHref(feed.feedUrl);
+  if (!href) {
+    return (
+      <span className="post-source feed-row-url" title={feed.feedUrl}>
+        <FeedUrlLabel url={feed.feedUrl} />
+      </span>
+    );
+  }
+  return (
+    <a
+      className="post-source feed-row-url"
+      href={href}
+      rel="noreferrer"
+      target="_blank"
+      title={feed.feedUrl}
+    >
+      <FeedUrlLabel url={feed.feedUrl} />
+    </a>
+  );
+}
+
 function FeedAction({
   action,
   feedId,
@@ -473,7 +488,7 @@ function TrashIcon() {
 
 function parseFilters(searchParams: PageSearchParams | undefined): ActiveFilters {
   const status = pickStatus(getSingleSearchParam(searchParams, "status"));
-  const q = getSingleSearchParam(searchParams, "q")?.trim() || undefined;
+  const q = getSingleSearchParam(searchParams, "q")?.trim().slice(0, 200) || undefined;
   const errors = getSingleSearchParam(searchParams, "errors") === "1";
   return { status, q, errors };
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { safeExternalHref } from "../lib/safe-external-href";
 import type {
   DomainSummary,
   PostPage,
@@ -245,19 +246,27 @@ function EmptyPostsState({ filters, page }: { filters: ActiveFilters; page: Post
 }
 
 function PostListItem({ post }: { post: PostSummary }) {
+  const sourceHref = safeExternalHref(post.source);
+  const directHref = safeExternalHref(post.directLink);
   return (
     <article className="post-item">
       <header className="post-heading">
         <div className="post-meta">
-          <a
-            className="post-source"
-            href={toExternalHref(post.source)}
-            rel="noreferrer"
-            target="_blank"
-            title={post.source}
-          >
-            {getSourceLabel(post)}
-          </a>
+          {sourceHref ? (
+            <a
+              className="post-source"
+              href={sourceHref}
+              rel="noreferrer"
+              target="_blank"
+              title={post.source}
+            >
+              {getSourceLabel(post)}
+            </a>
+          ) : (
+            <span className="post-source" title={post.source}>
+              {getSourceLabel(post)}
+            </span>
+          )}
           <span aria-hidden="true" className="post-meta-separator">
             /
           </span>
@@ -265,7 +274,7 @@ function PostListItem({ post }: { post: PostSummary }) {
         </div>
       </header>
       <h2>{post.description ?? "Untitled post"}</h2>
-      {post.urls.length > 0 || post.directLink ? (
+      {post.urls.length > 0 || directHref ? (
         <nav aria-label="Post links" className="post-links">
           {post.urls.length > 0 ? (
             <span className="post-url-actions">
@@ -276,10 +285,10 @@ function PostListItem({ post }: { post: PostSummary }) {
               ))}
             </span>
           ) : null}
-          {post.directLink ? (
+          {directHref ? (
             <a
               className="post-source-action"
-              href={post.directLink}
+              href={directHref}
               rel="noreferrer"
               target="_blank"
             >
@@ -309,10 +318,16 @@ function PostLinkAction({
 
 function PostUrlItem({ label, url }: { label: string; url: PostUrl }) {
   const usesUnshortenedUrl = url.href !== url.originalUrl;
+  const href = safeExternalHref(url.href);
+  if (!href) {
+    return (
+      <span title={url.href}>{label}</span>
+    );
+  }
 
   return (
     <a
-      href={url.href}
+      href={href}
       rel="noreferrer"
       target="_blank"
       title={usesUnshortenedUrl ? `via ${formatUrlLabel(url.originalUrl)}` : url.href}
@@ -419,14 +434,6 @@ function getSourceLabel(post: PostSummary) {
   return post.author?.trim() || formatUrlLabel(post.source);
 }
 
-function toExternalHref(value: string) {
-  try {
-    return new URL(value).toString();
-  } catch {
-    return `https://${value}`;
-  }
-}
-
 function normalizeFilters(filters: PostFilters): ActiveFilters {
   const source = normalizeOptionalText(filters.source);
   const domain = normalizeOptionalText(filters.domain)?.toLowerCase();
@@ -436,7 +443,7 @@ function normalizeFilters(filters: PostFilters): ActiveFilters {
 }
 
 function normalizeOptionalText(value: string | undefined): string | undefined {
-  const text = value?.trim();
+  const text = value?.trim().slice(0, 200);
 
   return text ? text : undefined;
 }

--- a/web/src/lib/safe-external-href.test.ts
+++ b/web/src/lib/safe-external-href.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { safeExternalHref } from "./safe-external-href";
+
+describe("safeExternalHref", () => {
+  it("returns http(s) URLs unchanged (modulo URL parsing)", () => {
+    expect(safeExternalHref("https://example.com/foo?bar=1#x")).toBe(
+      "https://example.com/foo?bar=1#x",
+    );
+    expect(safeExternalHref("http://example.com")).toBe("http://example.com/");
+  });
+
+  it("upgrades bare hostnames to https", () => {
+    expect(safeExternalHref("example.com")).toBe("https://example.com/");
+    expect(safeExternalHref("  reddit.com/r/foo  ")).toBe(
+      "https://reddit.com/r/foo",
+    );
+  });
+
+  it("rejects javascript: URLs", () => {
+    expect(safeExternalHref("javascript:alert(1)")).toBeNull();
+    expect(safeExternalHref("JavaScript:alert(1)")).toBeNull();
+    expect(safeExternalHref(" javascript:alert(1) ")).toBeNull();
+  });
+
+  it("rejects other dangerous schemes", () => {
+    expect(safeExternalHref("data:text/html,<script>alert(1)</script>")).toBeNull();
+    expect(safeExternalHref("vbscript:msgbox(1)")).toBeNull();
+    expect(safeExternalHref("file:///etc/passwd")).toBeNull();
+    expect(safeExternalHref("chrome://settings")).toBeNull();
+  });
+
+  it("rejects empty / nullish input", () => {
+    expect(safeExternalHref(null)).toBeNull();
+    expect(safeExternalHref(undefined)).toBeNull();
+    expect(safeExternalHref("")).toBeNull();
+    expect(safeExternalHref("   ")).toBeNull();
+  });
+
+  it("rejects scheme-less strings that contain a colon", () => {
+    expect(safeExternalHref("foo:bar")).toBeNull();
+  });
+});

--- a/web/src/lib/safe-external-href.ts
+++ b/web/src/lib/safe-external-href.ts
@@ -1,0 +1,34 @@
+/**
+ * Return a safe http(s) URL string for use in `<a href>`, or `null`
+ * if the value is missing, malformed, or uses an unsafe scheme
+ * (e.g. `javascript:`, `data:`, `vbscript:`, `file:`).
+ *
+ * Bare host-like strings (no scheme) are upgraded to `https://`.
+ */
+export function safeExternalHref(value: string | null | undefined): string | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return url.toString();
+    }
+    return null;
+  } catch {
+    // Bare host or host+path with no scheme: only upgrade things that
+    // look like a hostname character class. Reject anything containing
+    // characters that could be interpreted as a scheme separator.
+    if (!/^[a-z0-9.-]+(?:[:/?#][\w./?#=%&+\-]*)?$/i.test(trimmed)) {
+      return null;
+    }
+    if (trimmed.includes(":")) return null;
+    try {
+      const url = new URL(`https://${trimmed}`);
+      return url.toString();
+    } catch {
+      return null;
+    }
+  }
+}

--- a/web/src/server/db.ts
+++ b/web/src/server/db.ts
@@ -344,7 +344,7 @@ function normalizePostFilters(filters: PostFilters): NormalizedPostFilters {
 }
 
 function normalizeOptionalText(value: string | undefined): string | undefined {
-  const text = value?.trim();
+  const text = value?.trim().slice(0, 200);
 
   return text ? text : undefined;
 }


### PR DESCRIPTION
Three small fixes from the /web security review:

1. **`safeExternalHref` helper** (`web/src/lib/safe-external-href.ts` + tests)
   - Allow-lists `http(s):` only; rejects `javascript:`, `data:`, `vbscript:`, `file:`, `chrome:`, etc.
   - Applied to `post.source`, `post.directLink`, `url.href` on the public page and to `feed.feedUrl` in /admin/feeds.
   - Unsafe URLs render as plain `<span>` text instead of `<a>`.

2. **Security headers in `next.config.ts`**
   - `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy`.
   - `Content-Security-Policy` with `default-src 'self'`, `script-src 'self'` (no inline), `frame-ancestors 'none'`, `form-action 'self'`.

3. **Cap `q` at 200 chars** in both public and admin filter normalizers to prevent DoS-amplifying LIKE scans.

Out of scope / deferred:
- Basic Auth rate limiting (best done at nginx layer in deploy/).

58 vitest pass, lint + typecheck + build clean.