### PR TITLE
Read-only Bluesky and Mastodon follows admin pages

### DIFF
--- a/ingest/bluesky_links.py
+++ b/ingest/bluesky_links.py
@@ -15,7 +15,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMELINE_LIMIT = 100
 MAX_TIMELINE_LIMIT = 100
 MAX_PAGES = 10
-
+# Cap pages when mirroring the follows list so a huge graph can't stall ingest.
+FOLLOWS_PAGE_LIMIT = 100
+MAX_FOLLOWS_PAGES = 50
 # Hosts to exclude from extracted links (we don't want to link back to Bluesky itself).
 EXCLUDED_HOSTS = ('bsky.app', 'bsky.social')
 
@@ -249,3 +251,62 @@ def run(
         inserted_count,
         bool(next_cursor),
     )
+
+
+def _self_did(client) -> Optional[str]:
+    me = getattr(client, 'me', None)
+    did = getattr(me, 'did', None) if me is not None else None
+    return did if isinstance(did, str) and did else None
+
+
+def _call_get_follows(client, actor: str, cursor: Optional[str], limit: int) -> Dict[str, Any]:
+    params: Dict[str, Any] = {'actor': actor, 'limit': limit}
+    if cursor:
+        params['cursor'] = cursor
+
+    if hasattr(client, 'app') and hasattr(client.app, 'bsky') and hasattr(client.app.bsky, 'graph'):
+        response = client.app.bsky.graph.get_follows(params=params)
+    else:
+        response = client.get_follows(actor=actor, cursor=cursor, limit=limit)
+
+    return _as_dict(response)
+
+
+def sync_follows(bluesky_config: BlueskySource, db_path: Path) -> None:
+    """Refresh the read-only snapshot of accounts this Bluesky account follows.
+
+    Best-effort: any failure is logged and never raised into the ingest run.
+    """
+    if not bluesky_config.enabled:
+        return
+
+    try:
+        auth_client = BlueskyAuth(str(bluesky_config.credential_location))
+        client = auth_client.get_client()
+
+        actor = _self_did(client) or auth_client.identifier
+        if not actor:
+            logger.warning('Bluesky: could not resolve own actor; skipping follows sync')
+            return
+
+        follows: List[Tuple[str, str, str]] = []
+        cursor: Optional[str] = None
+        for _page in range(1, MAX_FOLLOWS_PAGES + 1):
+            response = _call_get_follows(client, actor, cursor, FOLLOWS_PAGE_LIMIT)
+            page = response.get('follows', [])
+            if not isinstance(page, list) or not page:
+                break
+            for entry in page:
+                profile = _as_dict(entry)
+                did = profile.get('did')
+                handle = profile.get('handle')
+                if isinstance(did, str) and isinstance(handle, str) and did and handle:
+                    follows.append((did, handle, profile.get('displayName') or ''))
+            cursor = response.get('cursor')
+            if not cursor:
+                break
+
+        written = db_utils.db_replace_bluesky_follows(follows, db_path)
+        logger.info('Bluesky: synced %s follows', written)
+    except Exception as exc:  # noqa: BLE001 - best-effort snapshot
+        logger.error('Bluesky: follows sync failed: %s', exc)

--- a/ingest/db_setup.py
+++ b/ingest/db_setup.py
@@ -240,6 +240,43 @@ def table_mastodon_state_configure(conn):
         raise RuntimeError('Failed to configure mastodon_state table') from exc
 
 
+def table_bluesky_follows_configure(conn):
+    try:
+        conn.execute("""
+    CREATE TABLE IF NOT EXISTS bluesky_follows (
+    did          TEXT PRIMARY KEY,
+    handle       TEXT NOT NULL,
+    display_name TEXT,
+    synced_at    TEXT NOT NULL)
+    """)
+        conn.execute(
+            'CREATE INDEX IF NOT EXISTS idx_bluesky_follows_handle '
+            'ON bluesky_follows(handle)'
+        )
+    except sqlite3.OperationalError as exc:
+        raise RuntimeError('Failed to configure bluesky_follows table') from exc
+
+
+def table_mastodon_follows_configure(conn):
+    try:
+        conn.execute("""
+    CREATE TABLE IF NOT EXISTS mastodon_follows (
+    instance_name TEXT NOT NULL,
+    account_id    TEXT NOT NULL,
+    acct          TEXT NOT NULL,
+    display_name  TEXT,
+    url           TEXT,
+    synced_at     TEXT NOT NULL,
+    PRIMARY KEY (instance_name, account_id))
+    """)
+        conn.execute(
+            'CREATE INDEX IF NOT EXISTS idx_mastodon_follows_instance '
+            'ON mastodon_follows(instance_name)'
+        )
+    except sqlite3.OperationalError as exc:
+        raise RuntimeError('Failed to configure mastodon_follows table') from exc
+
+
 def db_initial_setup(db_path):
     db_path = Path(db_path)
     logger.info('Creating or validating %s', db_path)
@@ -255,6 +292,8 @@ def db_initial_setup(db_path):
     table_reddit_state_configure(conn)
     table_subreddits_configure(conn)
     table_mastodon_state_configure(conn)
+    table_bluesky_follows_configure(conn)
+    table_mastodon_follows_configure(conn)
     conn.commit()
     conn.close()
     logger.info('Successfully created DB')

--- a/ingest/db_utils.py
+++ b/ingest/db_utils.py
@@ -166,6 +166,29 @@ def _ensure_mastodon_state_table(db):
     """)
 
 
+def _ensure_bluesky_follows_table(db):
+    db.execute("""
+    CREATE TABLE IF NOT EXISTS bluesky_follows (
+    did          TEXT PRIMARY KEY,
+    handle       TEXT NOT NULL,
+    display_name TEXT,
+    synced_at    TEXT NOT NULL)
+    """)
+
+
+def _ensure_mastodon_follows_table(db):
+    db.execute("""
+    CREATE TABLE IF NOT EXISTS mastodon_follows (
+    instance_name TEXT NOT NULL,
+    account_id    TEXT NOT NULL,
+    acct          TEXT NOT NULL,
+    display_name  TEXT,
+    url           TEXT,
+    synced_at     TEXT NOT NULL,
+    PRIMARY KEY (instance_name, account_id))
+    """)
+
+
 def db_get_rss_feed_states(db_location):
     """Return a {feed_url: (etag, last_modified)} map for all known feeds."""
     try:
@@ -517,3 +540,99 @@ def db_set_mastodon_last_seen_id(source_name, instance_url, last_seen_id, db_loc
             db.commit()
     except sqlite3.Error as exc:
         raise RuntimeError(f'Could not persist mastodon state for {source_name}: {exc}') from exc
+
+
+# --- follows snapshots (read-only mirror of remote social graph) -----------
+
+
+def db_replace_bluesky_follows(follows, db_location):
+    """Replace the entire Bluesky follows snapshot in one transaction.
+
+    ``follows`` is an iterable of ``(did, handle, display_name)`` tuples.
+    The table is fully rewritten so removed follows disappear. Returns the
+    number of rows written.
+    """
+    follows = list(follows)
+    now = datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S')
+    rows = [
+        (did, handle, display_name or None, now)
+        for (did, handle, display_name) in follows
+        if did and handle
+    ]
+    try:
+        with sqlite3.connect(db_location) as db:
+            _ensure_bluesky_follows_table(db)
+            db.execute('DELETE FROM bluesky_follows')
+            if rows:
+                db.executemany(
+                    'INSERT OR REPLACE INTO bluesky_follows '
+                    '(did, handle, display_name, synced_at) VALUES (?, ?, ?, ?)',
+                    rows,
+                )
+            db.commit()
+            return len(rows)
+    except sqlite3.Error as exc:
+        raise RuntimeError(f'Could not persist bluesky follows: {exc}') from exc
+
+
+def db_get_bluesky_follows(db_location):
+    """Return every Bluesky follow as a dict, ordered by handle."""
+    cols = ['did', 'handle', 'display_name', 'synced_at']
+    try:
+        with sqlite3.connect(db_location) as db:
+            _ensure_bluesky_follows_table(db)
+            cur = db.execute(
+                f'SELECT {", ".join(cols)} FROM bluesky_follows '
+                'ORDER BY LOWER(handle)'
+            )
+            return [dict(zip(cols, row)) for row in cur.fetchall()]
+    except sqlite3.Error as exc:
+        raise RuntimeError(f'Could not load bluesky follows: {exc}') from exc
+
+
+def db_replace_mastodon_follows(instance_name, follows, db_location):
+    """Replace the follows snapshot for one Mastodon instance.
+
+    ``follows`` is an iterable of ``(account_id, acct, display_name, url)``
+    tuples. Only rows for ``instance_name`` are rewritten, so other instances
+    are left untouched. Returns the number of rows written.
+    """
+    follows = list(follows)
+    now = datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S')
+    rows = [
+        (instance_name, account_id, acct, display_name or None, url or None, now)
+        for (account_id, acct, display_name, url) in follows
+        if account_id and acct
+    ]
+    try:
+        with sqlite3.connect(db_location) as db:
+            _ensure_mastodon_follows_table(db)
+            db.execute('DELETE FROM mastodon_follows WHERE instance_name = ?', [instance_name])
+            if rows:
+                db.executemany(
+                    'INSERT OR REPLACE INTO mastodon_follows '
+                    '(instance_name, account_id, acct, display_name, url, synced_at) '
+                    'VALUES (?, ?, ?, ?, ?, ?)',
+                    rows,
+                )
+            db.commit()
+            return len(rows)
+    except sqlite3.Error as exc:
+        raise RuntimeError(
+            f'Could not persist mastodon follows for {instance_name}: {exc}'
+        ) from exc
+
+
+def db_get_mastodon_follows(db_location):
+    """Return every Mastodon follow as a dict, ordered by instance then acct."""
+    cols = ['instance_name', 'account_id', 'acct', 'display_name', 'url', 'synced_at']
+    try:
+        with sqlite3.connect(db_location) as db:
+            _ensure_mastodon_follows_table(db)
+            cur = db.execute(
+                f'SELECT {", ".join(cols)} FROM mastodon_follows '
+                'ORDER BY instance_name, LOWER(acct)'
+            )
+            return [dict(zip(cols, row)) for row in cur.fetchall()]
+    except sqlite3.Error as exc:
+        raise RuntimeError(f'Could not load mastodon follows: {exc}') from exc

--- a/ingest/fetch_links.py
+++ b/ingest/fetch_links.py
@@ -43,9 +43,11 @@ def fetch_links(cfg: app_config.AppConfig) -> None:
 
     if cfg.sources.bluesky and cfg.sources.bluesky.enabled:
         bluesky_links.run(cfg.sources.bluesky, db_path, max_age, host_kw, desc_kw)
+        bluesky_links.sync_follows(cfg.sources.bluesky, db_path)
 
     if cfg.sources.mastodon and cfg.sources.mastodon.enabled:
         mastodon_links.run(cfg.sources.mastodon, db_path, max_age, host_kw, desc_kw)
+        mastodon_links.sync_follows(cfg.sources.mastodon, db_path)
 
 
 def main() -> None:

--- a/ingest/mastodon_links.py
+++ b/ingest/mastodon_links.py
@@ -20,7 +20,8 @@ MAX_TIMELINE_LIMIT = 80
 MAX_PAGES = 5
 REQUEST_TIMEOUT_SECONDS = 20
 SUPPORTED_TIMELINES = {'home'}
-
+# Cap pages when mirroring the following list so a huge graph can't stall ingest.
+MAX_FOLLOWING_PAGES = 40
 
 class _StatusContentParser(HTMLParser):
     def __init__(self):
@@ -282,3 +283,101 @@ def run(
         )
 
     logger.info('Inserted %s Mastodon posts into DB', total_inserted)
+
+
+def _verify_credentials_account_id(session: requests.Session, instance_url: str) -> str | None:
+    url = urljoin(_normalize_instance_url(instance_url) + '/', 'api/v1/accounts/verify_credentials')
+    try:
+        response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        payload = response.json()
+    except ValueError as exc:
+        logger.error('Invalid JSON verifying Mastodon credentials for %s: %s', instance_url, exc)
+        return None
+    except requests.RequestException as exc:
+        logger.error('Request error verifying Mastodon credentials for %s: %s', instance_url, exc)
+        return None
+    account_id = payload.get('id') if isinstance(payload, dict) else None
+    return str(account_id) if account_id else None
+
+
+def _next_following_url_from_link_header(link_header: str) -> str | None:
+    if not link_header:
+        return None
+    for link in requests.utils.parse_header_links(link_header):
+        if link.get('rel') == 'next':
+            url = link.get('url')
+            return url or None
+    return None
+
+
+def _fetch_following_pages(session: requests.Session, instance_url: str, account_id: str) -> list[dict]:
+    following: list[dict] = []
+    next_url: str | None = urljoin(
+        _normalize_instance_url(instance_url) + '/',
+        f'api/v1/accounts/{account_id}/following',
+    )
+    params: dict | None = {'limit': 80}
+    for _page in range(1, MAX_FOLLOWING_PAGES + 1):
+        if not next_url:
+            break
+        try:
+            response = session.get(next_url, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            payload = response.json()
+        except ValueError as exc:
+            logger.error('Invalid JSON listing Mastodon following for %s: %s', instance_url, exc)
+            break
+        except requests.RequestException as exc:
+            logger.error('Request error listing Mastodon following for %s: %s', instance_url, exc)
+            break
+        if not isinstance(payload, list) or not payload:
+            break
+        following.extend(payload)
+        # Subsequent pages come from the Link header's `next` URL (which
+        # already carries its own max_id query), so drop our initial params.
+        next_url = _next_following_url_from_link_header(response.headers.get('Link', ''))
+        params = None
+    return following
+
+
+def sync_follows(mastodon_config: MastodonSource, db_path: Path) -> None:
+    """Refresh the read-only follows snapshot for each enabled instance.
+
+    Best-effort: a failure for one instance is logged and does not abort the
+    others, and never raises into the ingest run.
+    """
+    if not mastodon_config.enabled:
+        return
+
+    for instance_config in mastodon_config.instances:
+        if not instance_config.enabled:
+            continue
+        source_name = instance_config.name
+        instance_url = _normalize_instance_url(instance_config.instance_url)
+        try:
+            auth_client = MastodonAuth(str(instance_config.credential_location))
+            with requests.Session() as session:
+                session.headers.update(auth_client.headers)
+                account_id = _verify_credentials_account_id(session, instance_url)
+                if not account_id:
+                    logger.warning(
+                        'Mastodon %s: could not resolve own account id; skipping follows sync',
+                        source_name,
+                    )
+                    continue
+                accounts = _fetch_following_pages(session, instance_url, account_id)
+            follows = [
+                (
+                    str(acc.get('id') or ''),
+                    acc.get('acct') or acc.get('username') or '',
+                    acc.get('display_name') or '',
+                    acc.get('url') or '',
+                )
+                for acc in accounts
+                if isinstance(acc, dict)
+            ]
+            written = db_utils.db_replace_mastodon_follows(source_name, follows, db_path)
+            logger.info('Mastodon %s: synced %s follows', source_name, written)
+        except Exception as exc:  # noqa: BLE001 - best-effort snapshot
+            logger.error('Mastodon %s: follows sync failed: %s', source_name, exc)

--- a/ingest/tests/test_bluesky_links.py
+++ b/ingest/tests/test_bluesky_links.py
@@ -199,5 +199,71 @@ class BlueskyRunTests(unittest.TestCase):
         self.assertEqual(inserted_posts[0].urls, ['https://example.com/recent'])
 
 
+class BlueskySyncFollowsTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = Path('/tmp/db/fetchlinks.db')
+
+    def _config(self, enabled=True):
+        return BlueskySource(
+            enabled=enabled,
+            credential_location=Path('/tmp/bsky.json'),
+            timeline_limit=50,
+        )
+
+    def test_skips_when_disabled(self):
+        with patch.object(bluesky_links, 'BlueskyAuth') as auth_cls, \
+             patch.object(bluesky_links.db_utils, 'db_replace_bluesky_follows') as replace:
+            bluesky_links.sync_follows(self._config(enabled=False), self.db_path)
+        auth_cls.assert_not_called()
+        replace.assert_not_called()
+
+    def test_paginates_and_writes_snapshot(self):
+        client = Mock()
+        client.me.did = 'did:self'
+        auth_client = Mock()
+        auth_client.get_client.return_value = client
+        auth_client.identifier = 'self.bsky.social'
+
+        pages = [
+            {
+                'follows': [
+                    {'did': 'did:a', 'handle': 'a.bsky.social', 'displayName': 'A'},
+                    {'did': 'did:b', 'handle': 'b.bsky.social', 'displayName': ''},
+                ],
+                'cursor': 'page-2',
+            },
+            {
+                'follows': [{'did': 'did:c', 'handle': 'c.bsky.social', 'displayName': 'C'}],
+                'cursor': None,
+            },
+        ]
+
+        with patch.object(bluesky_links, 'BlueskyAuth', return_value=auth_client), \
+             patch.object(bluesky_links, '_call_get_follows', side_effect=pages) as call_follows, \
+             patch.object(bluesky_links.db_utils, 'db_replace_bluesky_follows', return_value=3) as replace:
+            bluesky_links.sync_follows(self._config(), self.db_path)
+
+        # Uses the resolved self DID as the actor, paginates by cursor.
+        self.assertEqual(call_follows.call_args_list[0].args[1], 'did:self')
+        self.assertEqual(call_follows.call_args_list[1].args[2], 'page-2')
+        written = replace.call_args.args[0]
+        self.assertEqual(
+            written,
+            [
+                ('did:a', 'a.bsky.social', 'A'),
+                ('did:b', 'b.bsky.social', ''),
+                ('did:c', 'c.bsky.social', 'C'),
+            ],
+        )
+
+    def test_failure_is_swallowed(self):
+        auth_client = Mock()
+        auth_client.get_client.side_effect = RuntimeError('login failed')
+        with patch.object(bluesky_links, 'BlueskyAuth', return_value=auth_client), \
+             patch.object(bluesky_links.db_utils, 'db_replace_bluesky_follows') as replace:
+            bluesky_links.sync_follows(self._config(), self.db_path)
+        replace.assert_not_called()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/ingest/tests/test_db_setup_extra.py
+++ b/ingest/tests/test_db_setup_extra.py
@@ -23,7 +23,7 @@ class TablesAndSchemaTests(unittest.TestCase):
                 row[0]
                 for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
             }
-        for expected in ('posts', 'post_urls', 'bluesky_state', 'rss_feed_state', 'reddit_state', 'mastodon_state'):
+        for expected in ('posts', 'post_urls', 'bluesky_state', 'rss_feed_state', 'reddit_state', 'mastodon_state', 'bluesky_follows', 'mastodon_follows'):
             self.assertIn(expected, tables)
 
     def test_unique_id_string_constraint(self):

--- a/ingest/tests/test_db_utils.py
+++ b/ingest/tests/test_db_utils.py
@@ -239,5 +239,84 @@ class MastodonStateTests(_TmpDbCase):
         self.assertEqual(rows, [('infosec', 'https://infosec.exchange', '789')])
 
 
+class BlueskyFollowsTests(_TmpDbCase):
+    def test_get_returns_empty_on_fresh_db(self):
+        self.assertEqual(db_utils.db_get_bluesky_follows(self.db_path), [])
+
+    def test_replace_writes_and_reads_back_sorted(self):
+        written = db_utils.db_replace_bluesky_follows(
+            [
+                ('did:zed', 'zed.bsky.social', 'Zed'),
+                ('did:abc', 'abc.bsky.social', 'Abc'),
+            ],
+            self.db_path,
+        )
+        self.assertEqual(written, 2)
+        follows = db_utils.db_get_bluesky_follows(self.db_path)
+        self.assertEqual([f['handle'] for f in follows], ['abc.bsky.social', 'zed.bsky.social'])
+        self.assertEqual(follows[0]['did'], 'did:abc')
+        self.assertTrue(follows[0]['synced_at'])
+
+    def test_replace_is_a_full_snapshot(self):
+        db_utils.db_replace_bluesky_follows([('did:a', 'a.bsky.social', 'A')], self.db_path)
+        db_utils.db_replace_bluesky_follows([('did:b', 'b.bsky.social', 'B')], self.db_path)
+        follows = db_utils.db_get_bluesky_follows(self.db_path)
+        self.assertEqual([f['handle'] for f in follows], ['b.bsky.social'])
+
+    def test_replace_skips_rows_missing_did_or_handle(self):
+        written = db_utils.db_replace_bluesky_follows(
+            [('did:a', 'a.bsky.social', 'A'), ('', 'no-did', 'X'), ('did:c', '', 'Y')],
+            self.db_path,
+        )
+        self.assertEqual(written, 1)
+
+    def test_replace_empty_clears_snapshot(self):
+        db_utils.db_replace_bluesky_follows([('did:a', 'a.bsky.social', 'A')], self.db_path)
+        self.assertEqual(db_utils.db_replace_bluesky_follows([], self.db_path), 0)
+        self.assertEqual(db_utils.db_get_bluesky_follows(self.db_path), [])
+
+
+class MastodonFollowsTests(_TmpDbCase):
+    def test_get_returns_empty_on_fresh_db(self):
+        self.assertEqual(db_utils.db_get_mastodon_follows(self.db_path), [])
+
+    def test_replace_writes_per_instance_and_reads_sorted(self):
+        written = db_utils.db_replace_mastodon_follows(
+            'infosec',
+            [
+                ('2', 'zed', 'Zed', 'https://infosec.exchange/@zed'),
+                ('1', 'abe', 'Abe', 'https://infosec.exchange/@abe'),
+            ],
+            self.db_path,
+        )
+        self.assertEqual(written, 2)
+        follows = db_utils.db_get_mastodon_follows(self.db_path)
+        self.assertEqual([f['acct'] for f in follows], ['abe', 'zed'])
+        self.assertEqual(follows[0]['instance_name'], 'infosec')
+
+    def test_replace_only_affects_named_instance(self):
+        db_utils.db_replace_mastodon_follows(
+            'infosec', [('1', 'abe', 'Abe', 'https://infosec.exchange/@abe')], self.db_path
+        )
+        db_utils.db_replace_mastodon_follows(
+            'hachyderm', [('9', 'cleo', 'Cleo', 'https://hachyderm.io/@cleo')], self.db_path
+        )
+        # Re-syncing infosec must not drop hachyderm rows.
+        db_utils.db_replace_mastodon_follows(
+            'infosec', [('1', 'abe', 'Abe', 'https://infosec.exchange/@abe')], self.db_path
+        )
+        follows = db_utils.db_get_mastodon_follows(self.db_path)
+        instances = {f['instance_name'] for f in follows}
+        self.assertEqual(instances, {'infosec', 'hachyderm'})
+
+    def test_replace_skips_rows_missing_id_or_acct(self):
+        written = db_utils.db_replace_mastodon_follows(
+            'infosec',
+            [('1', 'abe', 'Abe', 'u'), ('', 'noid', 'X', 'u'), ('3', '', 'Y', 'u')],
+            self.db_path,
+        )
+        self.assertEqual(written, 1)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/ingest/tests/test_fetch_links.py
+++ b/ingest/tests/test_fetch_links.py
@@ -57,13 +57,17 @@ class FetchLinksRoutingTests(unittest.TestCase):
         with patch.object(fetch_links.rss_links, 'run') as rss_run, \
              patch.object(fetch_links.reddit_links, 'run') as reddit_run, \
              patch.object(fetch_links.bluesky_links, 'run') as bluesky_run, \
-             patch.object(fetch_links.mastodon_links, 'run') as mastodon_run:
+             patch.object(fetch_links.bluesky_links, 'sync_follows') as bluesky_sync, \
+             patch.object(fetch_links.mastodon_links, 'run') as mastodon_run, \
+             patch.object(fetch_links.mastodon_links, 'sync_follows') as mastodon_sync:
             fetch_links.fetch_links(cfg)
 
         rss_run.assert_called_once_with(rss, db_path, default_age, [], [])
         reddit_run.assert_called_once_with(reddit, db_path, default_age, [], [])
         bluesky_run.assert_called_once_with(bluesky, db_path, default_age, [], [])
         mastodon_run.assert_called_once_with(mastodon, db_path, default_age, [], [])
+        bluesky_sync.assert_called_once_with(bluesky, db_path)
+        mastodon_sync.assert_called_once_with(mastodon, db_path)
 
     def test_passes_configured_ingest_age_limit_to_sources(self):
         tmp = Path('/tmp/fl-test')

--- a/ingest/tests/test_mastodon_links.py
+++ b/ingest/tests/test_mastodon_links.py
@@ -351,5 +351,83 @@ class RunTests(unittest.TestCase):
         self.assertEqual(run_instance.call_args_list[1].args, (hachyderm, db_path, 3, [], []))
 
 
+class SyncFollowsTests(unittest.TestCase):
+    def setUp(self):
+        self.db_path = Path('/tmp/db/fetchlinks.db')
+
+    def test_skips_when_source_disabled(self):
+        with patch.object(mastodon_links, 'MastodonAuth') as auth_cls, \
+             patch.object(mastodon_links.db_utils, 'db_replace_mastodon_follows') as replace:
+            mastodon_links.sync_follows(MastodonSource(enabled=False, instances=(_instance(),)), self.db_path)
+        auth_cls.assert_not_called()
+        replace.assert_not_called()
+
+    def test_skips_disabled_instance(self):
+        config = MastodonSource(enabled=True, instances=(_instance(enabled=False),))
+        with patch.object(mastodon_links, 'MastodonAuth') as auth_cls, \
+             patch.object(mastodon_links.db_utils, 'db_replace_mastodon_follows') as replace:
+            mastodon_links.sync_follows(config, self.db_path)
+        auth_cls.assert_not_called()
+        replace.assert_not_called()
+
+    def test_resolves_account_then_writes_snapshot(self):
+        instance_config = _instance(name='infosec', instance_url='https://infosec.exchange/')
+        config = MastodonSource(enabled=True, instances=(instance_config,))
+        auth_client = Mock()
+        auth_client.headers = {'Authorization': 'Bearer tok'}
+        accounts = [
+            {'id': '1', 'acct': 'abe', 'display_name': 'Abe', 'url': 'https://infosec.exchange/@abe'},
+            {'id': '2', 'acct': 'cleo', 'display_name': '', 'url': 'https://infosec.exchange/@cleo'},
+        ]
+
+        with patch.object(mastodon_links, 'MastodonAuth', return_value=auth_client), \
+             patch.object(mastodon_links, '_verify_credentials_account_id', return_value='99') as verify, \
+             patch.object(mastodon_links, '_fetch_following_pages', return_value=accounts) as fetch_following, \
+             patch.object(mastodon_links.db_utils, 'db_replace_mastodon_follows', return_value=2) as replace:
+            mastodon_links.sync_follows(config, self.db_path)
+
+        verify.assert_called_once()
+        self.assertEqual(fetch_following.call_args.args[2], '99')
+        self.assertEqual(replace.call_args.args[0], 'infosec')
+        self.assertEqual(
+            replace.call_args.args[1],
+            [
+                ('1', 'abe', 'Abe', 'https://infosec.exchange/@abe'),
+                ('2', 'cleo', '', 'https://infosec.exchange/@cleo'),
+            ],
+        )
+
+    def test_skips_instance_when_account_id_unresolved(self):
+        config = MastodonSource(enabled=True, instances=(_instance(),))
+        auth_client = Mock()
+        auth_client.headers = {}
+        with patch.object(mastodon_links, 'MastodonAuth', return_value=auth_client), \
+             patch.object(mastodon_links, '_verify_credentials_account_id', return_value=None), \
+             patch.object(mastodon_links.db_utils, 'db_replace_mastodon_follows') as replace:
+            mastodon_links.sync_follows(config, self.db_path)
+        replace.assert_not_called()
+
+    def test_failure_for_one_instance_does_not_abort_others(self):
+        good = _instance(name='infosec')
+        bad = _instance(name='hachyderm', instance_url='https://hachyderm.io')
+        config = MastodonSource(enabled=True, instances=(bad, good))
+        auth_client = Mock()
+        auth_client.headers = {}
+
+        def verify(session, instance_url):
+            if 'hachyderm' in instance_url:
+                raise RuntimeError('boom')
+            return '5'
+
+        with patch.object(mastodon_links, 'MastodonAuth', return_value=auth_client), \
+             patch.object(mastodon_links, '_verify_credentials_account_id', side_effect=verify), \
+             patch.object(mastodon_links, '_fetch_following_pages', return_value=[]), \
+             patch.object(mastodon_links.db_utils, 'db_replace_mastodon_follows', return_value=0) as replace:
+            mastodon_links.sync_follows(config, self.db_path)
+
+        # infosec still synced despite hachyderm raising.
+        self.assertEqual(replace.call_args.args[0], 'infosec')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/web/src/app/admin/bluesky/page.tsx
+++ b/web/src/app/admin/bluesky/page.tsx
@@ -1,0 +1,207 @@
+import type { ReactNode } from "react";
+
+import Link from "next/link";
+
+import { formatRelative } from "../../../lib/format-relative";
+import { safeExternalHref } from "../../../lib/safe-external-href";
+import type { BlueskyFollow } from "../../../models/bluesky-follows";
+import { loadAppConfig } from "../../../server/config";
+import {
+  getBlueskyFollows,
+  withWritableBlueskyDatabase,
+} from "../../../server/bluesky";
+
+type LoadResult =
+  | {
+      status: "ready";
+      follows: BlueskyFollow[];
+      lastSyncedAt: string | null;
+    }
+  | { status: "error" };
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminBlueskyPage() {
+  const result = loadFollows();
+  return <AdminBlueskyView result={result} />;
+}
+
+function loadFollows(): LoadResult {
+  try {
+    const config = loadAppConfig(process.env);
+    return withWritableBlueskyDatabase(config, (db) => {
+      const snapshot = getBlueskyFollows(db);
+      return {
+        status: "ready" as const,
+        follows: snapshot.follows,
+        lastSyncedAt: snapshot.lastSyncedAt,
+      };
+    });
+  } catch {
+    return { status: "error" };
+  }
+}
+
+export function AdminBlueskyView({ result }: { result: LoadResult }) {
+  if (result.status === "error") {
+    return (
+      <main className="shell">
+        <header className="page-header">
+          <div className="page-title">
+            <p className="eyebrow">Fetchlinks admin</p>
+            <h1>Bluesky</h1>
+          </div>
+        </header>
+        <section className="state state-error" role="alert">
+          <h2>Bluesky follows are unavailable</h2>
+          <p>The database could not be opened. Check the server configuration.</p>
+        </section>
+      </main>
+    );
+  }
+
+  const { follows, lastSyncedAt } = result;
+  const syncedLabel = formatRelative(lastSyncedAt);
+
+  return (
+    <main className="shell">
+      <header className="page-header">
+        <div className="page-title">
+          <p className="eyebrow">
+            <Link href="/admin">&larr; Admin</Link>
+          </p>
+          <h1>Bluesky</h1>
+        </div>
+        <div className="feed-counts-tile" aria-label="Bluesky totals">
+          <span className="count-tile count-tile-ok">
+            <strong>{follows.length.toLocaleString("en-US")}</strong>
+            <span>following</span>
+          </span>
+        </div>
+      </header>
+
+      <p className="admin-readonly-note">
+        Read-only mirror of the accounts this Bluesky credential follows. The
+        list is refreshed by the ingest job
+        {syncedLabel ? (
+          <>
+            {" "}
+            (last synced <strong title={lastSyncedAt ?? undefined}>{syncedLabel}</strong>).
+          </>
+        ) : (
+          <> (not synced yet).</>
+        )}
+      </p>
+
+      {follows.length === 0 ? (
+        <section className="state">
+          <h2>No follows</h2>
+          <p>The ingest job has not recorded any Bluesky follows yet.</p>
+        </section>
+      ) : (
+        <section className="post-list" aria-label="Bluesky follows">
+          {follows.map((follow) => (
+            <FollowRow key={follow.did} follow={follow} />
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}
+
+function FollowRow({ follow }: { follow: BlueskyFollow }) {
+  return (
+    <article className="post-item feed-row feed-row-healthy">
+      <header className="feed-row-header">
+        <FollowNameLink follow={follow} />
+      </header>
+      <div className="feed-row-footer">
+        <FollowStats follow={follow} />
+        <nav aria-label="Bluesky follow actions" className="post-links feed-row-actions">
+          {follow.postSource ? <ViewPostsLink source={follow.postSource} /> : null}
+        </nav>
+      </div>
+    </article>
+  );
+}
+
+function FollowNameLink({ follow }: { follow: BlueskyFollow }) {
+  const url = `https://bsky.app/profile/${follow.handle}`;
+  const href = safeExternalHref(url);
+  const label = (
+    <span className="feed-url-host">
+      {follow.displayName ? `${follow.displayName} ` : ""}@{follow.handle}
+    </span>
+  );
+  if (!href) {
+    return (
+      <span className="post-source feed-row-url" title={url}>
+        {label}
+      </span>
+    );
+  }
+  return (
+    <a
+      className="post-source feed-row-url"
+      href={href}
+      rel="noreferrer"
+      target="_blank"
+      title={url}
+    >
+      {label}
+    </a>
+  );
+}
+
+function FollowStats({ follow }: { follow: BlueskyFollow }) {
+  const items: ReactNode[] = [];
+
+  const postLabel = formatRelative(follow.latestPostAt);
+  if (postLabel) {
+    items.push(
+      <span
+        key="post"
+        className="feed-stat"
+        title={follow.latestPostAt ?? undefined}
+      >
+        Newest post <strong>{postLabel}</strong>
+      </span>,
+    );
+  }
+
+  if (items.length === 0) return null;
+  return <div className="feed-stats">{items}</div>;
+}
+
+function ViewPostsLink({ source }: { source: string }) {
+  return (
+    <Link
+      aria-label="View posts from this account"
+      className="feed-action-btn feed-action-btn-icon feed-action-btn-view"
+      href={`/?source=${encodeURIComponent(source)}`}
+      title="View posts from this account"
+    >
+      <ViewPostsIcon />
+    </Link>
+  );
+}
+
+function ViewPostsIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      focusable="false"
+      height="16"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.75"
+      viewBox="0 0 24 24"
+      width="16"
+    >
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}

--- a/web/src/app/admin/mastodon/page.tsx
+++ b/web/src/app/admin/mastodon/page.tsx
@@ -1,0 +1,239 @@
+import type { ReactNode } from "react";
+
+import Link from "next/link";
+
+import { formatRelative } from "../../../lib/format-relative";
+import { safeExternalHref } from "../../../lib/safe-external-href";
+import type { MastodonFollow } from "../../../models/mastodon-follows";
+import { loadAppConfig } from "../../../server/config";
+import {
+  getMastodonFollows,
+  withWritableMastodonDatabase,
+} from "../../../server/mastodon";
+
+type LoadResult =
+  | {
+      status: "ready";
+      follows: MastodonFollow[];
+      lastSyncedAt: string | null;
+    }
+  | { status: "error" };
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminMastodonPage() {
+  const result = loadFollows();
+  return <AdminMastodonView result={result} />;
+}
+
+function loadFollows(): LoadResult {
+  try {
+    const config = loadAppConfig(process.env);
+    return withWritableMastodonDatabase(config, (db) => {
+      const snapshot = getMastodonFollows(db);
+      return {
+        status: "ready" as const,
+        follows: snapshot.follows,
+        lastSyncedAt: snapshot.lastSyncedAt,
+      };
+    });
+  } catch {
+    return { status: "error" };
+  }
+}
+
+export function AdminMastodonView({ result }: { result: LoadResult }) {
+  if (result.status === "error") {
+    return (
+      <main className="shell">
+        <header className="page-header">
+          <div className="page-title">
+            <p className="eyebrow">Fetchlinks admin</p>
+            <h1>Mastodon</h1>
+          </div>
+        </header>
+        <section className="state state-error" role="alert">
+          <h2>Mastodon follows are unavailable</h2>
+          <p>The database could not be opened. Check the server configuration.</p>
+        </section>
+      </main>
+    );
+  }
+
+  const { follows, lastSyncedAt } = result;
+  const syncedLabel = formatRelative(lastSyncedAt);
+  const groups = groupByInstance(follows);
+
+  return (
+    <main className="shell">
+      <header className="page-header">
+        <div className="page-title">
+          <p className="eyebrow">
+            <Link href="/admin">&larr; Admin</Link>
+          </p>
+          <h1>Mastodon</h1>
+        </div>
+        <div className="feed-counts-tile" aria-label="Mastodon totals">
+          <span className="count-tile count-tile-ok">
+            <strong>{follows.length.toLocaleString("en-US")}</strong>
+            <span>following</span>
+          </span>
+        </div>
+      </header>
+
+      <p className="admin-readonly-note">
+        Read-only mirror of the accounts each Mastodon credential follows. The
+        list is refreshed by the ingest job
+        {syncedLabel ? (
+          <>
+            {" "}
+            (last synced <strong title={lastSyncedAt ?? undefined}>{syncedLabel}</strong>).
+          </>
+        ) : (
+          <> (not synced yet).</>
+        )}
+      </p>
+
+      {follows.length === 0 ? (
+        <section className="state">
+          <h2>No follows</h2>
+          <p>The ingest job has not recorded any Mastodon follows yet.</p>
+        </section>
+      ) : (
+        groups.map((group) => (
+          <section
+            key={group.instanceName}
+            className="post-list"
+            aria-label={`Mastodon follows on ${group.instanceName}`}
+          >
+            <h2 className="feed-group-heading">{group.instanceName}</h2>
+            {group.follows.map((follow) => (
+              <FollowRow
+                key={`${follow.instanceName}:${follow.accountId}`}
+                follow={follow}
+              />
+            ))}
+          </section>
+        ))
+      )}
+    </main>
+  );
+}
+
+type InstanceGroup = {
+  instanceName: string;
+  follows: MastodonFollow[];
+};
+
+function groupByInstance(follows: MastodonFollow[]): InstanceGroup[] {
+  const groups = new Map<string, MastodonFollow[]>();
+  for (const follow of follows) {
+    const existing = groups.get(follow.instanceName);
+    if (existing) {
+      existing.push(follow);
+    } else {
+      groups.set(follow.instanceName, [follow]);
+    }
+  }
+  return Array.from(groups, ([instanceName, instanceFollows]) => ({
+    instanceName,
+    follows: instanceFollows,
+  }));
+}
+
+function FollowRow({ follow }: { follow: MastodonFollow }) {
+  return (
+    <article className="post-item feed-row feed-row-healthy">
+      <header className="feed-row-header">
+        <FollowNameLink follow={follow} />
+      </header>
+      <div className="feed-row-footer">
+        <FollowStats follow={follow} />
+        <nav aria-label="Mastodon follow actions" className="post-links feed-row-actions">
+          {follow.postSource ? <ViewPostsLink source={follow.postSource} /> : null}
+        </nav>
+      </div>
+    </article>
+  );
+}
+
+function FollowNameLink({ follow }: { follow: MastodonFollow }) {
+  const url = follow.url ?? "";
+  const href = url ? safeExternalHref(url) : null;
+  const label = (
+    <span className="feed-url-host">
+      {follow.displayName ? `${follow.displayName} ` : ""}@{follow.acct}
+    </span>
+  );
+  if (!href) {
+    return (
+      <span className="post-source feed-row-url" title={url || undefined}>
+        {label}
+      </span>
+    );
+  }
+  return (
+    <a
+      className="post-source feed-row-url"
+      href={href}
+      rel="noreferrer"
+      target="_blank"
+      title={url}
+    >
+      {label}
+    </a>
+  );
+}
+
+function FollowStats({ follow }: { follow: MastodonFollow }) {
+  const items: ReactNode[] = [];
+
+  const postLabel = formatRelative(follow.latestPostAt);
+  if (postLabel) {
+    items.push(
+      <span
+        key="post"
+        className="feed-stat"
+        title={follow.latestPostAt ?? undefined}
+      >
+        Newest post <strong>{postLabel}</strong>
+      </span>,
+    );
+  }
+
+  if (items.length === 0) return null;
+  return <div className="feed-stats">{items}</div>;
+}
+
+function ViewPostsLink({ source }: { source: string }) {
+  return (
+    <Link
+      aria-label="View posts from this account"
+      className="feed-action-btn feed-action-btn-icon feed-action-btn-view"
+      href={`/?source=${encodeURIComponent(source)}`}
+      title="View posts from this account"
+    >
+      <ViewPostsIcon />
+    </Link>
+  );
+}
+
+function ViewPostsIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      focusable="false"
+      height="16"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.75"
+      viewBox="0 0 24 24"
+      width="16"
+    >
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -25,14 +25,14 @@ const SECTIONS: AdminSection[] = [
   {
     href: "/admin/bluesky",
     title: "Bluesky",
-    description: "Manage handles to follow and credentials. (planned)",
-    status: "planned",
+    description: "Read-only view of the accounts this credential follows.",
+    status: "available",
   },
   {
     href: "/admin/mastodon",
     title: "Mastodon",
-    description: "Manage instances, handles, and credentials. (planned)",
-    status: "planned",
+    description: "Read-only view of the accounts each instance follows.",
+    status: "available",
   },
 ];
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -557,6 +557,20 @@ p {
   font-weight: 700;
 }
 
+.admin-readonly-note {
+  margin: 0 0 4px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.feed-group-heading {
+  margin: 0 0 4px;
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: lowercase;
+  color: var(--muted);
+}
+
 .feed-url-path {
   color: var(--muted);
   font-weight: 400;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -150,7 +150,7 @@ function PageHeader({
     <header className="page-header">
       <div className="page-title">
         <p className="eyebrow">
-          Fetchlinks &middot; <Link href="/admin/feeds">admin</Link>
+          Fetchlinks
         </p>
         <h1>Latest posts</h1>
       </div>

--- a/web/src/models/bluesky-follows.ts
+++ b/web/src/models/bluesky-follows.ts
@@ -1,0 +1,13 @@
+export type BlueskyFollow = {
+  did: string;
+  handle: string;
+  displayName: string | null;
+  syncedAt: string;
+  latestPostAt: string | null;
+  postSource: string | null;
+};
+
+export type BlueskyFollowsSnapshot = {
+  follows: BlueskyFollow[];
+  lastSyncedAt: string | null;
+};

--- a/web/src/models/mastodon-follows.ts
+++ b/web/src/models/mastodon-follows.ts
@@ -1,0 +1,15 @@
+export type MastodonFollow = {
+  instanceName: string;
+  accountId: string;
+  acct: string;
+  displayName: string | null;
+  url: string | null;
+  syncedAt: string;
+  latestPostAt: string | null;
+  postSource: string | null;
+};
+
+export type MastodonFollowsSnapshot = {
+  follows: MastodonFollow[];
+  lastSyncedAt: string | null;
+};

--- a/web/src/server/bluesky.test.ts
+++ b/web/src/server/bluesky.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import { getBlueskyFollows, withWritableBlueskyDatabase } from "./bluesky";
+
+type Fixture = {
+  dbPath: string;
+  cleanup: () => void;
+};
+
+function createFixture(seed: (db: DatabaseSync) => void): Fixture {
+  const directory = mkdtempSync(path.join(tmpdir(), "fetchlinks-bsky-"));
+  const dbPath = path.join(directory, "fetchlinks.db");
+  const database = new DatabaseSync(dbPath);
+  database.exec(`
+    CREATE TABLE posts (
+      idx              INTEGER PRIMARY KEY,
+      source           TEXT NOT NULL,
+      source_type      TEXT,
+      author           TEXT,
+      description      TEXT,
+      direct_link      TEXT,
+      date_created     TEXT NOT NULL,
+      unique_id_string TEXT NOT NULL UNIQUE
+    );
+  `);
+  seed(database);
+  database.close();
+  return {
+    dbPath,
+    cleanup: () => rmSync(directory, { force: true, recursive: true }),
+  };
+}
+
+describe("getBlueskyFollows", () => {
+  it("creates the schema on a fresh DB and returns an empty snapshot", () => {
+    const fixture = createFixture(() => {});
+    try {
+      const snapshot = withWritableBlueskyDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => getBlueskyFollows(db),
+      );
+      expect(snapshot.follows).toEqual([]);
+      expect(snapshot.lastSyncedAt).toBeNull();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("returns follows sorted by handle with derived latest post and source", () => {
+    const fixture = createFixture((db) => {
+      db.exec(`
+        CREATE TABLE bluesky_follows (
+          did          TEXT PRIMARY KEY,
+          handle       TEXT NOT NULL,
+          display_name TEXT,
+          synced_at    TEXT NOT NULL
+        );
+        INSERT INTO bluesky_follows (did, handle, display_name, synced_at) VALUES
+          ('did:b', 'beta.bsky.social', 'Beta', '2026-02-01 00:00:00'),
+          ('did:a', 'alpha.bsky.social', NULL, '2026-02-02 00:00:00');
+        INSERT INTO posts
+          (idx, source, source_type, author, description, direct_link, date_created, unique_id_string)
+        VALUES
+          (1, 'https://bsky.app/profile/alpha.bsky.social', 'bluesky', 'Alpha', 'd', 'l', '2026-01-10 00:00:00', 'u1'),
+          (2, 'https://bsky.app/profile/alpha.bsky.social', 'bluesky', 'Alpha', 'd', 'l', '2026-01-20 00:00:00', 'u2');
+      `);
+    });
+    try {
+      const snapshot = withWritableBlueskyDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => getBlueskyFollows(db),
+      );
+      expect(snapshot.follows.map((f) => f.handle)).toEqual([
+        "alpha.bsky.social",
+        "beta.bsky.social",
+      ]);
+      const alpha = snapshot.follows[0];
+      expect(alpha.displayName).toBeNull();
+      expect(alpha.latestPostAt).toBe("2026-01-20 00:00:00");
+      expect(alpha.postSource).toBe(
+        "https://bsky.app/profile/alpha.bsky.social",
+      );
+      const beta = snapshot.follows[1];
+      expect(beta.latestPostAt).toBeNull();
+      expect(beta.postSource).toBeNull();
+      expect(snapshot.lastSyncedAt).toBe("2026-02-02 00:00:00");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/web/src/server/bluesky.ts
+++ b/web/src/server/bluesky.ts
@@ -1,0 +1,112 @@
+import { DatabaseSync } from "node:sqlite";
+
+import type { AppConfig } from "./config";
+import { loadAppConfig } from "./config";
+import {
+  openWritableFetchlinksDatabase,
+  withWritableFetchlinksDatabase,
+  type WritableFetchlinksDatabase,
+} from "./feeds";
+import type {
+  BlueskyFollow,
+  BlueskyFollowsSnapshot,
+} from "../models/bluesky-follows";
+
+type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
+
+type Env = Partial<Record<string, string | undefined>>;
+
+type BlueskyFollowRow = {
+  did: string;
+  handle: string;
+  displayName: string | null;
+  syncedAt: string;
+  latestPostAt: string | null;
+  postSource: string | null;
+};
+
+const BLUESKY_PROFILE_PREFIX = "https://bsky.app/profile/";
+
+const SELECT_COLUMNS = `
+  f.did          AS did,
+  f.handle       AS handle,
+  f.display_name AS displayName,
+  f.synced_at    AS syncedAt,
+  (
+    SELECT MAX(p.date_created) FROM posts p
+    WHERE p.source_type = 'bluesky'
+      AND LOWER(p.source) = '${BLUESKY_PROFILE_PREFIX}' || LOWER(f.handle)
+  )              AS latestPostAt,
+  (
+    SELECT p.source FROM posts p
+    WHERE p.source_type = 'bluesky'
+      AND LOWER(p.source) = '${BLUESKY_PROFILE_PREFIX}' || LOWER(f.handle)
+    LIMIT 1
+  )              AS postSource
+`;
+
+// Idempotent guard so the web admin can read the snapshot even if the
+// ingest bootstrap hasn't created the table yet. Mirrors
+// table_bluesky_follows_configure in ingest/db_setup.py.
+function ensureBlueskyFollowsSchema(database: WritableFetchlinksDatabase): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS bluesky_follows (
+      did          TEXT PRIMARY KEY,
+      handle       TEXT NOT NULL,
+      display_name TEXT,
+      synced_at    TEXT NOT NULL
+    )
+  `);
+  database.exec(
+    "CREATE INDEX IF NOT EXISTS idx_bluesky_follows_handle ON bluesky_follows(handle)",
+  );
+}
+
+export function openWritableBlueskyDatabase(
+  config: DbConfig,
+): WritableFetchlinksDatabase {
+  const database = openWritableFetchlinksDatabase(config);
+  ensureBlueskyFollowsSchema(database);
+  return database;
+}
+
+export function withWritableBlueskyDatabase<T>(
+  config: DbConfig,
+  callback: (database: WritableFetchlinksDatabase) => T,
+): T {
+  return withWritableFetchlinksDatabase(config, (database) => {
+    ensureBlueskyFollowsSchema(database);
+    return callback(database);
+  });
+}
+
+export function openConfiguredWritableBlueskyDatabase(
+  env: Env = process.env,
+): WritableFetchlinksDatabase {
+  return openWritableBlueskyDatabase(loadAppConfig(env));
+}
+
+function rowToFollow(row: BlueskyFollowRow): BlueskyFollow {
+  return {
+    did: row.did,
+    handle: row.handle,
+    displayName: row.displayName,
+    syncedAt: row.syncedAt,
+    latestPostAt: row.latestPostAt,
+    postSource: row.postSource,
+  };
+}
+
+export function getBlueskyFollows(database: DatabaseSync): BlueskyFollowsSnapshot {
+  const rows = database
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM bluesky_follows f ORDER BY LOWER(f.handle) ASC`,
+    )
+    .all() as BlueskyFollowRow[];
+  const follows = rows.map(rowToFollow);
+  const lastSyncedAt = follows.reduce<string | null>((latest, follow) => {
+    if (!latest || follow.syncedAt > latest) return follow.syncedAt;
+    return latest;
+  }, null);
+  return { follows, lastSyncedAt };
+}

--- a/web/src/server/mastodon.test.ts
+++ b/web/src/server/mastodon.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import { getMastodonFollows, withWritableMastodonDatabase } from "./mastodon";
+
+type Fixture = {
+  dbPath: string;
+  cleanup: () => void;
+};
+
+function createFixture(seed: (db: DatabaseSync) => void): Fixture {
+  const directory = mkdtempSync(path.join(tmpdir(), "fetchlinks-masto-"));
+  const dbPath = path.join(directory, "fetchlinks.db");
+  const database = new DatabaseSync(dbPath);
+  database.exec(`
+    CREATE TABLE posts (
+      idx              INTEGER PRIMARY KEY,
+      source           TEXT NOT NULL,
+      source_type      TEXT,
+      author           TEXT,
+      description      TEXT,
+      direct_link      TEXT,
+      date_created     TEXT NOT NULL,
+      unique_id_string TEXT NOT NULL UNIQUE
+    );
+  `);
+  seed(database);
+  database.close();
+  return {
+    dbPath,
+    cleanup: () => rmSync(directory, { force: true, recursive: true }),
+  };
+}
+
+describe("getMastodonFollows", () => {
+  it("creates the schema on a fresh DB and returns an empty snapshot", () => {
+    const fixture = createFixture(() => {});
+    try {
+      const snapshot = withWritableMastodonDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => getMastodonFollows(db),
+      );
+      expect(snapshot.follows).toEqual([]);
+      expect(snapshot.lastSyncedAt).toBeNull();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("returns follows ordered by instance then acct with derived posts", () => {
+    const fixture = createFixture((db) => {
+      db.exec(`
+        CREATE TABLE mastodon_follows (
+          instance_name TEXT NOT NULL,
+          account_id    TEXT NOT NULL,
+          acct          TEXT NOT NULL,
+          display_name  TEXT,
+          url           TEXT,
+          synced_at     TEXT NOT NULL,
+          PRIMARY KEY (instance_name, account_id)
+        );
+        INSERT INTO mastodon_follows
+          (instance_name, account_id, acct, display_name, url, synced_at)
+        VALUES
+          ('infosec', '2', 'zed', 'Zed', 'https://infosec.exchange/@zed', '2026-02-01 00:00:00'),
+          ('infosec', '1', 'abe', NULL, 'https://infosec.exchange/@abe', '2026-02-03 00:00:00'),
+          ('hachyderm', '5', 'kit', 'Kit', 'https://hachyderm.io/@kit', '2026-02-02 00:00:00');
+        INSERT INTO posts
+          (idx, source, source_type, author, description, direct_link, date_created, unique_id_string)
+        VALUES
+          (1, 'https://infosec.exchange/@abe', 'mastodon', 'Abe', 'd', 'l', '2026-01-15 00:00:00', 'u1');
+      `);
+    });
+    try {
+      const snapshot = withWritableMastodonDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (db) => getMastodonFollows(db),
+      );
+      expect(
+        snapshot.follows.map((f) => `${f.instanceName}/${f.acct}`),
+      ).toEqual(["hachyderm/kit", "infosec/abe", "infosec/zed"]);
+      const abe = snapshot.follows.find((f) => f.acct === "abe");
+      expect(abe?.latestPostAt).toBe("2026-01-15 00:00:00");
+      expect(abe?.postSource).toBe("https://infosec.exchange/@abe");
+      const zed = snapshot.follows.find((f) => f.acct === "zed");
+      expect(zed?.latestPostAt).toBeNull();
+      expect(snapshot.lastSyncedAt).toBe("2026-02-03 00:00:00");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});

--- a/web/src/server/mastodon.ts
+++ b/web/src/server/mastodon.ts
@@ -1,0 +1,124 @@
+import { DatabaseSync } from "node:sqlite";
+
+import type { AppConfig } from "./config";
+import { loadAppConfig } from "./config";
+import {
+  openWritableFetchlinksDatabase,
+  withWritableFetchlinksDatabase,
+  type WritableFetchlinksDatabase,
+} from "./feeds";
+import type {
+  MastodonFollow,
+  MastodonFollowsSnapshot,
+} from "../models/mastodon-follows";
+
+type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
+
+type Env = Partial<Record<string, string | undefined>>;
+
+type MastodonFollowRow = {
+  instanceName: string;
+  accountId: string;
+  acct: string;
+  displayName: string | null;
+  url: string | null;
+  syncedAt: string;
+  latestPostAt: string | null;
+  postSource: string | null;
+};
+
+const SELECT_COLUMNS = `
+  f.instance_name AS instanceName,
+  f.account_id    AS accountId,
+  f.acct          AS acct,
+  f.display_name  AS displayName,
+  f.url           AS url,
+  f.synced_at     AS syncedAt,
+  (
+    SELECT MAX(p.date_created) FROM posts p
+    WHERE p.source_type = 'mastodon'
+      AND p.source = f.url
+  )               AS latestPostAt,
+  (
+    SELECT p.source FROM posts p
+    WHERE p.source_type = 'mastodon'
+      AND p.source = f.url
+    LIMIT 1
+  )               AS postSource
+`;
+
+// Idempotent guard so the web admin can read the snapshot even if the
+// ingest bootstrap hasn't created the table yet. Mirrors
+// table_mastodon_follows_configure in ingest/db_setup.py.
+function ensureMastodonFollowsSchema(
+  database: WritableFetchlinksDatabase,
+): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS mastodon_follows (
+      instance_name TEXT NOT NULL,
+      account_id    TEXT NOT NULL,
+      acct          TEXT NOT NULL,
+      display_name  TEXT,
+      url           TEXT,
+      synced_at     TEXT NOT NULL,
+      PRIMARY KEY (instance_name, account_id)
+    )
+  `);
+  database.exec(
+    "CREATE INDEX IF NOT EXISTS idx_mastodon_follows_instance ON mastodon_follows(instance_name)",
+  );
+}
+
+export function openWritableMastodonDatabase(
+  config: DbConfig,
+): WritableFetchlinksDatabase {
+  const database = openWritableFetchlinksDatabase(config);
+  ensureMastodonFollowsSchema(database);
+  return database;
+}
+
+export function withWritableMastodonDatabase<T>(
+  config: DbConfig,
+  callback: (database: WritableFetchlinksDatabase) => T,
+): T {
+  return withWritableFetchlinksDatabase(config, (database) => {
+    ensureMastodonFollowsSchema(database);
+    return callback(database);
+  });
+}
+
+export function openConfiguredWritableMastodonDatabase(
+  env: Env = process.env,
+): WritableFetchlinksDatabase {
+  return openWritableMastodonDatabase(loadAppConfig(env));
+}
+
+function rowToFollow(row: MastodonFollowRow): MastodonFollow {
+  return {
+    instanceName: row.instanceName,
+    accountId: row.accountId,
+    acct: row.acct,
+    displayName: row.displayName,
+    url: row.url,
+    syncedAt: row.syncedAt,
+    latestPostAt: row.latestPostAt,
+    postSource: row.postSource,
+  };
+}
+
+export function getMastodonFollows(
+  database: DatabaseSync,
+): MastodonFollowsSnapshot {
+  const rows = database
+    .prepare(
+      `SELECT ${SELECT_COLUMNS} FROM mastodon_follows f ` +
+        "ORDER BY f.instance_name ASC, LOWER(f.acct) ASC",
+    )
+    .all() as MastodonFollowRow[];
+  const follows = rows.map(rowToFollow);
+  const lastSyncedAt = follows.reduce<string | null>((latest, follow) => {
+    if (!latest || follow.syncedAt > latest) return follow.syncedAt;
+    return latest;
+  }, null);
+  return { follows, lastSyncedAt };
+}


### PR DESCRIPTION
Adds read-only `/admin/bluesky` and `/admin/mastodon` pages backed by ingest-written follows snapshots.

## Ingest
- New `bluesky_follows` and `mastodon_follows` snapshot tables + `db_utils` replace/read helpers (full-snapshot replace; Mastodon scoped per instance).
- `bluesky_links.sync_follows` paginates `app.bsky.graph.getFollows`; `mastodon_links.sync_follows` resolves each instance account then pages `/accounts/{id}/following`. Both best-effort (never raise), run from `fetch_links` after each source.

## Web
- Models + server modules with idempotent schema guards.
- Pages show followed accounts, following count, last-synced freshness, per-account newest-post age (derived via posts joins), and a view-posts link. Mastodon groups by instance.
- Admin index marks both available; removed the admin link from the public home page.

## Tests
- 335 ingest + 70 web tests pass; typecheck and lint clean.