### PR TITLE
feeds: per-feed site_link + view-posts link

### DIFF
--- a/ingest/fetchlinks/db_setup.py
+++ b/ingest/fetchlinks/db_setup.py
@@ -103,12 +103,20 @@ def table_rss_feeds_configure(conn):
     consecutive_failures INTEGER NOT NULL DEFAULT 0,
     etag                 TEXT,
     last_modified        TEXT,
-    latest_entry_at      TEXT)
+    latest_entry_at      TEXT,
+    site_link            TEXT)
     """)
         conn.execute(
             'CREATE INDEX IF NOT EXISTS idx_rss_feeds_live '
             'ON rss_feeds(enabled, deleted_at)'
         )
+        # In-place upgrade for DBs created before site_link existed.
+        existing_columns = {
+            row[1]
+            for row in conn.execute('PRAGMA table_info(rss_feeds)').fetchall()
+        }
+        if 'site_link' not in existing_columns:
+            conn.execute('ALTER TABLE rss_feeds ADD COLUMN site_link TEXT')
     except sqlite3.OperationalError as exc:
         raise RuntimeError('Failed to configure rss_feeds table') from exc
 

--- a/ingest/fetchlinks/db_utils.py
+++ b/ingest/fetchlinks/db_utils.py
@@ -282,6 +282,7 @@ def db_update_rss_feed_after_fetch(results, db_location, auto_disable_after):
                 etag = r.get('etag') or None
                 last_mod = r.get('last_modified') or None
                 latest_entry = r.get('latest_entry_at')
+                site_link = r.get('site_link')
                 error = r.get('error')
 
                 if success:
@@ -294,10 +295,11 @@ def db_update_rss_feed_after_fetch(results, db_location, auto_disable_after):
                         '  consecutive_failures = 0, '
                         '  etag            = ?, '
                         '  last_modified   = ?, '
-                        '  latest_entry_at = COALESCE(?, latest_entry_at) '
+                        '  latest_entry_at = COALESCE(?, latest_entry_at), '
+                        '  site_link       = COALESCE(?, site_link) '
                         'WHERE feed_id = ?',
                         (now, now, status, etag, last_mod,
-                         latest_entry, r['feed_id']),
+                         latest_entry, site_link, r['feed_id']),
                     )
                 else:
                     db.execute(
@@ -334,7 +336,7 @@ def db_get_all_rss_feeds(db_location):
     cols = ['feed_id', 'feed_url', 'normalized_url', 'enabled', 'added_at',
             'deleted_at', 'last_fetched_at', 'last_success_at', 'last_status',
             'last_error', 'consecutive_failures', 'etag', 'last_modified',
-            'latest_entry_at']
+            'latest_entry_at', 'site_link']
     try:
         with sqlite3.connect(db_location) as db:
             _ensure_rss_feeds_table(db)

--- a/ingest/fetchlinks/rss_links.py
+++ b/ingest/fetchlinks/rss_links.py
@@ -133,6 +133,48 @@ def parse_posts(fetch_results):
     return posts
 
 
+def pick_site_link(parsed_feed) -> str | None:
+    """Best-effort extraction of a feed's public website URL.
+
+    Tries, in order:
+      1. ``parsed_feed.link`` if it looks like an absolute http(s) URL.
+      2. The first entry in ``parsed_feed.links`` whose ``rel`` is
+         ``'alternate'`` and whose ``type`` starts with ``'text/html'``
+         (or has no type), and whose ``href`` is an absolute http(s) URL.
+      3. Otherwise ``None`` -- callers should leave the column untouched
+         rather than fall back to the feed XML URL.
+    """
+    if parsed_feed is None:
+        return None
+
+    def _is_http_url(value):
+        if not isinstance(value, str):
+            return False
+        v = value.strip()
+        return v.startswith('http://') or v.startswith('https://')
+
+    link = parsed_feed.get('link') if hasattr(parsed_feed, 'get') else None
+    if _is_http_url(link):
+        return link.strip()
+
+    links = parsed_feed.get('links') if hasattr(parsed_feed, 'get') else None
+    if isinstance(links, list):
+        for entry in links:
+            if not hasattr(entry, 'get'):
+                continue
+            rel = entry.get('rel')
+            if rel and rel != 'alternate':
+                continue
+            etype = entry.get('type') or ''
+            if etype and not etype.startswith('text/html'):
+                continue
+            href = entry.get('href')
+            if _is_http_url(href):
+                return href.strip()
+
+    return None
+
+
 def run(
     rss_source,
     db_path: Path,
@@ -159,8 +201,9 @@ def run(
             'etag': etag,
             'last_modified': last_mod,
             'error': err,
+            'site_link': pick_site_link(feed),
         }
-        for (fid, _url, _feed, etag, last_mod, status, err) in fetch_results
+        for (fid, _url, feed, etag, last_mod, status, err) in fetch_results
     ]
     auto_disabled = db_utils.db_update_rss_feed_after_fetch(
         health_updates, db_path, rss_source.auto_disable_after_failures,

--- a/ingest/fetchlinks/tests/test_rss_links.py
+++ b/ingest/fetchlinks/tests/test_rss_links.py
@@ -393,5 +393,66 @@ class RunTests(unittest.TestCase):
         db_insert.assert_called_once_with([allowed], self.db_path)
 
 
+class PickSiteLinkTests(unittest.TestCase):
+    def test_returns_none_when_feed_missing(self):
+        self.assertIsNone(rss_links.pick_site_link(None))
+
+    def test_prefers_top_level_link(self):
+        feed = SimpleNamespace(
+            get=lambda key, default=None: {
+                'link': 'https://example.com/',
+                'links': [],
+            }.get(key, default),
+        )
+        self.assertEqual(rss_links.pick_site_link(feed), 'https://example.com/')
+
+    def test_strips_whitespace_on_link(self):
+        feed = SimpleNamespace(
+            get=lambda key, default=None: {
+                'link': '  https://example.com/news  ',
+            }.get(key, default),
+        )
+        self.assertEqual(
+            rss_links.pick_site_link(feed), 'https://example.com/news',
+        )
+
+    def test_falls_back_to_alternate_html_link(self):
+        link_entries = [
+            SimpleNamespace(get=lambda k, d=None: {
+                'rel': 'self', 'type': 'application/rss+xml',
+                'href': 'https://example.com/feed.xml',
+            }.get(k, d)),
+            SimpleNamespace(get=lambda k, d=None: {
+                'rel': 'alternate', 'type': 'text/html',
+                'href': 'https://example.com/',
+            }.get(k, d)),
+        ]
+        feed = SimpleNamespace(
+            get=lambda key, default=None: {
+                'link': '',
+                'links': link_entries,
+            }.get(key, default),
+        )
+        self.assertEqual(rss_links.pick_site_link(feed), 'https://example.com/')
+
+    def test_returns_none_when_only_non_http_scheme(self):
+        feed = SimpleNamespace(
+            get=lambda key, default=None: {
+                'link': 'javascript:alert(1)',
+                'links': [],
+            }.get(key, default),
+        )
+        self.assertIsNone(rss_links.pick_site_link(feed))
+
+    def test_returns_none_when_nothing_usable(self):
+        feed = SimpleNamespace(
+            get=lambda key, default=None: {
+                'link': None,
+                'links': [],
+            }.get(key, default),
+        )
+        self.assertIsNone(rss_links.pick_site_link(feed))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/web/src/app/admin/feeds/page.tsx
+++ b/web/src/app/admin/feeds/page.tsx
@@ -208,6 +208,9 @@ function FeedRow({
       <div className="feed-row-footer">
         <FeedStats feed={feed} />
         <nav aria-label="Feed actions" className="post-links feed-row-actions">
+          {feed.status !== "removed" && feed.siteLink && !confirmRemove ? (
+            <ViewPostsLink siteLink={feed.siteLink} />
+          ) : null}
           {feed.status !== "removed" ? (
             confirmRemove ? (
               <ConfirmRemove feedId={feed.id} filters={filters} />
@@ -482,6 +485,42 @@ function TrashIcon() {
       <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
       <path d="M10 11v6" />
       <path d="M14 11v6" />
+    </svg>
+  );
+}
+
+function ViewPostsLink({ siteLink }: { siteLink: string }) {
+  return (
+    <Link
+      aria-label="View posts from this feed"
+      className="feed-action-btn feed-action-btn-icon feed-action-btn-view"
+      href={`/?source=${encodeURIComponent(siteLink)}`}
+      title="View posts from this feed"
+    >
+      <ViewPostsIcon />
+    </Link>
+  );
+}
+
+function ViewPostsIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      focusable="false"
+      height="16"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.75"
+      viewBox="0 0 24 24"
+      width="16"
+    >
+      <path d="M4 5h6" />
+      <path d="M4 12h6" />
+      <path d="M4 19h10" />
+      <path d="M15 9l5 5-5 5" />
+      <path d="M20 14h-9" />
     </svg>
   );
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -470,6 +470,12 @@ p {
   display: block;
 }
 
+.feed-action-btn-view:hover {
+  color: var(--accent-strong);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+  background: color-mix(in srgb, var(--accent) 10%, var(--panel));
+}
+
 .feed-action-btn-danger {
   border-color: color-mix(in srgb, var(--danger) 50%, var(--border));
   background: color-mix(in srgb, var(--danger) 12%, var(--panel));

--- a/web/src/models/rss-feeds.ts
+++ b/web/src/models/rss-feeds.ts
@@ -15,6 +15,7 @@ export type RssFeed = {
   etag: string | null;
   lastModified: string | null;
   latestEntryAt: string | null;
+  siteLink: string | null;
   status: RssFeedStatus;
 };
 

--- a/web/src/server/feeds.test.ts
+++ b/web/src/server/feeds.test.ts
@@ -40,16 +40,17 @@ function createFeedsFixture(): Fixture {
       consecutive_failures INTEGER NOT NULL DEFAULT 0,
       etag                 TEXT,
       last_modified        TEXT,
-      latest_entry_at      TEXT
+      latest_entry_at      TEXT,
+      site_link            TEXT
     );
 
     INSERT INTO rss_feeds
       (feed_id, feed_url, normalized_url, enabled, added_at, deleted_at,
-       last_error, consecutive_failures)
+       last_error, consecutive_failures, site_link)
     VALUES
-      (1, 'https://a.example/feed', 'https://a.example/feed', 1, '2026-01-01 00:00:00', NULL, NULL, 0),
-      (2, 'https://b.example/feed', 'https://b.example/feed', 0, '2026-01-02 00:00:00', NULL, 'HTTP 500', 10),
-      (3, 'https://c.example/feed', 'https://c.example/feed', 0, '2026-01-03 00:00:00', '2026-02-01 00:00:00', NULL, 0);
+      (1, 'https://a.example/feed', 'https://a.example/feed', 1, '2026-01-01 00:00:00', NULL, NULL, 0, 'https://a.example/'),
+      (2, 'https://b.example/feed', 'https://b.example/feed', 0, '2026-01-02 00:00:00', NULL, 'HTTP 500', 10, NULL),
+      (3, 'https://c.example/feed', 'https://c.example/feed', 0, '2026-01-03 00:00:00', '2026-02-01 00:00:00', NULL, 0, NULL);
   `);
   database.close();
   return {
@@ -108,6 +109,26 @@ describe("listRssFeeds", () => {
       fixture.cleanup();
     }
   });
+
+  it("surfaces siteLink (or null) from the rss_feeds row", () => {
+    const fixture = createFeedsFixture();
+    try {
+      const feeds = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => listRssFeeds(db),
+      );
+      const byUrl = Object.fromEntries(
+        feeds.map((f) => [f.feedUrl, f.siteLink]),
+      );
+      expect(byUrl).toEqual({
+        "https://a.example/feed": "https://a.example/",
+        "https://b.example/feed": null,
+        "https://c.example/feed": null,
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
 });
 
 describe("countRssFeedsByStatus", () => {
@@ -149,7 +170,8 @@ describe("countRssFeedsByStatus", () => {
         consecutive_failures INTEGER NOT NULL DEFAULT 0,
         etag                 TEXT,
         last_modified        TEXT,
-        latest_entry_at      TEXT
+        latest_entry_at      TEXT,
+        site_link            TEXT
       );
       INSERT INTO rss_feeds
         (feed_id, feed_url, normalized_url, enabled, added_at,

--- a/web/src/server/feeds.ts
+++ b/web/src/server/feeds.ts
@@ -27,6 +27,7 @@ type RssFeedRow = {
   etag: string | null;
   lastModified: string | null;
   latestEntryAt: string | null;
+  siteLink: string | null;
 };
 
 export type WritableFetchlinksDatabase = DatabaseSync;
@@ -45,7 +46,8 @@ const SELECT_COLUMNS = `
   consecutive_failures AS consecutiveFailures,
   etag                 AS etag,
   last_modified        AS lastModified,
-  latest_entry_at      AS latestEntryAt
+  latest_entry_at      AS latestEntryAt,
+  site_link            AS siteLink
 `;
 
 export function openWritableFetchlinksDatabase(
@@ -57,7 +59,28 @@ export function openWritableFetchlinksDatabase(
   // Make sure we honour foreign keys and don't block forever on a writer.
   database.exec("PRAGMA foreign_keys = ON");
   database.exec("PRAGMA busy_timeout = 5000");
+  ensureRssFeedsSchema(database);
   return database;
+}
+
+// Idempotent in-place upgrade for DBs created before site_link existed.
+// Mirrors the ingest-side ALTER in ingest/fetchlinks/db_setup.py so the
+// web admin doesn't 500 when a fresh column hasn't been added by ingest
+// yet. Safe to call on every writable open; the PRAGMA lookup is cheap
+// and the ALTER only fires once per DB.
+function ensureRssFeedsSchema(database: WritableFetchlinksDatabase): void {
+  const columns = database
+    .prepare("PRAGMA table_info(rss_feeds)")
+    .all() as { name: string }[];
+  if (columns.length === 0) {
+    // Table doesn't exist yet (e.g. fresh DB before ingest bootstrap).
+    // Nothing to upgrade.
+    return;
+  }
+  const hasSiteLink = columns.some((c) => c.name === "site_link");
+  if (!hasSiteLink) {
+    database.exec("ALTER TABLE rss_feeds ADD COLUMN site_link TEXT");
+  }
 }
 
 export function openConfiguredWritableFetchlinksDatabase(
@@ -101,6 +124,7 @@ function rowToFeed(row: RssFeedRow): RssFeed {
     etag: row.etag,
     lastModified: row.lastModified,
     latestEntryAt: row.latestEntryAt,
+    siteLink: row.siteLink,
     status,
   };
 }


### PR DESCRIPTION
Adds a nullable `site_link` column on `rss_feeds` populated from each feed's parsed top-level/alternate HTML link, and surfaces it as a small icon link in the admin feeds list that opens `/?source=<siteLink>`. Both ingest and web apply an idempotent ALTER so existing DBs upgrade in place. 290 ingest tests + 59 web tests pass.