### PR TITLE
rss: fix pick_site_link to read from parsed_feed.feed

### DIFF
--- a/ingest/fetchlinks/rss_links.py
+++ b/ingest/fetchlinks/rss_links.py
@@ -136,15 +136,22 @@ def parse_posts(fetch_results):
 def pick_site_link(parsed_feed) -> str | None:
     """Best-effort extraction of a feed's public website URL.
 
+    ``parsed_feed`` is the object returned by ``feedparser.parse()``; the
+    channel-level metadata lives under ``parsed_feed.feed`` (a FeedParserDict
+    with ``link`` / ``links`` keys).
+
     Tries, in order:
-      1. ``parsed_feed.link`` if it looks like an absolute http(s) URL.
-      2. The first entry in ``parsed_feed.links`` whose ``rel`` is
+      1. ``parsed_feed.feed.link`` if it looks like an absolute http(s) URL.
+      2. The first entry in ``parsed_feed.feed.links`` whose ``rel`` is
          ``'alternate'`` and whose ``type`` starts with ``'text/html'``
          (or has no type), and whose ``href`` is an absolute http(s) URL.
       3. Otherwise ``None`` -- callers should leave the column untouched
          rather than fall back to the feed XML URL.
     """
     if parsed_feed is None:
+        return None
+    channel = parsed_feed.get('feed') if hasattr(parsed_feed, 'get') else None
+    if channel is None:
         return None
 
     def _is_http_url(value):
@@ -153,11 +160,11 @@ def pick_site_link(parsed_feed) -> str | None:
         v = value.strip()
         return v.startswith('http://') or v.startswith('https://')
 
-    link = parsed_feed.get('link') if hasattr(parsed_feed, 'get') else None
+    link = channel.get('link') if hasattr(channel, 'get') else None
     if _is_http_url(link):
         return link.strip()
 
-    links = parsed_feed.get('links') if hasattr(parsed_feed, 'get') else None
+    links = channel.get('links') if hasattr(channel, 'get') else None
     if isinstance(links, list):
         for entry in links:
             if not hasattr(entry, 'get'):

--- a/ingest/fetchlinks/tests/test_rss_links.py
+++ b/ingest/fetchlinks/tests/test_rss_links.py
@@ -394,24 +394,32 @@ class RunTests(unittest.TestCase):
 
 
 class PickSiteLinkTests(unittest.TestCase):
+    @staticmethod
+    def _wrap(channel_dict):
+        """Build a feedparser-shaped object: top-level dict with a 'feed' key
+        holding the channel-level metadata (link, links, ...)."""
+        channel = SimpleNamespace(
+            get=lambda key, default=None, _d=channel_dict: _d.get(key, default),
+        )
+        return SimpleNamespace(
+            get=lambda key, default=None, _c=channel: (
+                _c if key == 'feed' else default
+            ),
+        )
+
     def test_returns_none_when_feed_missing(self):
         self.assertIsNone(rss_links.pick_site_link(None))
 
+    def test_returns_none_when_channel_missing(self):
+        bare = SimpleNamespace(get=lambda key, default=None: default)
+        self.assertIsNone(rss_links.pick_site_link(bare))
+
     def test_prefers_top_level_link(self):
-        feed = SimpleNamespace(
-            get=lambda key, default=None: {
-                'link': 'https://example.com/',
-                'links': [],
-            }.get(key, default),
-        )
+        feed = self._wrap({'link': 'https://example.com/', 'links': []})
         self.assertEqual(rss_links.pick_site_link(feed), 'https://example.com/')
 
     def test_strips_whitespace_on_link(self):
-        feed = SimpleNamespace(
-            get=lambda key, default=None: {
-                'link': '  https://example.com/news  ',
-            }.get(key, default),
-        )
+        feed = self._wrap({'link': '  https://example.com/news  '})
         self.assertEqual(
             rss_links.pick_site_link(feed), 'https://example.com/news',
         )
@@ -427,30 +435,15 @@ class PickSiteLinkTests(unittest.TestCase):
                 'href': 'https://example.com/',
             }.get(k, d)),
         ]
-        feed = SimpleNamespace(
-            get=lambda key, default=None: {
-                'link': '',
-                'links': link_entries,
-            }.get(key, default),
-        )
+        feed = self._wrap({'link': '', 'links': link_entries})
         self.assertEqual(rss_links.pick_site_link(feed), 'https://example.com/')
 
     def test_returns_none_when_only_non_http_scheme(self):
-        feed = SimpleNamespace(
-            get=lambda key, default=None: {
-                'link': 'javascript:alert(1)',
-                'links': [],
-            }.get(key, default),
-        )
+        feed = self._wrap({'link': 'javascript:alert(1)', 'links': []})
         self.assertIsNone(rss_links.pick_site_link(feed))
 
     def test_returns_none_when_nothing_usable(self):
-        feed = SimpleNamespace(
-            get=lambda key, default=None: {
-                'link': None,
-                'links': [],
-            }.get(key, default),
-        )
+        feed = self._wrap({'link': None, 'links': []})
         self.assertIsNone(rss_links.pick_site_link(feed))
 
 


### PR DESCRIPTION
Follow-up to #50. `pick_site_link()` was being handed the top-level FeedParserDict instead of the channel sub-dict, so `get('link')` and `get('links')` always missed and every feed wrote `site_link = NULL`. Fix drills into `parsed_feed.get('feed')` first; tests rewritten to match the real feedparser shape.