### PR TITLE
web: refresh public posts UI; ingest: posts.source_type

### DIFF
--- a/ingest/fetchlinks/db_setup.py
+++ b/ingest/fetchlinks/db_setup.py
@@ -21,15 +21,23 @@ def table_posts_configure(conn):
     CREATE TABLE IF NOT EXISTS posts (
     idx INTEGER PRIMARY KEY,
     source TEXT,
+    source_type TEXT,
     author TEXT,
     description TEXT,
     direct_link TEXT,
     date_created TEXT,
     unique_id_string TEXT UNIQUE NOT NULL )
     """)
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_posts_unique_id ON posts(unique_id_string)")
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_posts_source    ON posts(source)")
-        conn.execute("CREATE INDEX IF NOT EXISTS idx_posts_date      ON posts(date_created)")
+        # Idempotent in-place upgrade for DBs created before source_type
+        # existed. Matches the pattern used for rss_feeds.site_link.
+        existing_columns = {row[1] for row in conn.execute('PRAGMA table_info(posts)').fetchall()}
+        if 'source_type' not in existing_columns:
+            conn.execute('ALTER TABLE posts ADD COLUMN source_type TEXT')
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_posts_unique_id   ON posts(unique_id_string)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_posts_source      ON posts(source)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_posts_date        ON posts(date_created)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_posts_source_type ON posts(source_type)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_posts_author      ON posts(author)")
     except sqlite3.OperationalError as exc:
         raise RuntimeError('Failed to configure posts table') from exc
 

--- a/ingest/fetchlinks/db_utils.py
+++ b/ingest/fetchlinks/db_utils.py
@@ -25,8 +25,8 @@ def db_insert(fetched_data, db_location):
 
     insert_post_sql = (
         'INSERT OR IGNORE INTO posts '
-        '(source, author, description, direct_link, date_created, unique_id_string) '
-        'VALUES (?, ?, ?, ?, ?, ?)'
+        '(source, source_type, author, description, direct_link, date_created, unique_id_string) '
+        'VALUES (?, ?, ?, ?, ?, ?, ?)'
     )
     insert_url_sql = (
         'INSERT OR IGNORE INTO post_urls (post_id, position, url, url_hash) '

--- a/ingest/fetchlinks/rss_links.py
+++ b/ingest/fetchlinks/rss_links.py
@@ -119,12 +119,19 @@ def parse_posts(fetch_results):
         if feed is None:
             continue
         feed_meta = feed.feed if hasattr(feed, 'feed') else {}
-        source = feed_meta.get('link') or url
-        author = feed_meta.get('title') or source
+        # `feed_source` is the URL used as the base for resolving relative
+        # <link> values inside each entry. `site_link` is the feed's
+        # advertised website -- preferred for posts.source so the UI can
+        # group "all posts from this feed" without exposing the feed XML
+        # URL. Falls back to `url` (the feed XML URL) when site_link is
+        # not advertised.
+        feed_source = feed_meta.get('link') or url
+        site_link = pick_site_link(feed)
+        author = feed_meta.get('title') or feed_source
 
         for post in feed.entries:
             try:
-                parsed = RssPost(source, author, post)
+                parsed = RssPost(feed_source, author, post, site_link=site_link)
             except Exception as exc:
                 logger.warning('Skipping malformed entry from %s: %s', url, exc)
                 continue

--- a/ingest/fetchlinks/tests/test_utils.py
+++ b/ingest/fetchlinks/tests/test_utils.py
@@ -147,12 +147,16 @@ class PostTests(unittest.TestCase):
     def test_get_post_row_shape(self):
         p = Post()
         p.source = 's'
+        p.source_type = 'rss'
         p.author = 'a'
         p.description = 'd'
         p.direct_link = 'dl'
         p.date_created = '2026-01-01 00:00:00'
         p.unique_id_string = 'u'
-        self.assertEqual(p.get_post_row(), ('s', 'a', 'd', 'dl', '2026-01-01 00:00:00', 'u'))
+        self.assertEqual(
+            p.get_post_row(),
+            ('s', 'rss', 'a', 'd', 'dl', '2026-01-01 00:00:00', 'u'),
+        )
 
     def test_get_url_rows_shape(self):
         p = Post()
@@ -191,6 +195,26 @@ class RssPostTests(unittest.TestCase):
         post = RssPost('https://example.com/feed.xml', 'Example', entry)
         self.assertEqual(post.description, '')
 
+    def test_source_type_is_rss(self):
+        entry = _RssEntry(title='t', link='https://example.com/a', published='2026-04-19T12:00:00Z')
+        post = RssPost('https://example.com/feed.xml', 'Example', entry)
+        self.assertEqual(post.source_type, 'rss')
+
+    def test_prefers_site_link_over_feed_source(self):
+        entry = _RssEntry(title='t', link='https://example.com/a', published='2026-04-19T12:00:00Z')
+        post = RssPost(
+            'https://example.com/feed.xml',
+            'Example',
+            entry,
+            site_link='https://example.com/',
+        )
+        self.assertEqual(post.source, 'https://example.com/')
+
+    def test_falls_back_to_feed_source_when_site_link_missing(self):
+        entry = _RssEntry(title='t', link='https://example.com/a', published='2026-04-19T12:00:00Z')
+        post = RssPost('https://example.com/feed.xml', 'Example', entry, site_link=None)
+        self.assertEqual(post.source, 'https://example.com/feed.xml')
+
 
 class RedditPostTests(unittest.TestCase):
     def test_extract_data_builds_source_and_direct_link(self):
@@ -212,6 +236,10 @@ class RedditPostTests(unittest.TestCase):
         post = RedditPost(_make_reddit_post('https://example.com/article'))
         self.assertNotEqual(post.unique_id_string, '')
 
+    def test_source_type_is_reddit(self):
+        post = RedditPost(_make_reddit_post('https://example.com/article'))
+        self.assertEqual(post.source_type, 'reddit')
+
 
 class BlueskyPostTests(unittest.TestCase):
     def test_filters_invalid_urls(self):
@@ -225,6 +253,17 @@ class BlueskyPostTests(unittest.TestCase):
         )
         self.assertEqual(post.urls, ['https://example.com/a', 'https://example.com/b'])
         self.assertEqual(post.date_created, '2026-04-19 12:34:56')
+
+    def test_source_type_is_bluesky(self):
+        post = BlueskyPost(
+            source='https://bsky.app/profile/alice',
+            author='Alice',
+            description='hi',
+            direct_link='https://bsky.app/profile/alice/post/xyz',
+            created_at='2026-04-19T12:34:56Z',
+            urls=['https://example.com/a'],
+        )
+        self.assertEqual(post.source_type, 'bluesky')
 
 
 class ClampDateNotInFutureTests(unittest.TestCase):
@@ -265,7 +304,7 @@ class ClampDateNotInFutureTests(unittest.TestCase):
         post._generate_unique_url_string()
 
         row = post.get_post_row()
-        clamped_date = row[4]
+        clamped_date = row[5]
         parsed = dt.datetime.strptime(clamped_date, '%Y-%m-%d %H:%M:%S')
         self.assertLess(parsed.year, 2999)
         # In-memory value is untouched; only the persisted column changes.

--- a/ingest/fetchlinks/utils.py
+++ b/ingest/fetchlinks/utils.py
@@ -99,6 +99,7 @@ def normalize_url(url: str, base: str = '') -> str:
 class Post:
     def __init__(self):
         self.source = ''
+        self.source_type = ''
         self.author = ''
         self.description = ''
         self.direct_link = ''
@@ -123,6 +124,7 @@ class Post:
         # Row for the `posts` table; matches db_utils.db_insert column order.
         return (
             self.source,
+            self.source_type,
             self.author,
             self.description,
             self.direct_link,
@@ -136,12 +138,17 @@ class Post:
 
 
 class RssPost(Post):
-    def __init__(self, feed_source, feed_author, post):
+    def __init__(self, feed_source, feed_author, post, site_link=None):
         super().__init__()
-        self.extract_data_from_post(feed_source, feed_author, post)
+        self.extract_data_from_post(feed_source, feed_author, post, site_link)
 
-    def extract_data_from_post(self, feed_source, feed_author, post):
-        self.source = feed_source
+    def extract_data_from_post(self, feed_source, feed_author, post, site_link=None):
+        # Prefer the feed's advertised website (site_link) as the post's
+        # source so the public UI can link "all posts from this feed"
+        # without exposing the feed XML URL. Fall back to the feed URL
+        # when site_link is unknown.
+        self.source = site_link or feed_source
+        self.source_type = 'rss'
         self.author = feed_author
         self.description = post.get('title', '')
         self.direct_link = ''
@@ -167,6 +174,7 @@ class RedditPost(Post):
 
     def extract_data_from_post(self, post):
         self.source = f'https://www.reddit.com/{post["data"]["subreddit_name_prefixed"]}'
+        self.source_type = 'reddit'
         self.author = post['data']['author']
         self.description = post['data']['title']
         self.direct_link = f'https://www.reddit.com{post["data"]["permalink"]}'
@@ -186,6 +194,7 @@ class BlueskyPost(Post):
     def __init__(self, source: str, author: str, description: str, direct_link: str, created_at: str, urls: List[str]):
         super().__init__()
         self.source = source
+        self.source_type = 'bluesky'
         self.author = author
         self.description = description
         self.direct_link = direct_link
@@ -199,6 +208,7 @@ class MastodonPost(Post):
     def __init__(self, source: str, author: str, description: str, direct_link: str, created_at: str, urls: List[str]):
         super().__init__()
         self.source = source
+        self.source_type = 'mastodon'
         self.author = author
         self.description = description
         self.direct_link = direct_link

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -670,7 +670,11 @@ p {
 }
 
 .post-source {
-  max-width: min(560px, 100%);
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+  max-width: min(620px, 100%);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -678,10 +682,42 @@ p {
   font-weight: 700;
 }
 
-.post-source:hover {
+.post-source-type {
+  color: var(--accent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+
+.post-source-sep {
+  color: var(--border-strong);
+  font-weight: 400;
+}
+
+.post-source-mid {
+  color: var(--foreground);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 360px;
+}
+
+.post-source-author {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+a.post-source:hover .post-source-mid,
+a.post-source:hover .post-source-author {
   color: var(--accent);
   text-decoration: underline;
   text-underline-offset: 3px;
+}
+
+a.post-source:hover .post-source-type {
+  color: var(--accent-strong);
 }
 
 .pagination a {
@@ -707,15 +743,66 @@ p {
 
 .post-links {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px 16px;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  gap: 4px;
   padding-top: 8px;
   border-top: 1px solid var(--subtle);
   color: var(--muted);
   font-size: 14px;
   line-height: 1.4;
+}
+
+.post-link-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.post-link-row {
+  display: block;
+  min-width: 0;
+}
+
+.post-link-row a,
+.post-link-row > span {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 0;
+  padding: 2px 6px;
+  margin: 0 -6px;
+  border-radius: 4px;
+  color: var(--link);
+  text-decoration: none;
+  font-weight: 400;
+}
+
+.post-link-row a:hover {
+  background: var(--subtle);
+  color: var(--link-hover);
+}
+
+.post-link-host {
+  flex: 0 0 auto;
+  color: var(--foreground);
+  font-weight: 700;
+}
+
+.post-link-row a:hover .post-link-host {
+  color: var(--link-hover);
+}
+
+.post-link-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
 }
 
 .post-url-actions {
@@ -734,7 +821,8 @@ p {
   color: var(--muted);
 }
 
-.post-links a {
+.post-source-action {
+  align-self: flex-end;
   color: var(--link);
   font-weight: 700;
   text-decoration: underline;
@@ -742,12 +830,69 @@ p {
   text-underline-offset: 3px;
 }
 
-.post-links a:hover {
+.post-source-action:hover {
   color: var(--link-hover);
 }
 
-.post-source-action {
-  margin-left: auto;
+.filter-bar {
+  display: flex;
+  gap: 10px;
+  align-items: end;
+  margin-bottom: 16px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.filter-search {
+  display: grid;
+  flex: 1;
+  min-width: 0;
+  gap: 6px;
+}
+
+.filter-search span {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.filter-search input {
+  width: 100%;
+  min-height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #ffffff;
+  color: var(--foreground);
+  text-overflow: ellipsis;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.filter-actions button {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--accent);
+  color: #ffffff;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.filter-actions button:hover {
+  background: var(--accent-strong);
 }
 
 .state {
@@ -791,7 +936,8 @@ p {
 }
 
 @media (max-width: 900px) {
-  .search-form {
+  .search-form,
+  .filter-bar {
     flex-wrap: wrap;
   }
 }
@@ -820,7 +966,8 @@ p {
     align-items: stretch;
   }
 
-  .search-form {
+  .search-form,
+  .filter-bar {
     flex-direction: column;
     align-items: stretch;
   }
@@ -837,6 +984,10 @@ p {
   .post-source {
     max-width: 100%;
     white-space: normal;
+  }
+
+  .post-source-mid {
+    max-width: 100%;
   }
 
   .pagination {

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -1,35 +1,37 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import type { DomainSummary, PostPage, SourceSummary } from "../models/read-models";
+import type { PostPage } from "../models/read-models";
 import { LatestPostsView, loadLatestPosts } from "./page";
 
 describe("Home", () => {
-  it("renders posts with metadata, extracted URLs, and pagination links", () => {
+  it("renders posts with the source label, extracted URL rows, and pagination links", () => {
     const markup = renderToStaticMarkup(<LatestPostsView result={createReadyResult()} />);
 
     expect(markup).toContain("Latest posts");
     expect(markup).toContain("Newest post");
     expect(markup).toContain("Grace");
-    expect(markup).toContain('href="https://www.reddit.com/r/test"');
+    expect(markup).toContain("reddit/test");
+    expect(markup).toContain('href="/?source_type=reddit&amp;author=Grace"');
     expect(markup).toContain("Apr 28, 2026, 10:00 AM");
     expect(markup).toContain('aria-label="Post links"');
-    expect(markup).toContain('class="post-url-actions"');
-    expect(markup).toContain("link 1");
-    expect(markup).toContain("link 2");
+    expect(markup).toContain('class="post-link-list"');
+    expect(markup).toContain('class="post-link-row"');
+    expect(markup).toContain('class="post-link-host"');
+    expect(markup).toContain('class="post-link-path"');
     expect(markup).toContain('class="post-source-action"');
     expect(markup).toContain("source");
     expect(markup).toContain('href="https://example.com/unshortened-b"');
-    expect(markup).toContain('title="via short.example/b"');
-    expect(markup).not.toContain("Source post");
+    expect(markup).toContain('href="https://example.com/direct-b"');
+    expect(markup).not.toContain(">link 1<");
     expect(markup).toContain('href="/?page=2"');
   });
 
-  it("renders filters and preserves them in pagination links", () => {
+  it("renders a search-only filter bar and preserves filters in pagination links", () => {
     const markup = renderToStaticMarkup(
       <LatestPostsView
         result={createReadyResult({
-          filters: { source: "reddit", domain: "example.com", q: "AI" },
+          filters: { sourceType: "reddit", author: "Grace", q: "AI" },
           page: createPostPage({ totalPosts: 75 }),
         })}
       />,
@@ -39,29 +41,31 @@ describe("Home", () => {
     expect(markup).toContain('name="q"');
     expect(markup).toContain('aria-label="Filter posts"');
     expect(markup).toContain('value="AI"');
-    expect(markup).toContain("reddit (1)");
-    expect(markup).toContain("example.com (1)");
+    expect(markup).not.toContain('name="source"');
+    expect(markup).not.toContain('name="domain"');
+    expect(markup).toContain("Clear");
     expect(markup).toContain('href="/"');
     expect(markup).toContain(
-      'href="/?source=reddit&amp;domain=example.com&amp;q=AI&amp;page=2"',
+      'href="/?source_type=reddit&amp;author=Grace&amp;q=AI&amp;page=2"',
     );
   });
 
-  it("renders a single extracted URL as link 1", () => {
-    const page = createPostPage();
-    const [post] = page.posts;
+  it("renders the RSS source label as a filter linking by source_type and source", () => {
     const markup = renderToStaticMarkup(
       <LatestPostsView
         result={createReadyResult({
           page: createPostPage({
-            posts: [{ ...post, urls: [post.urls[0]], directLink: null }],
+            posts: [createRssPost()],
           }),
         })}
       />,
     );
 
-    expect(markup).toContain(">link 1</a>");
-    expect(markup).not.toContain(">link</a>");
+    expect(markup).toContain(">rss<");
+    expect(markup).toContain("example.com/blog");
+    expect(markup).toContain(
+      'href="/?source_type=rss&amp;source=https%3A%2F%2Fexample.com%2Fblog"',
+    );
   });
 
   it("renders an empty state when no posts exist", () => {
@@ -104,21 +108,20 @@ describe("Home", () => {
 });
 
 function createReadyResult({
-  domains = createDomainSummaries(),
   filters = {},
   page = createPostPage(),
-  sources = createSourceSummaries(),
 }: {
-  domains?: DomainSummary[];
-  filters?: { source?: string; domain?: string; q?: string };
+  filters?: {
+    source?: string;
+    sourceType?: "rss" | "reddit" | "bluesky" | "mastodon";
+    author?: string;
+    q?: string;
+  };
   page?: PostPage;
-  sources?: SourceSummary[];
 } = {}) {
   return {
     status: "ready" as const,
     page,
-    sources,
-    domains,
     filters,
   };
 }
@@ -129,6 +132,7 @@ function createPostPage(overrides: Partial<PostPage> = {}): PostPage {
       {
         id: 2,
         source: "https://www.reddit.com/r/test",
+        sourceType: "reddit",
         author: "Grace",
         description: "Newest post",
         directLink: "https://example.com/source-post",
@@ -166,34 +170,26 @@ function createPostPage(overrides: Partial<PostPage> = {}): PostPage {
   };
 }
 
-function createSourceSummaries(): SourceSummary[] {
-  return [
-    {
-      source: "reddit",
-      postCount: 1,
-      latestPostDate: "2026-04-28T10:00:00Z",
-    },
-    {
-      source: "rss",
-      postCount: 50,
-      latestPostDate: "2026-04-27T10:00:00Z",
-    },
-  ];
-}
-
-function createDomainSummaries(): DomainSummary[] {
-  return [
-    {
-      domain: "example.com",
-      postCount: 1,
-      urlCount: 2,
-      latestPostDate: "2026-04-28T10:00:00Z",
-    },
-    {
-      domain: "docs.example.org",
-      postCount: 12,
-      urlCount: 12,
-      latestPostDate: "2026-04-27T10:00:00Z",
-    },
-  ];
+function createRssPost(): PostPage["posts"][number] {
+  return {
+    id: 1,
+    source: "https://example.com/blog",
+    sourceType: "rss",
+    author: "Ada",
+    description: "First RSS post",
+    directLink: "https://example.com/post-1",
+    dateCreated: "2026-04-27T10:00:00Z",
+    uniqueId: "rss-1",
+    urls: [
+      {
+        id: 1,
+        postId: 1,
+        position: 0,
+        originalUrl: "https://example.com/a",
+        urlHash: "hash-a",
+        unshortenedUrl: null,
+        href: "https://example.com/a",
+      },
+    ],
+  };
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,16 +2,13 @@ import Link from "next/link";
 
 import { safeExternalHref } from "../lib/safe-external-href";
 import type {
-  DomainSummary,
   PostPage,
   PostSummary,
   PostUrl,
-  SourceSummary,
+  SourceType,
 } from "../models/read-models";
 import {
-  getDomainSummaries,
   getPosts,
-  getSourceSummaries,
   openConfiguredFetchlinksDatabase,
   type PostFilters,
 } from "../server/db";
@@ -26,7 +23,8 @@ type Env = Partial<Record<string, string | undefined>>;
 
 type ActiveFilters = {
   source?: string;
-  domain?: string;
+  sourceType?: SourceType;
+  author?: string;
   q?: string;
 };
 
@@ -34,8 +32,6 @@ type LatestPostsResult =
   | {
       status: "ready";
       page: PostPage;
-      sources: SourceSummary[];
-      domains: DomainSummary[];
       filters: ActiveFilters;
     }
   | {
@@ -43,6 +39,13 @@ type LatestPostsResult =
     };
 
 const POSTS_PER_PAGE = 50;
+
+const VALID_SOURCE_TYPES: readonly SourceType[] = [
+  "rss",
+  "reddit",
+  "bluesky",
+  "mastodon",
+];
 
 const dateFormatter = new Intl.DateTimeFormat("en-US", {
   dateStyle: "medium",
@@ -82,14 +85,6 @@ export function loadLatestPosts({
           page,
           pageSize: POSTS_PER_PAGE,
         }),
-        sources: getSourceSummaries(database, {
-          domain: activeFilters.domain,
-          q: activeFilters.q,
-        }),
-        domains: getDomainSummaries(database, {
-          source: activeFilters.source,
-          q: activeFilters.q,
-        }),
         filters: activeFilters,
       };
     } finally {
@@ -120,18 +115,18 @@ export function LatestPostsView({ result }: { result: LatestPostsResult }) {
   return (
     <main className="shell">
       <PageHeader filters={result.filters} page={page} />
-      <FilterBar
-        domains={result.domains}
-        filters={result.filters}
-        sources={result.sources}
-      />
+      <FilterBar filters={result.filters} />
       {page.posts.length === 0 ? (
         <EmptyPostsState filters={result.filters} page={page} />
       ) : null}
       {page.posts.length > 0 ? (
         <section className="post-list" aria-label="Latest posts">
           {page.posts.map((post) => (
-            <PostListItem key={post.id} post={post} />
+            <PostListItem
+              key={post.id}
+              filters={result.filters}
+              post={post}
+            />
           ))}
         </section>
       ) : null}
@@ -172,21 +167,10 @@ function PageHeader({
   );
 }
 
-function FilterBar({
-  domains,
-  filters,
-  sources,
-}: {
-  domains: DomainSummary[];
-  filters: ActiveFilters;
-  sources: SourceSummary[];
-}) {
-  const sourceOptions = includeActiveSource(sources, filters.source);
-  const domainOptions = includeActiveDomain(domains, filters.domain);
-
+function FilterBar({ filters }: { filters: ActiveFilters }) {
   return (
     <form action="/" aria-label="Filter posts" className="filter-bar" method="get">
-      <label>
+      <label className="filter-search">
         <span>Search</span>
         <input
           defaultValue={filters.q ?? ""}
@@ -195,30 +179,8 @@ function FilterBar({
           type="search"
         />
       </label>
-      <label>
-        <span>Source</span>
-        <select defaultValue={filters.source ?? ""} name="source">
-          <option value="">Any source</option>
-          {sourceOptions.map((source) => (
-            <option key={source.source} value={source.source}>
-              {source.source} ({source.postCount.toLocaleString("en-US")})
-            </option>
-          ))}
-        </select>
-      </label>
-      <label>
-        <span>Domain</span>
-        <select defaultValue={filters.domain ?? ""} name="domain">
-          <option value="">Any domain</option>
-          {domainOptions.map((domain) => (
-            <option key={domain.domain} value={domain.domain}>
-              {domain.domain} ({domain.postCount.toLocaleString("en-US")})
-            </option>
-          ))}
-        </select>
-      </label>
       <div className="filter-actions">
-        <button type="submit">Apply</button>
+        <button type="submit">Search</button>
         {hasActiveFilters(filters) ? (
           <Link className="clear-filters" href="/">
             Clear
@@ -245,28 +207,20 @@ function EmptyPostsState({ filters, page }: { filters: ActiveFilters; page: Post
   );
 }
 
-function PostListItem({ post }: { post: PostSummary }) {
-  const sourceHref = safeExternalHref(post.source);
+function PostListItem({
+  filters,
+  post,
+}: {
+  filters: ActiveFilters;
+  post: PostSummary;
+}) {
   const directHref = safeExternalHref(post.directLink);
+
   return (
     <article className="post-item">
       <header className="post-heading">
         <div className="post-meta">
-          {sourceHref ? (
-            <a
-              className="post-source"
-              href={sourceHref}
-              rel="noreferrer"
-              target="_blank"
-              title={post.source}
-            >
-              {getSourceLabel(post)}
-            </a>
-          ) : (
-            <span className="post-source" title={post.source}>
-              {getSourceLabel(post)}
-            </span>
-          )}
+          <SourceLabel currentQ={filters.q} post={post} />
           <span aria-hidden="true" className="post-meta-separator">
             /
           </span>
@@ -275,15 +229,13 @@ function PostListItem({ post }: { post: PostSummary }) {
       </header>
       <h2>{post.description ?? "Untitled post"}</h2>
       {post.urls.length > 0 || directHref ? (
-        <nav aria-label="Post links" className="post-links">
+        <div className="post-links">
           {post.urls.length > 0 ? (
-            <span className="post-url-actions">
-              {post.urls.map((url, index) => (
-                <PostLinkAction key={url.id} showSeparator={index > 0}>
-                  <PostUrlItem label={`link ${index + 1}`} url={url} />
-                </PostLinkAction>
+            <ul className="post-link-list" aria-label="Post links">
+              {post.urls.map((url) => (
+                <PostLinkRow key={url.id} url={url} />
               ))}
-            </span>
+            </ul>
           ) : null}
           {directHref ? (
             <a
@@ -295,45 +247,83 @@ function PostListItem({ post }: { post: PostSummary }) {
               source
             </a>
           ) : null}
-        </nav>
+        </div>
       ) : null}
     </article>
   );
 }
 
-function PostLinkAction({
-  children,
-  showSeparator,
+function SourceLabel({
+  currentQ,
+  post,
 }: {
-  children: React.ReactNode;
-  showSeparator: boolean;
+  currentQ: string | undefined;
+  post: PostSummary;
 }) {
-  return (
-    <span className="post-link-action">
-      {showSeparator ? <span className="post-link-separator">,</span> : null}
-      {children}
-    </span>
-  );
-}
+  const descriptor = getSourceDescriptor(post);
+  const filterHref = buildSourceFilterHref(descriptor, currentQ);
+  const title = descriptor.tooltip ?? post.source;
 
-function PostUrlItem({ label, url }: { label: string; url: PostUrl }) {
-  const usesUnshortenedUrl = url.href !== url.originalUrl;
-  const href = safeExternalHref(url.href);
-  if (!href) {
+  const content = (
+    <>
+      <span className="post-source-type">{descriptor.typeLabel}</span>
+      {descriptor.middle ? (
+        <>
+          <span className="post-source-sep">·</span>
+          <span className="post-source-mid">{descriptor.middle}</span>
+        </>
+      ) : null}
+      {descriptor.author ? (
+        <>
+          <span className="post-source-sep">·</span>
+          <span className="post-source-author">{descriptor.author}</span>
+        </>
+      ) : null}
+    </>
+  );
+
+  if (filterHref) {
     return (
-      <span title={url.href}>{label}</span>
+      <Link className="post-source" href={filterHref} title={title}>
+        {content}
+      </Link>
     );
   }
 
   return (
-    <a
-      href={href}
-      rel="noreferrer"
-      target="_blank"
-      title={usesUnshortenedUrl ? `via ${formatUrlLabel(url.originalUrl)}` : url.href}
-    >
-      {label}
-    </a>
+    <span className="post-source" title={title}>
+      {content}
+    </span>
+  );
+}
+
+function PostLinkRow({ url }: { url: PostUrl }) {
+  const href = safeExternalHref(url.href);
+  const { hostname, pathLabel } = splitUrlForDisplay(url.href);
+  const usesUnshortenedUrl = url.href !== url.originalUrl;
+  const title = usesUnshortenedUrl
+    ? `${url.href} (via ${url.originalUrl})`
+    : url.href;
+
+  const content = (
+    <>
+      <span className="post-link-host">{hostname || url.href}</span>
+      {pathLabel ? (
+        <span className="post-link-path">{pathLabel}</span>
+      ) : null}
+    </>
+  );
+
+  return (
+    <li className="post-link-row">
+      {href ? (
+        <a href={href} rel="noreferrer" target="_blank" title={title}>
+          {content}
+        </a>
+      ) : (
+        <span title={title}>{content}</span>
+      )}
+    </li>
   );
 }
 
@@ -364,7 +354,8 @@ function getFiltersFromSearchParams(
 ): ActiveFilters {
   return normalizeFilters({
     source: getSingleSearchParam(searchParams, "source"),
-    domain: getSingleSearchParam(searchParams, "domain"),
+    sourceType: getSingleSearchParam(searchParams, "source_type"),
+    author: getSingleSearchParam(searchParams, "author"),
     q: getSingleSearchParam(searchParams, "q"),
   });
 }
@@ -397,8 +388,12 @@ function buildPageHref(page: number, filters: ActiveFilters) {
     params.set("source", filters.source);
   }
 
-  if (filters.domain) {
-    params.set("domain", filters.domain);
+  if (filters.sourceType) {
+    params.set("source_type", filters.sourceType);
+  }
+
+  if (filters.author) {
+    params.set("author", filters.author);
   }
 
   if (filters.q) {
@@ -412,6 +407,118 @@ function buildPageHref(page: number, filters: ActiveFilters) {
   const query = params.toString();
 
   return query ? `/?${query}` : "/";
+}
+
+type SourceDescriptor = {
+  typeLabel: string;
+  middle?: string;
+  author?: string;
+  filter?: {
+    sourceType?: SourceType;
+    source?: string;
+    author?: string;
+  };
+  tooltip?: string;
+};
+
+function getSourceDescriptor(post: PostSummary): SourceDescriptor {
+  const author = post.author?.trim() || undefined;
+
+  if (post.sourceType === "reddit") {
+    const subreddit = extractRedditSubreddit(post.source);
+
+    return {
+      typeLabel: subreddit ? `reddit/${subreddit}` : "reddit",
+      author,
+      filter: author ? { sourceType: "reddit", author } : undefined,
+      tooltip: post.source,
+    };
+  }
+
+  if (post.sourceType === "bluesky" || post.sourceType === "mastodon") {
+    return {
+      typeLabel: post.sourceType,
+      author,
+      filter: author
+        ? { sourceType: post.sourceType, author }
+        : undefined,
+      tooltip: post.source,
+    };
+  }
+
+  if (post.sourceType === "rss") {
+    return {
+      typeLabel: "rss",
+      middle: formatUrlLabel(post.source),
+      author,
+      filter: { sourceType: "rss", source: post.source },
+      tooltip: post.source,
+    };
+  }
+
+  return {
+    typeLabel: formatUrlLabel(post.source),
+    author,
+    filter: post.source ? { source: post.source } : undefined,
+    tooltip: post.source,
+  };
+}
+
+function buildSourceFilterHref(
+  descriptor: SourceDescriptor,
+  currentQ: string | undefined,
+) {
+  if (!descriptor.filter) {
+    return undefined;
+  }
+
+  const params = new URLSearchParams();
+
+  if (descriptor.filter.sourceType) {
+    params.set("source_type", descriptor.filter.sourceType);
+  }
+
+  if (descriptor.filter.source) {
+    params.set("source", descriptor.filter.source);
+  }
+
+  if (descriptor.filter.author) {
+    params.set("author", descriptor.filter.author);
+  }
+
+  if (currentQ) {
+    params.set("q", currentQ);
+  }
+
+  const query = params.toString();
+
+  return query ? `/?${query}` : "/";
+}
+
+function extractRedditSubreddit(source: string): string | undefined {
+  try {
+    const url = new URL(source);
+    const match = url.pathname.match(/^\/r\/([^/]+)/i);
+
+    return match?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+function splitUrlForDisplay(value: string): {
+  hostname: string;
+  pathLabel: string;
+} {
+  try {
+    const url = new URL(value);
+    const pathLabel = `${url.pathname}${url.search}${url.hash}`;
+    const cleanPath = pathLabel === "/" ? "" : pathLabel;
+
+    return { hostname: url.hostname, pathLabel: cleanPath };
+  } catch {
+    return { hostname: value, pathLabel: "" };
+  }
 }
 
 function formatPostDate(value: string) {
@@ -430,16 +537,13 @@ function formatUrlLabel(value: string) {
   }
 }
 
-function getSourceLabel(post: PostSummary) {
-  return post.author?.trim() || formatUrlLabel(post.source);
-}
-
 function normalizeFilters(filters: PostFilters): ActiveFilters {
   const source = normalizeOptionalText(filters.source);
-  const domain = normalizeOptionalText(filters.domain)?.toLowerCase();
+  const sourceType = normalizeSourceType(filters.sourceType);
+  const author = normalizeOptionalText(filters.author);
   const q = normalizeOptionalText(filters.q);
 
-  return { source, domain, q };
+  return { source, sourceType, author, q };
 }
 
 function normalizeOptionalText(value: string | undefined): string | undefined {
@@ -448,31 +552,14 @@ function normalizeOptionalText(value: string | undefined): string | undefined {
   return text ? text : undefined;
 }
 
+function normalizeSourceType(value: string | undefined): SourceType | undefined {
+  const text = value?.trim().toLowerCase();
+
+  return VALID_SOURCE_TYPES.find((t) => t === text);
+}
+
 function hasActiveFilters(filters: ActiveFilters) {
-  return Boolean(filters.source || filters.domain || filters.q);
-}
-
-function includeActiveSource(
-  sources: SourceSummary[],
-  activeSource: string | undefined,
-): SourceSummary[] {
-  if (!activeSource || sources.some((source) => source.source === activeSource)) {
-    return sources;
-  }
-
-  return [{ source: activeSource, postCount: 0, latestPostDate: null }, ...sources];
-}
-
-function includeActiveDomain(
-  domains: DomainSummary[],
-  activeDomain: string | undefined,
-): DomainSummary[] {
-  if (!activeDomain || domains.some((domain) => domain.domain === activeDomain)) {
-    return domains;
-  }
-
-  return [
-    { domain: activeDomain, postCount: 0, urlCount: 0, latestPostDate: null },
-    ...domains,
-  ];
+  return Boolean(
+    filters.source || filters.sourceType || filters.author || filters.q,
+  );
 }

--- a/web/src/models/read-models.test.ts
+++ b/web/src/models/read-models.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 
 import type {
-  DomainSummary,
   PostPage,
   PostSummary,
   PostUrl,
-  SourceSummary,
+  SourceType,
 } from "./read-models";
 
 describe("read models", () => {
@@ -22,7 +21,8 @@ describe("read models", () => {
 
     const post = {
       id: 1,
-      source: "rss",
+      source: "https://example.com/feed",
+      sourceType: "rss",
       author: null,
       description: "A collected link",
       directLink: "https://example.com/post",
@@ -34,6 +34,7 @@ describe("read models", () => {
     expect(post.urls[0]?.href).toBe("https://example.com/a");
     expectTypeOf<PostSummary["urls"][number]>().toEqualTypeOf<PostUrl>();
     expectTypeOf<PostUrl["unshortenedUrl"]>().toEqualTypeOf<string | null>();
+    expectTypeOf<PostSummary["sourceType"]>().toEqualTypeOf<SourceType | null>();
   });
 
   it("models paginated post results", () => {
@@ -51,27 +52,12 @@ describe("read models", () => {
     expectTypeOf<PostPage["posts"][number]>().toEqualTypeOf<PostSummary>();
   });
 
-  it("models source and domain summaries", () => {
-    const sourceSummary = {
-      source: "reddit",
-      postCount: 12,
-      latestPostDate: "2026-04-28T12:00:00Z",
-    } satisfies SourceSummary;
+  it("constrains source type to the supported ingest sources", () => {
+    const types: SourceType[] = ["rss", "reddit", "bluesky", "mastodon"];
 
-    const domainSummary = {
-      domain: "example.com",
-      postCount: 4,
-      urlCount: 9,
-      latestPostDate: null,
-    } satisfies DomainSummary;
-
-    expect(sourceSummary.postCount).toBe(12);
-    expect(domainSummary.latestPostDate).toBeNull();
-    expectTypeOf<SourceSummary["latestPostDate"]>().toEqualTypeOf<
-      string | null
-    >();
-    expectTypeOf<DomainSummary["latestPostDate"]>().toEqualTypeOf<
-      string | null
+    expect(types).toHaveLength(4);
+    expectTypeOf<SourceType>().toEqualTypeOf<
+      "rss" | "reddit" | "bluesky" | "mastodon"
     >();
   });
 });

--- a/web/src/models/read-models.ts
+++ b/web/src/models/read-models.ts
@@ -2,6 +2,8 @@ export type DatabaseId = number;
 
 export type IsoDateString = string;
 
+export type SourceType = "rss" | "reddit" | "bluesky" | "mastodon";
+
 export type PostUrl = {
   id: DatabaseId;
   postId: DatabaseId;
@@ -15,6 +17,7 @@ export type PostUrl = {
 export type PostSummary = {
   id: DatabaseId;
   source: string;
+  sourceType: SourceType | null;
   author: string | null;
   description: string | null;
   directLink: string | null;
@@ -31,17 +34,4 @@ export type PostPage = {
   totalPages: number;
   hasPreviousPage: boolean;
   hasNextPage: boolean;
-};
-
-export type SourceSummary = {
-  source: string;
-  postCount: number;
-  latestPostDate: IsoDateString | null;
-};
-
-export type DomainSummary = {
-  domain: string;
-  postCount: number;
-  urlCount: number;
-  latestPostDate: IsoDateString | null;
 };

--- a/web/src/server/db.test.ts
+++ b/web/src/server/db.test.ts
@@ -5,10 +5,8 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
 import {
-  getDomainSummaries,
   getPosts,
   getPostCount,
-  getSourceSummaries,
   openConfiguredFetchlinksDatabase,
   openFetchlinksDatabase,
   withFetchlinksDatabase,
@@ -192,14 +190,22 @@ describe("getPosts", () => {
     const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
 
     try {
-      const page = getPosts(database, {
-        domain: "EXAMPLE.com",
+      const byType = getPosts(database, {
+        sourceType: "rss",
+        page: 1,
+        pageSize: 10,
+      });
+      const byAuthor = getPosts(database, {
+        author: "Linus",
         page: 1,
         pageSize: 10,
       });
 
-      expect(page).toMatchObject({ totalPosts: 2, totalPages: 1 });
-      expect(page.posts.map((post) => post.uniqueId)).toEqual(["reddit-2", "rss-1"]);
+      expect(byType.posts.map((post) => post.uniqueId)).toEqual([
+        "rss-4",
+        "rss-1",
+      ]);
+      expect(byAuthor.posts.map((post) => post.uniqueId)).toEqual(["rss-4"]);
     } finally {
       database.close();
       fixture.cleanup();
@@ -228,8 +234,8 @@ describe("getPosts", () => {
 
     try {
       const page = getPosts(database, {
-        source: "rss",
-        domain: "docs.example.org",
+        sourceType: "rss",
+        author: "Linus",
         q: "tie-break",
       });
 
@@ -259,116 +265,12 @@ describe("getPosts", () => {
   });
 });
 
-describe("getSourceSummaries", () => {
-  it("returns source counts ordered by popularity and name", () => {
-    const fixture = createPostsQueryFixture();
-    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
-
-    try {
-      expect(getSourceSummaries(database)).toEqual([
-        {
-          source: "rss",
-          postCount: 2,
-          latestPostDate: "2026-04-26T10:00:00Z",
-        },
-        {
-          source: "mastodon",
-          postCount: 1,
-          latestPostDate: "2026-04-26T10:00:00Z",
-        },
-        {
-          source: "reddit",
-          postCount: 1,
-          latestPostDate: "2026-04-28T10:00:00Z",
-        },
-      ]);
-    } finally {
-      database.close();
-      fixture.cleanup();
-    }
-  });
-
-  it("can summarize sources after domain and search filters", () => {
-    const fixture = createPostsQueryFixture();
-    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
-
-    try {
-      expect(getSourceSummaries(database, { domain: "example.com", q: "post" })).toEqual([
-        {
-          source: "reddit",
-          postCount: 1,
-          latestPostDate: "2026-04-28T10:00:00Z",
-        },
-        {
-          source: "rss",
-          postCount: 1,
-          latestPostDate: "2026-04-25T10:00:00Z",
-        },
-      ]);
-    } finally {
-      database.close();
-      fixture.cleanup();
-    }
-  });
-});
-
-describe("getDomainSummaries", () => {
-  it("returns URL domain counts from normalized hrefs", () => {
-    const fixture = createPostsQueryFixture();
-    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
-
-    try {
-      expect(getDomainSummaries(database)).toEqual([
-        {
-          domain: "example.com",
-          postCount: 2,
-          urlCount: 3,
-          latestPostDate: "2026-04-28T10:00:00Z",
-        },
-        {
-          domain: "docs.example.org",
-          postCount: 1,
-          urlCount: 1,
-          latestPostDate: "2026-04-26T10:00:00Z",
-        },
-      ]);
-    } finally {
-      database.close();
-      fixture.cleanup();
-    }
-  });
-
-  it("can summarize domains after source and search filters", () => {
-    const fixture = createPostsQueryFixture();
-    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
-
-    try {
-      expect(getDomainSummaries(database, { source: "rss", q: "post" })).toEqual([
-        {
-          domain: "docs.example.org",
-          postCount: 1,
-          urlCount: 1,
-          latestPostDate: "2026-04-26T10:00:00Z",
-        },
-        {
-          domain: "example.com",
-          postCount: 1,
-          urlCount: 1,
-          latestPostDate: "2026-04-25T10:00:00Z",
-        },
-      ]);
-    } finally {
-      database.close();
-      fixture.cleanup();
-    }
-  });
-});
-
 function createFixtureDatabase(): Fixture {
   return createDatabaseWithSql(`
     CREATE TABLE posts (
       idx INTEGER PRIMARY KEY,
       source TEXT NOT NULL,
+      source_type TEXT,
       author TEXT,
       description TEXT,
       direct_link TEXT,
@@ -389,14 +291,15 @@ function createFixtureDatabase(): Fixture {
     INSERT INTO posts (
       idx,
       source,
+      source_type,
       author,
       description,
       direct_link,
       date_created,
       unique_id_string
     ) VALUES
-      (1, 'rss', 'Ada', 'First post', 'https://example.com/first', '2026-04-27T10:00:00Z', 'rss-1'),
-      (2, 'reddit', 'Grace', 'Second post', 'https://example.com/second', '2026-04-28T10:00:00Z', 'reddit-2');
+      (1, 'rss', 'rss', 'Ada', 'First post', 'https://example.com/first', '2026-04-27T10:00:00Z', 'rss-1'),
+      (2, 'reddit', 'reddit', 'Grace', 'Second post', 'https://example.com/second', '2026-04-28T10:00:00Z', 'reddit-2');
 
     INSERT INTO post_urls (
       idx,
@@ -416,6 +319,7 @@ function createPostsQueryFixture(): Fixture {
     CREATE TABLE posts (
       idx INTEGER PRIMARY KEY,
       source TEXT NOT NULL,
+      source_type TEXT,
       author TEXT,
       description TEXT,
       direct_link TEXT,
@@ -436,16 +340,17 @@ function createPostsQueryFixture(): Fixture {
     INSERT INTO posts (
       idx,
       source,
+      source_type,
       author,
       description,
       direct_link,
       date_created,
       unique_id_string
     ) VALUES
-      (1, 'rss', 'Ada', 'Oldest post', 'https://example.com/first', '2026-04-25T10:00:00Z', 'rss-1'),
-      (2, 'reddit', 'Grace', 'Newest post', 'https://example.com/second', '2026-04-28T10:00:00Z', 'reddit-2'),
-      (3, 'mastodon', NULL, NULL, NULL, '2026-04-26T10:00:00Z', 'mastodon-3'),
-      (4, 'rss', 'Linus', 'Tie-break post', 'https://example.com/fourth', '2026-04-26T10:00:00Z', 'rss-4');
+      (1, 'rss', 'rss', 'Ada', 'Oldest post', 'https://example.com/first', '2026-04-25T10:00:00Z', 'rss-1'),
+      (2, 'reddit', 'reddit', 'Grace', 'Newest post', 'https://example.com/second', '2026-04-28T10:00:00Z', 'reddit-2'),
+      (3, 'mastodon', 'mastodon', NULL, NULL, NULL, '2026-04-26T10:00:00Z', 'mastodon-3'),
+      (4, 'rss', 'rss', 'Linus', 'Tie-break post', 'https://example.com/fourth', '2026-04-26T10:00:00Z', 'rss-4');
 
     INSERT INTO post_urls (
       idx,
@@ -487,6 +392,7 @@ function insertPost(database: FetchlinksDatabase): void {
     INSERT INTO posts (
       idx,
       source,
+      source_type,
       author,
       description,
       direct_link,
@@ -494,6 +400,7 @@ function insertPost(database: FetchlinksDatabase): void {
       unique_id_string
     ) VALUES (
       3,
+      'rss',
       'rss',
       'Read Only',
       'This should fail',

--- a/web/src/server/db.ts
+++ b/web/src/server/db.ts
@@ -1,11 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 
-import type {
-  DomainSummary,
-  PostPage,
-  PostUrl,
-  SourceSummary,
-} from "../models/read-models";
+import type { PostPage, PostUrl, SourceType } from "../models/read-models";
 import { loadAppConfig, type AppConfig } from "./config";
 
 type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
@@ -25,13 +20,15 @@ type PostFilterQuery = {
 
 type NormalizedPostFilters = {
   source?: string;
-  domain?: string;
+  sourceType?: SourceType;
+  author?: string;
   q?: string;
 };
 
 type PostRow = {
   id: number;
   source: string;
+  sourceType: SourceType | null;
   author: string | null;
   description: string | null;
   directLink: string | null;
@@ -48,22 +45,10 @@ type PostUrlRow = {
   unshortenedUrl: string | null;
 };
 
-type SourceSummaryRow = {
-  source: string;
-  postCount: number;
-  latestPostDate: string | null;
-};
-
-type DomainSummaryRow = {
-  domain: string;
-  postCount: number;
-  urlCount: number;
-  latestPostDate: string | null;
-};
-
 export type PostFilters = {
   source?: string;
-  domain?: string;
+  sourceType?: string;
+  author?: string;
   q?: string;
 };
 
@@ -133,6 +118,7 @@ export function getPosts(
       SELECT
         idx AS id,
         source,
+        source_type AS sourceType,
         author,
         description,
         direct_link AS directLink,
@@ -161,67 +147,6 @@ export function getPosts(
     hasPreviousPage: page > 1,
     hasNextPage: page < totalPages,
   };
-}
-
-export function getSourceSummaries(
-  database: FetchlinksDatabase,
-  filters: PostFilters = {},
-): SourceSummary[] {
-  const filterQuery = buildPostFilterQuery(normalizePostFilters(filters));
-  const rows = database
-    .prepare(`
-      SELECT
-        source,
-        COUNT(*) AS postCount,
-        MAX(date_created) AS latestPostDate
-      FROM posts
-      ${toWhereSql(filterQuery.clauses)}
-      GROUP BY source
-      ORDER BY postCount DESC, source ASC
-    `)
-    .all(...filterQuery.params) as SourceSummaryRow[];
-
-  return rows;
-}
-
-export function getDomainSummaries(
-  database: FetchlinksDatabase,
-  filters: PostFilters = {},
-): DomainSummary[] {
-  const normalizedFilters = normalizePostFilters(filters);
-  const postFilterQuery = buildPostFilterQuery(normalizedFilters, {
-    includeDomain: false,
-  });
-  const clauses = ["url_domains.domain <> ''", ...postFilterQuery.clauses];
-  const params = [...postFilterQuery.params];
-
-  if (normalizedFilters.domain) {
-    clauses.push("url_domains.domain = ?");
-    params.push(normalizedFilters.domain);
-  }
-
-  const rows = database
-    .prepare(`
-      WITH url_domains AS (
-        SELECT
-          post_id AS postId,
-          ${domainSqlExpression("post_urls")} AS domain
-        FROM post_urls
-      )
-      SELECT
-        url_domains.domain,
-        COUNT(DISTINCT url_domains.postId) AS postCount,
-        COUNT(*) AS urlCount,
-        MAX(posts.date_created) AS latestPostDate
-      FROM url_domains
-      INNER JOIN posts ON posts.idx = url_domains.postId
-      ${toWhereSql(clauses)}
-      GROUP BY url_domains.domain
-      ORDER BY postCount DESC, urlCount DESC, url_domains.domain ASC
-    `)
-    .all(...params) as DomainSummaryRow[];
-
-  return rows;
 }
 
 function getFilteredPostCount(
@@ -279,37 +204,26 @@ function getUrlsByPostId(
 
 function buildPostFilterQuery(
   filters: NormalizedPostFilters,
-  {
-    includeSource = true,
-    includeDomain = true,
-    includeSearch = true,
-  }: {
-    includeSource?: boolean;
-    includeDomain?: boolean;
-    includeSearch?: boolean;
-  } = {},
 ): PostFilterQuery {
   const clauses: string[] = [];
   const params: SqlParameter[] = [];
 
-  if (includeSource && filters.source) {
+  if (filters.source) {
     clauses.push("posts.source = ?");
     params.push(filters.source);
   }
 
-  if (includeDomain && filters.domain) {
-    clauses.push(`
-      EXISTS (
-        SELECT 1
-        FROM post_urls domain_urls
-        WHERE domain_urls.post_id = posts.idx
-          AND ${domainSqlExpression("domain_urls")} = ?
-      )
-    `);
-    params.push(filters.domain);
+  if (filters.sourceType) {
+    clauses.push("posts.source_type = ?");
+    params.push(filters.sourceType);
   }
 
-  if (includeSearch && filters.q) {
+  if (filters.author) {
+    clauses.push("posts.author = ?");
+    params.push(filters.author);
+  }
+
+  if (filters.q) {
     const pattern = `%${escapeLikeValue(filters.q.toLowerCase())}%`;
 
     clauses.push(`
@@ -335,12 +249,25 @@ function buildPostFilterQuery(
   return { clauses, params };
 }
 
+const VALID_SOURCE_TYPES: readonly SourceType[] = [
+  "rss",
+  "reddit",
+  "bluesky",
+  "mastodon",
+];
+
+function normalizeSourceType(value: string | undefined): SourceType | undefined {
+  const text = value?.trim().toLowerCase();
+  return VALID_SOURCE_TYPES.find((t) => t === text);
+}
+
 function normalizePostFilters(filters: PostFilters): NormalizedPostFilters {
   const source = normalizeOptionalText(filters.source);
-  const domain = normalizeOptionalText(filters.domain)?.toLowerCase();
+  const sourceType = normalizeSourceType(filters.sourceType);
+  const author = normalizeOptionalText(filters.author);
   const q = normalizeOptionalText(filters.q);
 
-  return { source, domain, q };
+  return { source, sourceType, author, q };
 }
 
 function normalizeOptionalText(value: string | undefined): string | undefined {
@@ -358,15 +285,6 @@ function escapeLikeValue(value: string): string {
     .replaceAll("\\", "\\\\")
     .replaceAll("%", "\\%")
     .replaceAll("_", "\\_");
-}
-
-function domainSqlExpression(tableAlias: string): string {
-  const href = `COALESCE(${tableAlias}.unshortened_url, ${tableAlias}.url)`;
-  const withoutScheme = `CASE WHEN INSTR(${href}, '://') > 0 THEN SUBSTR(${href}, INSTR(${href}, '://') + 3) ELSE ${href} END`;
-  const beforePath = `CASE WHEN INSTR(${withoutScheme}, '/') > 0 THEN SUBSTR(${withoutScheme}, 1, INSTR(${withoutScheme}, '/') - 1) ELSE ${withoutScheme} END`;
-  const beforeQuery = `CASE WHEN INSTR(${beforePath}, '?') > 0 THEN SUBSTR(${beforePath}, 1, INSTR(${beforePath}, '?') - 1) ELSE ${beforePath} END`;
-
-  return `LOWER(CASE WHEN INSTR(${beforeQuery}, '#') > 0 THEN SUBSTR(${beforeQuery}, 1, INSTR(${beforeQuery}, '#') - 1) ELSE ${beforeQuery} END)`;
 }
 
 function normalizePositiveInteger(


### PR DESCRIPTION
Refreshes the public posts page and adds a posts.source_type column to the ingest schema so the UI can pick a per-type label and filter strategy.

## Ingest

- New 'posts.source_type' column ('rss' | 'reddit' | 'bluesky' | 'mastodon'). Populated in each 'Post' subclass and written by 'db_utils.db_insert'.
- 'db_setup.table_posts_configure' adds an idempotent ALTER for existing databases and indexes 'source_type' and 'author' for fast filtering.
- 'RssPost' now uses the advertised feed 'site_link' as its 'source' when available, falling back to the feed URL. Feed-XML URL stays available internally for resolving relative links.
- New + updated tests in 'test_utils.py'; 296 ingest tests pass.

## Web

- Filter bar simplified to a single search input; the Source / Domain dropdowns are gone.
- Each post now shows a clickable per-type label:
  - 'rss · <hostname/path of site_link> · <author?>'
  - 'reddit/<subreddit> · <author>'
  - 'bluesky · <author>'
  - 'mastodon · <author>'
- Click semantics:
  - rss -> '?source_type=rss&source=<site_link>'
  - socials -> '?source_type=<type>&author=<username>'
  - any active '?q=' is preserved.
- Extracted URLs render as a vertical list (hostname bold + path muted), one anchor per row, replacing the old 'link 1, link 2' nav.
- 'db.ts' gains 'source_type' / 'author' filters and selects 'source_type AS sourceType'. 'getSourceSummaries' / 'getDomainSummaries' and the unused 'domain' filter are removed.
- 'safeExternalHref' continues to guard every outbound href.

## Verification

- 'npm run validate' (lint, typecheck, vitest, build) all green; 53 web tests pass.
- 296 ingest tests pass.

## Follow-up

- Existing rows have NULL 'source_type' until re-ingested; user will re-run ingest after merge.
