### PR TITLE
Make deployment checkout-relative

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -26,12 +26,12 @@ No Docker. No Ansible. No container registry. No managed database.
 Azure VM (Ubuntu 24.04 LTS, B1ms, East US)
   ├─ nginx + certbot                            host TLS reverse proxy (optional, via tls.sh)
   ├─ Node.js 24                                 runs `next start`
-  ├─ Python 3.12 + venv at /opt/fetchlinks/.venv
-  ├─ /opt/fetchlinks                            git checkout + runtime home
-  ├─ /opt/fetchlinks/ingest/db/fetchlinks.db    SQLite (WAL)
-  ├─ /opt/fetchlinks/ingest/data/config/        fetchlinks.toml + rss_feeds.txt
-  ├─ /opt/fetchlinks/ingest/data/logs/          ingest logs
-  ├─ /opt/fetchlinks/web/.env.production        web env + admin Basic auth
+  ├─ Python 3.12 + venv at <checkout>/.venv
+  ├─ <checkout>                            git checkout + runtime home
+  ├─ <checkout>/ingest/db/fetchlinks.db    SQLite (WAL)
+  ├─ <checkout>/ingest/data/config/        fetchlinks.toml + rss_feeds.txt
+  ├─ <checkout>/ingest/data/logs/          ingest logs
+  ├─ <checkout>/web/.env.production        web env + admin Basic auth
   ├─ systemd: fetchlinks-web.service            127.0.0.1:3000 (Next.js)
   ├─ systemd: fetchlinks-ingest.{service,timer} oneshot Python ingest, every 30 min
   ├─ systemd: fetchlinks-retain.{service,timer} weekly retention + conditional VACUUM
@@ -94,7 +94,7 @@ web/                                   Next.js webapp (TypeScript, vitest)
   credentials live in ignored `web/.env.production`.
 - Web admin (`/admin/*`) is gated by HTTP Basic against
   `FETCHLINKS_ADMIN_USER` / `FETCHLINKS_ADMIN_PASS` in
-  `/opt/fetchlinks/web/.env.production`. Constant-time credential compare. If either
+  `<checkout>/web/.env.production`. Constant-time credential compare. If either
   var is unset, `/admin/*` returns 503 instead of granting access.
 - TLS via certbot with auto-renewal timer.
 - Security updates via `unattended-upgrades`.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ For project orientation (goal, architecture, cost, layout, security) see
 
 Install and run the ingest app. Create the virtualenv at `.venv` in the
 repo root — that's the path the VS Code workspace (`.vscode/settings.json`,
-`.vscode/tasks.json`) and the production layout (`/opt/fetchlinks/.venv`)
-both expect:
+`.vscode/tasks.json`) and the production bootstrap both expect:
 
 ```bash
 python3 -m venv .venv
@@ -57,7 +56,7 @@ npm run validate
 ## Deployment Examples
 
 Example systemd and nginx files for running the web app on a VM live in
-`deploy/`. They are adapted for a single checkout at `/opt/fetchlinks` with the
-web app at `/opt/fetchlinks/web`.
+`deploy/`. Bootstrap renders them for whichever checkout directory contains the
+project, commonly `~/fetchlinks` on the VM.
 
 For detailed setup notes, see `ingest/SETUP.md` and `web/README.md`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,8 +30,8 @@ deploy/
 
     ```bash
     sudo apt-get update && sudo apt-get install -y git
-    sudo git clone https://github.com/poptart-sommelier/fetchlinks.git /opt/fetchlinks
-    sudo /opt/fetchlinks/deploy/bootstrap.sh
+   git clone https://github.com/poptart-sommelier/fetchlinks.git ~/fetchlinks
+   sudo ~/fetchlinks/deploy/bootstrap.sh
     ```
 
    `bootstrap.sh` installs packages, builds the app, installs the systemd
@@ -44,14 +44,14 @@ deploy/
    For each missing enabled source, bootstrap asks whether to configure it.
    Enter either a path to an existing JSON credential file or paste a JSON
    object directly. Pasted JSON is written to the default path from
-   `/opt/fetchlinks/ingest/data/config/fetchlinks.toml`; copied/pasted secrets
-   are owned by `fetchlinks:fetchlinks` and chmod `0600`.
+   `<checkout>/ingest/data/config/fetchlinks.toml`; copied/pasted secrets are
+   owned by `fetchlinks:fetchlinks` and chmod `0600`.
 
    You can skip credential setup at the first prompt and do it later. Bootstrap
    leaves sources enabled when credentials are skipped, so validation may warn
    until those files exist. See `ingest/SETUP.md` for the JSON formats.
 
-   Bootstrap also configures `/opt/fetchlinks/web/.env.production` when it is
+   Bootstrap also configures `<checkout>/web/.env.production` when it is
    missing. The admin password defaults to a generated strong password unless
    you enter your own.
 
@@ -63,7 +63,7 @@ deploy/
    the VM.
 
 5. Optional: copy an existing `fetchlinks.db` to
-   `/opt/fetchlinks/ingest/db/fetchlinks.db`.
+   `<checkout>/ingest/db/fetchlinks.db`.
 
 6. Optional: point a DNS record at the VM, then install nginx and Let's Encrypt
    TLS:
@@ -71,7 +71,7 @@ deploy/
     ```bash
     sudo FETCHLINKS_DOMAIN=fetchlinks.example.com \
          FETCHLINKS_EMAIL=you@example.com \
-         /opt/fetchlinks/deploy/tls.sh
+         ~/fetchlinks/deploy/tls.sh
     ```
 
     `tls.sh` is idempotent — re-run it to rotate cert metadata or after
@@ -80,7 +80,7 @@ deploy/
 ## Updating an existing VM
 
 ```bash
-sudo /opt/fetchlinks/deploy/bootstrap.sh
+sudo ~/fetchlinks/deploy/bootstrap.sh
 ```
 
 The script is idempotent. It fast-forwards the checkout on `master`, reinstalls
@@ -91,8 +91,11 @@ the fast-forward fails and the script stops rather than overwriting work.
 To deploy a specific tag/branch:
 
 ```bash
-sudo FETCHLINKS_REPO_REF=v1.2.3 /opt/fetchlinks/deploy/bootstrap.sh
+sudo FETCHLINKS_REPO_REF=v1.2.3 ~/fetchlinks/deploy/bootstrap.sh
 ```
+
+By default, `bootstrap.sh` uses the checkout that contains the script. To use a
+different checkout path, set `FETCHLINKS_APP_DIR=/absolute/path/to/fetchlinks`.
 
 ## What `bootstrap.sh` does
 
@@ -103,14 +106,14 @@ In order:
    sqlite3, ufw, unattended-upgrades. **No nginx here** — that's `tls.sh`.
 3. Enables the unattended-upgrades schedule.
 4. Creates the `fetchlinks` system user/group and standard directories under
-   `/opt/fetchlinks` (`ingest/db`, `ingest/data/logs`, `ingest/data/config`).
+   the checkout (`ingest/db`, `ingest/data/logs`, `ingest/data/config`).
 5. Configures `ufw` (deny inbound, allow 22/80/443).
-6. Clones or fast-forwards the repo at `/opt/fetchlinks` using
+6. Fast-forwards the checkout using
    `git merge --ff-only` (no destructive reset).
 7. Prompts for missing enabled-source credentials. Each prompt accepts either a
    readable JSON file path or a pasted JSON object. Skipped credentials leave
    sources enabled and produce warnings later.
-8. Prompts for web admin credentials when `/opt/fetchlinks/web/.env.production`
+8. Prompts for web admin credentials when `<checkout>/web/.env.production`
    is missing. Press Enter at the password prompt to generate a strong random
    password.
 9. Builds the Python venv and installs `ingest/requirements.txt`.
@@ -118,7 +121,7 @@ In order:
 11. Installs the seven systemd units (web + ingest + retain + export-rss-feeds),
     daemon-reload, enable + start.
 12. On first run, seeds the `rss_feeds` SQLite table from
-   `/opt/fetchlinks/ingest/data/config/rss_feeds.txt` (no-op once the table
+   `<checkout>/ingest/data/config/rss_feeds.txt` (no-op once the table
    has any rows), then exports the DB snapshot to
    `/var/lib/fetchlinks/rss_feeds.txt`.
 13. Runs per-source ingest validation and prints non-fatal warnings for sources
@@ -144,7 +147,7 @@ add TLS later, or re-run only the TLS step when changing domain.
 2. SSH in, run `bootstrap.sh`.
 3. `scp` the credential JSON files (and optionally a `fetchlinks.db`
    snapshot) into place. Set the admin user/pass in
-   `/opt/fetchlinks/web/.env.production` and `systemctl restart fetchlinks-web`.
+   `<checkout>/web/.env.production` and `systemctl restart fetchlinks-web`.
 4. Run `tls.sh` with domain + email.
 5. Done.
 
@@ -164,15 +167,15 @@ journalctl -u fetchlinks-export-rss-feeds.service --since '7 days ago'
 
 ## Filesystem layout on the VM
 
-```
-/opt/fetchlinks/                       git checkout, owned by fetchlinks
-/opt/fetchlinks/.venv/                 Python venv for ingest
-/opt/fetchlinks/ingest/data/config/fetchlinks.toml  runtime config
-/opt/fetchlinks/ingest/data/config/rss_feeds.txt    first-install seed file
-/var/lib/fetchlinks/rss_feeds.txt                   5-minute DB snapshot
-/opt/fetchlinks/ingest/db/fetchlinks.db             SQLite DB
-/opt/fetchlinks/ingest/data/logs/                   ingest logs
-/opt/fetchlinks/web/.env.production                 env vars for the web service
+```text
+~/fetchlinks/                       git checkout, owned by fetchlinks after bootstrap
+~/fetchlinks/.venv/                 Python venv for ingest
+~/fetchlinks/ingest/data/config/fetchlinks.toml  runtime config
+~/fetchlinks/ingest/data/config/rss_feeds.txt    first-install seed file
+/var/lib/fetchlinks/rss_feeds.txt                5-minute DB snapshot
+~/fetchlinks/ingest/db/fetchlinks.db             SQLite DB
+~/fetchlinks/ingest/data/logs/                   ingest logs
+~/fetchlinks/web/.env.production                 env vars for the web service
 ```
 
 All services run as the unprivileged `fetchlinks` system user.

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -4,8 +4,8 @@
 # Run this ON the VM, as root, from a fresh Ubuntu 24.04 install:
 #
 #   sudo apt-get update && sudo apt-get install -y git
-#   sudo git clone https://github.com/poptart-sommelier/fetchlinks.git /opt/fetchlinks
-#   sudo /opt/fetchlinks/deploy/bootstrap.sh
+#   git clone https://github.com/poptart-sommelier/fetchlinks.git ~/fetchlinks
+#   sudo ~/fetchlinks/deploy/bootstrap.sh
 #
 # Re-running this script later is safe; it acts as the upgrade path
 # (fast-forwards git, rebuilds web, restarts services).
@@ -14,6 +14,7 @@
 # Run it once you have a DNS record pointing at this VM.
 #
 # Optional environment variables:
+#   FETCHLINKS_APP_DIR  checkout directory to install/update (default: parent of this script's deploy/ dir)
 #   FETCHLINKS_REPO_URL git URL to clone/pull (default: poptart-sommelier/fetchlinks)
 #   FETCHLINKS_REPO_REF branch/tag to deploy   (default: master)
 
@@ -21,9 +22,12 @@ set -euo pipefail
 
 # ---- config -----------------------------------------------------------------
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+DEFAULT_APP_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+
 APP_USER="fetchlinks"
 APP_GROUP="fetchlinks"
-APP_DIR="/opt/fetchlinks"
+APP_DIR="$(realpath -m "${FETCHLINKS_APP_DIR:-${DEFAULT_APP_DIR}}")"
 VENV_DIR="${APP_DIR}/.venv"
 INGEST_DIR="${APP_DIR}/ingest"
 WEB_DIR="${APP_DIR}/web"
@@ -42,6 +46,26 @@ REPO_REF="${FETCHLINKS_REPO_REF:-master}"
 log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
 warn() { printf '\n\033[1;33m!!\033[0m %s\n' "$*" >&2; }
 die()  { printf '\n\033[1;31m!!\033[0m %s\n' "$*" >&2; exit 1; }
+
+sed_escape_replacement() {
+    printf '%s' "$1" | sed 's/[\\&|]/\\&/g'
+}
+
+render_systemd_unit() {
+    local source_path="$1"
+    local target_path="$2"
+    local app_dir_escaped=""
+    local state_dir_escaped=""
+
+    app_dir_escaped="$(sed_escape_replacement "${APP_DIR}")"
+    state_dir_escaped="$(sed_escape_replacement "${STATE_DIR}")"
+
+    sed \
+        -e "s|__FETCHLINKS_APP_DIR__|${app_dir_escaped}|g" \
+        -e "s|__FETCHLINKS_STATE_DIR__|${state_dir_escaped}|g" \
+        "${source_path}" >"${target_path}"
+    chmod 0644 "${target_path}"
+}
 
 GENERATED_ADMIN_PASSWORD=""
 declare -a SKIPPED_CREDENTIAL_SOURCES=()
@@ -321,6 +345,7 @@ configure_web_admin_if_missing() {
     local admin_user=""
     local admin_pass=""
     local generated_password=""
+    local app_dir_escaped=""
 
     if [[ -f "${WEB_ENV_FILE}" ]]; then
         printf '  ok - web environment exists at %s\n' "${WEB_ENV_FILE}"
@@ -328,8 +353,11 @@ configure_web_admin_if_missing() {
     fi
 
     log "Configuring web admin credentials"
-    install -o "${APP_USER}" -g "${APP_GROUP}" -m 0600 \
-        "${WEB_DIR}/.env.production.example" "${WEB_ENV_FILE}"
+    app_dir_escaped="$(sed_escape_replacement "${APP_DIR}")"
+    sed "s|__FETCHLINKS_APP_DIR__|${app_dir_escaped}|g" \
+        "${WEB_DIR}/.env.production.example" >"${WEB_ENV_FILE}"
+    chown "${APP_USER}:${APP_GROUP}" "${WEB_ENV_FILE}"
+    chmod 0600 "${WEB_ENV_FILE}"
 
     read -r -p "Admin username [admin]: " admin_user
     admin_user="${admin_user:-admin}"
@@ -636,6 +664,16 @@ if [[ ! -t 0 ]]; then
     die "bootstrap.sh must be run from an interactive terminal because first install may prompt for credentials and admin setup."
 fi
 
+case "${APP_DIR}" in
+    /|/home|/root|/opt|/usr|/var)
+        die "Refusing to use broad install directory: ${APP_DIR}"
+        ;;
+esac
+
+if [[ "${APP_DIR}" =~ [[:space:]] ]]; then
+    die "Install directory must not contain whitespace: ${APP_DIR}"
+fi
+
 # ---- swap -------------------------------------------------------------------
 # A 2 GB VM (B1ms) has little/no swap by default, and `next build` can spike
 # memory enough to OOM. Ensure a swap file exists before the web build.
@@ -693,6 +731,7 @@ log "Ensuring ${APP_USER} user and app directory"
 getent group  "${APP_GROUP}" >/dev/null || groupadd --system "${APP_GROUP}"
 getent passwd "${APP_USER}"  >/dev/null || useradd  --system --gid "${APP_GROUP}" \
     --home-dir "${APP_DIR}" --shell /usr/sbin/nologin "${APP_USER}"
+usermod --home "${APP_DIR}" "${APP_USER}"
 
 install -d -o "${APP_USER}" -g "${APP_GROUP}" -m 0755 "${APP_DIR}"
 chown -R "${APP_USER}:${APP_GROUP}" "${APP_DIR}"
@@ -712,8 +751,6 @@ if [[ -d "${APP_DIR}/.git" ]]; then
     sudo -u "${APP_USER}" git -C "${APP_DIR}" fetch origin "${REPO_REF}"
     sudo -u "${APP_USER}" git -C "${APP_DIR}" merge --ff-only "origin/${REPO_REF}"
 else
-    # The README's bootstrap clones into ${APP_DIR} as root; reset ownership
-    # in case this is the first run after that clone.
     if [[ -d "${APP_DIR}" ]] && [[ -z "$(ls -A "${APP_DIR}")" ]]; then
         sudo -u "${APP_USER}" git clone --branch "${REPO_REF}" "${REPO_URL}" "${APP_DIR}"
     else
@@ -754,12 +791,12 @@ sudo -u "${APP_USER}" env npm_config_cache="${CACHE_DIR}/npm" \
 # ---- systemd units ----------------------------------------------------------
 
 log "Installing systemd units"
-install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-web.service"                 /etc/systemd/system/
-install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-ingest.service"              /etc/systemd/system/
+render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-web.service"              /etc/systemd/system/fetchlinks-web.service
+render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-ingest.service"           /etc/systemd/system/fetchlinks-ingest.service
 install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-ingest.timer"                /etc/systemd/system/
-install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-retain.service"              /etc/systemd/system/
+render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-retain.service"           /etc/systemd/system/fetchlinks-retain.service
 install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-retain.timer"                /etc/systemd/system/
-install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-export-rss-feeds.service"    /etc/systemd/system/
+render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-export-rss-feeds.service" /etc/systemd/system/fetchlinks-export-rss-feeds.service
 install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-export-rss-feeds.timer"      /etc/systemd/system/
 systemctl daemon-reload
 

--- a/deploy/systemd/fetchlinks-export-rss-feeds.service
+++ b/deploy/systemd/fetchlinks-export-rss-feeds.service
@@ -7,8 +7,8 @@ Wants=network-online.target
 Type=oneshot
 User=fetchlinks
 Group=fetchlinks
-WorkingDirectory=/opt/fetchlinks/ingest
-ExecStart=/opt/fetchlinks/.venv/bin/python /opt/fetchlinks/ingest/export_rss_feeds.py --config /opt/fetchlinks/ingest/data/config/fetchlinks.toml --output /var/lib/fetchlinks/rss_feeds.txt
+WorkingDirectory=__FETCHLINKS_APP_DIR__/ingest
+ExecStart=__FETCHLINKS_APP_DIR__/.venv/bin/python __FETCHLINKS_APP_DIR__/ingest/export_rss_feeds.py --config __FETCHLINKS_APP_DIR__/ingest/data/config/fetchlinks.toml --output __FETCHLINKS_STATE_DIR__/rss_feeds.txt
 Nice=10
 TimeoutStartSec=5min
 SyslogIdentifier=fetchlinks-export-rss-feeds
@@ -16,8 +16,8 @@ SyslogIdentifier=fetchlinks-export-rss-feeds
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/opt/fetchlinks/ingest /var/lib/fetchlinks
+ProtectHome=false
+ReadWritePaths=__FETCHLINKS_APP_DIR__/ingest __FETCHLINKS_STATE_DIR__
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/systemd/fetchlinks-ingest.service
+++ b/deploy/systemd/fetchlinks-ingest.service
@@ -7,8 +7,8 @@ Wants=network-online.target
 Type=oneshot
 User=fetchlinks
 Group=fetchlinks
-WorkingDirectory=/opt/fetchlinks/ingest
-ExecStart=/opt/fetchlinks/.venv/bin/python /opt/fetchlinks/ingest/fetch_links.py --config /opt/fetchlinks/ingest/data/config/fetchlinks.toml
+WorkingDirectory=__FETCHLINKS_APP_DIR__/ingest
+ExecStart=__FETCHLINKS_APP_DIR__/.venv/bin/python __FETCHLINKS_APP_DIR__/ingest/fetch_links.py --config __FETCHLINKS_APP_DIR__/ingest/data/config/fetchlinks.toml
 Nice=10
 TimeoutStartSec=30min
 SyslogIdentifier=fetchlinks-ingest
@@ -16,8 +16,8 @@ SyslogIdentifier=fetchlinks-ingest
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/opt/fetchlinks/ingest
+ProtectHome=false
+ReadWritePaths=__FETCHLINKS_APP_DIR__/ingest
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/systemd/fetchlinks-retain.service
+++ b/deploy/systemd/fetchlinks-retain.service
@@ -7,8 +7,8 @@ Wants=network-online.target
 Type=oneshot
 User=fetchlinks
 Group=fetchlinks
-WorkingDirectory=/opt/fetchlinks/ingest
-ExecStart=/opt/fetchlinks/.venv/bin/python /opt/fetchlinks/ingest/retain.py --config /opt/fetchlinks/ingest/data/config/fetchlinks.toml
+WorkingDirectory=__FETCHLINKS_APP_DIR__/ingest
+ExecStart=__FETCHLINKS_APP_DIR__/.venv/bin/python __FETCHLINKS_APP_DIR__/ingest/retain.py --config __FETCHLINKS_APP_DIR__/ingest/data/config/fetchlinks.toml
 Nice=10
 TimeoutStartSec=30min
 SyslogIdentifier=fetchlinks-retain
@@ -16,8 +16,8 @@ SyslogIdentifier=fetchlinks-retain
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/opt/fetchlinks/ingest
+ProtectHome=false
+ReadWritePaths=__FETCHLINKS_APP_DIR__/ingest
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/systemd/fetchlinks-web.service
+++ b/deploy/systemd/fetchlinks-web.service
@@ -7,8 +7,8 @@ Wants=network-online.target
 Type=simple
 User=fetchlinks
 Group=fetchlinks
-WorkingDirectory=/opt/fetchlinks/web
-EnvironmentFile=/opt/fetchlinks/web/.env.production
+WorkingDirectory=__FETCHLINKS_APP_DIR__/web
+EnvironmentFile=__FETCHLINKS_APP_DIR__/web/.env.production
 ExecStart=/usr/bin/npm run start -- --hostname 127.0.0.1 --port 3000
 Restart=on-failure
 RestartSec=5
@@ -18,7 +18,7 @@ SyslogIdentifier=fetchlinks-web
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
-ReadWritePaths=/opt/fetchlinks/web
+ReadWritePaths=__FETCHLINKS_APP_DIR__/web
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/tls.sh
+++ b/deploy/tls.sh
@@ -13,17 +13,19 @@
 # Usage:
 #   sudo FETCHLINKS_DOMAIN=fetchlinks.example.com \
 #        FETCHLINKS_EMAIL=you@example.com \
-#        /opt/fetchlinks/deploy/tls.sh
+#        ~/fetchlinks/deploy/tls.sh
 #
 # Or positionally:
-#   sudo /opt/fetchlinks/deploy/tls.sh fetchlinks.example.com you@example.com
+#   sudo ~/fetchlinks/deploy/tls.sh fetchlinks.example.com you@example.com
 #
 # Re-running is safe; certbot will renew rather than re-issue when the cert
 # is still valid.
 
 set -euo pipefail
 
-APP_DIR="/opt/fetchlinks"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+DEFAULT_APP_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+APP_DIR="$(realpath -m "${FETCHLINKS_APP_DIR:-${DEFAULT_APP_DIR}}")"
 SITE_TEMPLATE="${APP_DIR}/deploy/nginx/fetchlinks-web.conf.example"
 SITE_AVAILABLE="/etc/nginx/sites-available/fetchlinks-web.conf"
 SITE_ENABLED="/etc/nginx/sites-enabled/fetchlinks-web.conf"

--- a/ingest/SETUP.md
+++ b/ingest/SETUP.md
@@ -6,8 +6,8 @@ These instructions configure and run the Fetchlinks ingest app on Linux.
 
 From the monorepo root. The venv MUST live at `.venv` in the repo root
 (not a sibling `../venv`): VS Code (`.vscode/settings.json`,
-`.vscode/tasks.json`) and the production install at `/opt/fetchlinks/.venv`
-both assume this path. `.venv/` is already in `.gitignore`.
+`.vscode/tasks.json`) and the production bootstrap both assume this path.
+`.venv/` is already in `.gitignore`.
 
 ```bash
 python3 -m venv .venv

--- a/ingest/data/config/fetchlinks.toml
+++ b/ingest/data/config/fetchlinks.toml
@@ -1,7 +1,8 @@
 # Fetchlinks runtime configuration.
 #
 # All path values may be absolute or relative to this file's directory.
-# The production install lives at /opt/fetchlinks and uses this file directly.
+# Production installs use this file directly from whichever checkout directory
+# bootstrap.sh is run from.
 
 [paths]
 db        = "../../db/fetchlinks.db"

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,2 @@
 # Absolute path to the SQLite database written by the fetchlinks ingestion app.
-FETCHLINKS_DB=/opt/fetchlinks/ingest/db/fetchlinks.db
+FETCHLINKS_DB=/absolute/path/to/fetchlinks/ingest/db/fetchlinks.db

--- a/web/.env.production.example
+++ b/web/.env.production.example
@@ -1,5 +1,6 @@
 # Absolute path to the SQLite database written by the fetchlinks ingestion app.
-FETCHLINKS_DB=/opt/fetchlinks/ingest/db/fetchlinks.db
+# bootstrap.sh rewrites this to the checkout path on first install.
+FETCHLINKS_DB=__FETCHLINKS_APP_DIR__/ingest/db/fetchlinks.db
 
 NODE_ENV=production
 NEXT_TELEMETRY_DISABLED=1

--- a/web/src/server/config.test.ts
+++ b/web/src/server/config.test.ts
@@ -22,12 +22,12 @@ describe("loadAppConfig", () => {
 
   it("loads the configured database path and read-only SQLite URI", () => {
     const config = loadAppConfig({
-      FETCHLINKS_DB: "/opt/fetchlinks/ingest/db/fetchlinks.db",
+      FETCHLINKS_DB: "/home/ubuntu/fetchlinks/ingest/db/fetchlinks.db",
     });
 
     expect(config).toEqual({
-      fetchlinksDbPath: "/opt/fetchlinks/ingest/db/fetchlinks.db",
-      fetchlinksDbReadOnlyUri: "file:///opt/fetchlinks/ingest/db/fetchlinks.db?mode=ro",
+      fetchlinksDbPath: "/home/ubuntu/fetchlinks/ingest/db/fetchlinks.db",
+      fetchlinksDbReadOnlyUri: "file:///home/ubuntu/fetchlinks/ingest/db/fetchlinks.db?mode=ro",
     });
   });
 });


### PR DESCRIPTION
## Summary
- derive bootstrap and TLS app paths from the checkout instead of hard-coding /opt/fetchlinks
- render systemd units and production env paths with the actual checkout directory
- update deployment docs and stale path fixtures to use ~/fetchlinks / <checkout>

## Validation
- bash -n deploy/bootstrap.sh deploy/tls.sh
- rendered systemd templates have no unresolved placeholders
- npm test -- config.test.ts
- git diff --check