### PR TITLE
Split PLAN.md into committed OVERVIEW.md and deploy runbook

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,0 +1,122 @@
+# Fetchlinks overview
+
+Fetchlinks ingests links shared on RSS, Reddit, Bluesky, and Mastodon into a
+single SQLite database and serves them through a server-rendered Next.js web
+app. It runs on one small Ubuntu VM with the smallest possible operational
+surface.
+
+For how to deploy and operate it on a VM, see [deploy/README.md](deploy/README.md).
+For forward-looking work and history, see `PLAN.md` (local, untracked).
+
+## Goal
+
+Deploy Fetchlinks on a single Ubuntu 24.04 VM with the smallest possible
+operational surface:
+
+- Stand up a fresh VM in Azure (manual, a few clicks, once or twice a year).
+- SSH in, run **one script**, get a working system. Run a second, separate
+  script when DNS exists and you want public TLS.
+- Re-run either script to update or recover from drift.
+
+No Docker. No Ansible. No container registry. No managed database.
+
+## Architecture
+
+```text
+Azure VM (Ubuntu 24.04 LTS, B1ms, East US)
+  ├─ nginx + certbot                            host TLS reverse proxy (optional, via tls.sh)
+  ├─ Node.js 24                                 runs `next start`
+  ├─ Python 3.12 + venv at /opt/fetchlinks/.venv
+  ├─ /opt/fetchlinks                            git checkout + runtime home
+  ├─ /opt/fetchlinks/ingest/db/fetchlinks.db    SQLite (WAL)
+  ├─ /opt/fetchlinks/ingest/data/config/        fetchlinks.toml + rss_feeds.txt
+  ├─ /opt/fetchlinks/ingest/data/logs/          ingest logs
+  ├─ /opt/fetchlinks/web/.env.production        web env + admin Basic auth
+  ├─ systemd: fetchlinks-web.service            127.0.0.1:3000 (Next.js)
+  ├─ systemd: fetchlinks-ingest.{service,timer} oneshot Python ingest, every 30 min
+  ├─ systemd: fetchlinks-retain.{service,timer} weekly retention + conditional VACUUM
+  └─ systemd: fetchlinks-export-rss-feeds.{service,timer} 5-minute DB → rss_feeds.txt snapshot
+```
+
+Request path: `Internet -> nginx:443 (TLS) -> 127.0.0.1:3000 -> SQLite`
+Ingest path:  `timer -> venv python fetch_links.py -> SQLite`
+Admin path:   `Internet -> nginx:443 -> /admin/* -> HTTP Basic -> SQLite (read-write)`
+
+Public site is read-only; the `/admin` route is an index of admin
+sub-pages (currently just `/admin/feeds` for the RSS feed table). All
+`/admin/*` routes open the DB read-write to manage their respective
+state. Auth is HTTP Basic via env vars
+(`FETCHLINKS_ADMIN_USER` / `FETCHLINKS_ADMIN_PASS`) read by `web/src/proxy.ts`.
+
+## Cost target
+
+| Item | Approx GBP/mo |
+|---|---|
+| B1ms VM (East US) | £11.62 |
+| Standard SSD (~32 GB) | ~£2.50 |
+| Static IP | ~£2.75 |
+| **Total** | **~£17/mo (~$21 USD)** |
+
+## Repository layout
+
+```text
+deploy/
+├── README.md                          how to deploy + operate on a VM
+├── bootstrap.sh                       app + services + firewall installer / updater
+├── tls.sh                             nginx + Let's Encrypt provisioner (separate, idempotent)
+├── nginx/fetchlinks-web.conf.example  nginx site template (rendered by tls.sh)
+└── systemd/
+    ├── fetchlinks-web.service                         Next.js webapp
+    ├── fetchlinks-ingest.{service,timer}              ingest (every 30 min)
+    ├── fetchlinks-retain.{service,timer}              retention (weekly)
+    └── fetchlinks-export-rss-feeds.{service,timer}    feed snapshot (every 5 min)
+
+ingest/                                Python ingest package + tests
+  ├── data/config/fetchlinks.toml      runtime config used in dev + production
+  ├── data/config/rss_feeds.txt        seed file + 5-minute DB snapshot
+  └── db/fetchlinks.db                 SQLite DB (ignored)
+web/                                   Next.js webapp (TypeScript, vitest)
+  ├── .env.production.example          production web env template
+  ├── src/app/page.tsx                 public posts listing
+  ├── src/app/admin/page.tsx           admin index (links to sub-pages)
+  ├── src/app/admin/feeds/             admin UI for the rss_feeds table
+  ├── src/server/                      DB helpers, config loader
+  └── src/proxy.ts                     /admin/* HTTP Basic gate (Next 16 proxy convention)
+```
+
+## Security
+
+- SSH: key-only (Azure default), root login disabled (Ubuntu default).
+- Firewall: `ufw` deny inbound, allow 22/80/443 only.
+- Services run as `fetchlinks`, never root.
+- API credentials live wherever `ingest/data/config/fetchlinks.toml` points;
+  bootstrap does not create, copy, chmod, or otherwise manage them. Web admin
+  credentials live in ignored `web/.env.production`.
+- Web admin (`/admin/*`) is gated by HTTP Basic against
+  `FETCHLINKS_ADMIN_USER` / `FETCHLINKS_ADMIN_PASS` in
+  `/opt/fetchlinks/web/.env.production`. Constant-time credential compare. If either
+  var is unset, `/admin/*` returns 503 instead of granting access.
+- TLS via certbot with auto-renewal timer.
+- Security updates via `unattended-upgrades`.
+
+## Local development
+
+- `npm run dev` in `web/` (or the **Webapp: Dev Server** VS Code task —
+  sets `FETCHLINKS_DB`, `FETCHLINKS_ADMIN_USER`, `FETCHLINKS_ADMIN_PASS`).
+- Host Python venv for ingest, run via the **Ingest: Run** task.
+- `npm run validate` in `web/` for lint + typecheck + tests + build.
+- `pytest` (under `.venv`) for the Python suite.
+
+## Baseline facts
+
+- Reddit, Bluesky, Mastodon, and RSS are **all live in production** with
+  credentials at the paths referenced by `ingest/data/config/fetchlinks.toml`.
+  New credentialed sources need config entries and matching external files.
+- The DB is the live source of truth for posts, URLs, and `rss_feeds`.
+  `rss_feeds.txt` is seed input on first install and is then refreshed from
+  the DB every 5 minutes for review, backup, and occasional repo commits.
+- `bootstrap.sh` is idempotent and is also the upgrade path. There is no
+  separate "deploy" or "release" script.
+- The web app is server-rendered, forms-only (no client JS), opens the DB
+  read-only on the public pages and read-write on `/admin/*`. SQLite is
+  in WAL mode; concurrent ingest writes don't block reads.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The shared boundary between the apps is the SQLite database. The ingest app owns
 creating and updating the database; the web app opens it read-only via the
 `FETCHLINKS_DB` environment variable.
 
+For project orientation (goal, architecture, cost, layout, security) see
+[OVERVIEW.md](OVERVIEW.md). For deploy and operations see
+[deploy/README.md](deploy/README.md).
+
 ## Quick Start
 
 Install and run the ingest app. Create the virtualenv at `.venv` in the

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -111,6 +111,53 @@ To deploy a specific tag/branch:
 sudo FETCHLINKS_REPO_REF=v1.2.3 /opt/fetchlinks/deploy/bootstrap.sh
 ```
 
+## What `bootstrap.sh` does
+
+In order:
+
+1. Sanity-checks root + Ubuntu.
+2. `apt-get install` base packages, Python 3.12 toolchain, Node 24 (NodeSource),
+   sqlite3, ufw, unattended-upgrades. **No nginx here** — that's `tls.sh`.
+3. Enables the unattended-upgrades schedule.
+4. Creates the `fetchlinks` system user/group and standard directories under
+   `/opt/fetchlinks` (`ingest/db`, `ingest/data/logs`, `ingest/data/config`).
+5. Configures `ufw` (deny inbound, allow 22/80/443).
+6. Clones or fast-forwards the repo at `/opt/fetchlinks` using
+   `git merge --ff-only` (no destructive reset).
+7. Builds the Python venv and installs `ingest/requirements.txt`.
+8. `npm ci && npm run build` in `web/`.
+9. Seeds `/opt/fetchlinks/web/.env.production` from
+   `web/.env.production.example` if missing, then preserves it on upgrade.
+10. Installs the seven systemd units (web + ingest + retain + export-rss-feeds),
+    daemon-reload, enable + start.
+11. On first run, seeds the `rss_feeds` SQLite table from
+    `/opt/fetchlinks/ingest/data/config/rss_feeds.txt` (no-op once the table
+    has any rows), then immediately exports the DB snapshot back to that file.
+
+## What `tls.sh` does
+
+Decoupled from bootstrap so you can stand the box up before DNS exists and
+add TLS later, or re-run only the TLS step when changing domain.
+
+1. Requires `FETCHLINKS_DOMAIN` + `FETCHLINKS_EMAIL` (env or positional args).
+2. Bails if `bootstrap.sh` hasn't already run (looks for the nginx site
+   template in the repo).
+3. `apt-get install nginx python3-certbot-nginx`.
+4. Renders `deploy/nginx/fetchlinks-web.conf.example` for the domain,
+   enables the site, removes the default nginx welcome site, reloads nginx.
+5. Runs `certbot --nginx --redirect` to obtain (or renew) the cert.
+6. Enables `certbot.timer` for unattended renewals.
+
+## Rebuild drill
+
+1. Provision a new Ubuntu VM, point DNS at it.
+2. SSH in, run `bootstrap.sh`.
+3. `scp` the credential JSON files (and optionally a `fetchlinks.db`
+   snapshot) into place. Set the admin user/pass in
+   `/opt/fetchlinks/web/.env.production` and `systemctl restart fetchlinks-web`.
+4. Run `tls.sh` with domain + email.
+5. Done.
+
 ## Day-to-day ops
 
 ```bash


### PR DESCRIPTION
PLAN.md is gitignored, so its architecture, security, and runbook content was invisible in the repo.

- Add committed `OVERVIEW.md` with goal, architecture, cost target, repository layout, security, local development, and baseline facts.
- Fold `bootstrap.sh`/`tls.sh` internals and the rebuild drill into `deploy/README.md`.
- Link both docs from the root `README.md`.

PLAN.md (still ignored) is trimmed locally to just the roadmap and progress log.