### PR TITLE
web: push post date to the far right of the heading row

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -398,6 +398,15 @@ p {
   line-height: 1.4;
 }
 
+.post-date {
+  flex-shrink: 0;
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
 .post-meta-separator {
   color: var(--border);
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -221,11 +221,10 @@ function PostListItem({
       <header className="post-heading">
         <div className="post-meta">
           <SourceLabel currentQ={filters.q} post={post} />
-          <span aria-hidden="true" className="post-meta-separator">
-            /
-          </span>
-          <time dateTime={post.dateCreated}>{formatPostDate(post.dateCreated)}</time>
         </div>
+        <time className="post-date" dateTime={post.dateCreated}>
+          {formatPostDate(post.dateCreated)}
+        </time>
       </header>
       <h2>{post.description ?? "Untitled post"}</h2>
       {post.urls.length > 0 || directHref ? (


### PR DESCRIPTION
Moves the post date out of '.post-meta' into the heading row with 'margin-left: auto' so it sits flush right instead of next to the source label.

Verified: 53 web tests pass.