### PR TITLE
Split ingest off the VM: dual-DB (control + data) with Pi sync

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,9 +1,10 @@
 # Fetchlinks overview
 
-Fetchlinks ingests links shared on RSS, Reddit, Bluesky, and Mastodon into a
-single SQLite database and serves them through a server-rendered Next.js web
-app. It runs on one small Ubuntu VM with the smallest possible operational
-surface.
+Fetchlinks ingests links shared on RSS, Reddit, Bluesky, and Mastodon into
+SQLite and serves them through a server-rendered Next.js web app. It runs on a
+single small Ubuntu VM by default, with the smallest possible operational
+surface; ingest can optionally be split onto a home Raspberry Pi (see
+Architecture below).
 
 For how to deploy and operate it on a VM, see [deploy/README.md](deploy/README.md).
 For forward-looking work and history, see `PLAN.md` (local, untracked).
@@ -21,6 +22,15 @@ operational surface:
 No Docker. No Ansible. No container registry. No managed database.
 
 ## Architecture
+
+Fetchlinks runs in one of two topologies. **Single-host** (the default) keeps
+everything on one VM with one SQLite file. The **two-host split** moves ingest
+to a home Raspberry Pi (residential IP, to escape Azure-IP RSS throttling)
+while the web GUI stays on the VM; the two sides share two SQLite files, one
+writer each. The split is opt-in — leaving `[paths].control_db` unset collapses
+back to a single physical file.
+
+### Single-host (default)
 
 ```text
 Azure VM (Ubuntu 24.04 LTS, B1ms, East US)
@@ -42,6 +52,43 @@ Request path: `Internet -> nginx:443 (TLS) -> 127.0.0.1:3000 -> SQLite`
 Ingest path:  `timer -> venv python fetch_links.py -> SQLite`
 Admin path:   `Internet -> nginx:443 -> /admin/* -> HTTP Basic -> SQLite (read-write)`
 
+### Two-host split (opt-in)
+
+Two SQLite files, one writer each:
+
+- **control.db (VM-owned)** — feed/subreddit *identity + on/off*. The web admin
+  writes it; the Pi only reads a pulled copy.
+- **data.db (Pi-owned)** — everything ingest produces: posts, per-feed health,
+  follows snapshots, ingest cursors. The Pi writes it; the web only reads it.
+
+Cross-file relations key on natural keys (`normalized_url`, `normalized_name`,
+post `unique_id_string`, Bluesky `did`) — never autoincrement ids, which don't
+match across separate files. The web admin opens control.db read-write and
+`ATTACH`es a read-only data.db so membership + health show as one row.
+
+```text
+Home Pi (ingest role)                         Azure VM (web role)
+  fetchlinks-sync.timer (30 min)                fetchlinks-web.service (Next.js)
+    1. rsync pull  control.db  <───────────────  control.db (canonical; admin writes)
+    2. fetch_links.py  -> data.db
+    3. retain.py       -> data.db (Pi only)
+    4. sqlite3 VACUUM INTO snapshot
+    5. rsync push  data.db     ───────────────>  data.db (replica; atomic rename; web reads)
+```
+
+Transport is **Pi-initiated SSH/rsync** — no inbound to the home network and no
+new service on the VM. The VM restricts the Pi's key to rsync within one
+directory (see `deploy/sync/authorized_keys.example`). The web opens data.db
+per request read-only, so an atomic rename swap needs no web restart. A
+one-cycle lag is acceptable: adding/removing a feed is instant (read from
+control.db), and its health columns fill in on the next data.db ship.
+Retention runs **only on the Pi** because the VM's data.db is a pure replica.
+Auto-disable-on-failure is dropped (the Pi can't write VM-owned `enabled`);
+the Pi counts `consecutive_failures` + `last_error` and the admin surfaces
+failing feeds for manual removal.
+
+See [deploy/sync/README.md](deploy/sync/README.md) for setup.
+
 Public site is read-only; the `/admin` route is an index of admin
 sub-pages (currently just `/admin/feeds` for the RSS feed table). All
 `/admin/*` routes open the DB read-write to manage their respective
@@ -62,19 +109,25 @@ state. Auth is HTTP Basic via env vars
 ```text
 deploy/
 ├── README.md                          how to deploy + operate on a VM
-├── bootstrap.sh                       app + services + firewall installer / updater
+├── bootstrap.sh                       app + services + firewall installer / updater (FETCHLINKS_ROLE=all|web|ingest)
 ├── tls.sh                             nginx + Let's Encrypt provisioner (separate, idempotent)
 ├── nginx/fetchlinks-web.conf.example  nginx site template (rendered by tls.sh)
+├── sync/                              two-host (Pi ingest + VM web) sync layer
+│   ├── README.md                      two-host setup + cycle docs
+│   ├── fetchlinks-sync.sh             Pi cycle: pull control.db, ingest, retain, snapshot, push data.db
+│   ├── fetchlinks-sync.env.example    sync service environment (VM target, paths)
+│   └── authorized_keys.example        VM-side rsync-restricted SSH key
 └── systemd/
-    ├── fetchlinks-web.service                         Next.js webapp
-    ├── fetchlinks-ingest.{service,timer}              ingest (every 30 min)
-    ├── fetchlinks-retain.{service,timer}              retention (weekly)
-    └── fetchlinks-export-rss-feeds.{service,timer}    feed snapshot (every 5 min)
+    ├── fetchlinks-web.service                         Next.js webapp (web role)
+    ├── fetchlinks-ingest.{service,timer}              ingest, every 30 min (single-host)
+    ├── fetchlinks-retain.{service,timer}              retention, weekly (single-host)
+    ├── fetchlinks-export-rss-feeds.{service,timer}    feed snapshot, every 5 min (web role)
+    └── fetchlinks-sync.{service,timer}                Pi sync cycle, every 30 min (ingest role)
 
 ingest/                                Python ingest package + tests
   ├── data/config/fetchlinks.toml      runtime config used in dev + production
   ├── data/config/rss_feeds.txt        seed file + 5-minute DB snapshot
-  └── db/fetchlinks.db                 SQLite DB (ignored)
+  └── db/fetchlinks.db                 SQLite DB (single-host; two-host uses control.db + data.db)
 web/                                   Next.js webapp (TypeScript, vitest)
   ├── .env.production.example          production web env template
   ├── src/app/page.tsx                 public posts listing
@@ -87,7 +140,9 @@ web/                                   Next.js webapp (TypeScript, vitest)
 ## Security
 
 - SSH: key-only (Azure default), root login disabled (Ubuntu default).
-- Firewall: `ufw` deny inbound, allow 22/80/443 only.
+- Firewall: `ufw` deny inbound. The web role allows 22/80/443; the ingest Pi
+  allows only 22 (and initiates all sync outbound). The Pi's SSH key on the VM
+  is restricted to rsync within a single directory (`restrict` + rrsync).
 - Services run as `fetchlinks`, never root.
 - API credentials live wherever `ingest/data/config/fetchlinks.toml` points;
   bootstrap can install missing enabled-source credential files during first
@@ -113,6 +168,9 @@ web/                                   Next.js webapp (TypeScript, vitest)
   credentials at the paths referenced by `ingest/data/config/fetchlinks.toml`.
   New credentialed sources need config entries and matching external files.
 - The DB is the live source of truth for posts, URLs, and `rss_feeds`.
+  In the two-host split, feed/subreddit identity + on/off live in VM-owned
+  control.db and everything ingest produces (posts, health, follows, cursors)
+  lives in Pi-owned data.db, joined on natural keys.
   `rss_feeds.txt` is seed input on first install and is then refreshed from
   the DB every 5 minutes for review, backup, and occasional repo commits.
 - `bootstrap.sh` is idempotent and is also the upgrade path. There is no

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,15 +11,40 @@ deploy/
 ├── tls.sh                             nginx + Let's Encrypt provisioner (run after bootstrap)
 ├── nginx/
 │   └── fetchlinks-web.conf.example    nginx reverse-proxy site
+├── sync/                              two-host (Pi ingest + VM web) sync layer
+│   ├── README.md                      two-host setup + cycle docs
+│   ├── fetchlinks-sync.sh             Pi cycle: pull control.db, ingest, retain, snapshot, push data.db
+│   ├── fetchlinks-sync.env.example    sync service environment (VM target, paths)
+│   └── authorized_keys.example        VM-side rsync-restricted SSH key
 └── systemd/
-    ├── fetchlinks-web.service         Next.js web app
-    ├── fetchlinks-ingest.service      Python ingest one-shot
-    ├── fetchlinks-ingest.timer        ingest schedule (every 30 min)
-    ├── fetchlinks-retain.service      weekly DB retention one-shot
-    ├── fetchlinks-retain.timer        retention schedule (Sun 03:30)
-    ├── fetchlinks-export-rss-feeds.service  rss_feeds DB → runtime text snapshot
-    └── fetchlinks-export-rss-feeds.timer    snapshot schedule (every 5 min)
+    ├── fetchlinks-web.service         Next.js web app (web role)
+    ├── fetchlinks-ingest.service      Python ingest one-shot (single-host)
+    ├── fetchlinks-ingest.timer        ingest schedule, every 30 min (single-host)
+    ├── fetchlinks-retain.service      weekly DB retention one-shot (single-host)
+    ├── fetchlinks-retain.timer        retention schedule, Sun 03:30 (single-host)
+    ├── fetchlinks-export-rss-feeds.service  rss_feeds DB → runtime text snapshot (web role)
+    ├── fetchlinks-export-rss-feeds.timer    snapshot schedule, every 5 min (web role)
+    ├── fetchlinks-sync.service         Pi sync cycle (ingest role)
+    └── fetchlinks-sync.timer           Pi sync schedule, every 30 min (ingest role)
 ```
+
+## Roles (single-host vs two-host)
+
+`bootstrap.sh` provisions one of three roles via `FETCHLINKS_ROLE`:
+
+- **`all`** (default) — single-host: web + ingest + retain + export on one VM,
+  one SQLite file. This is the standard deployment described below.
+- **`web`** — the Azure VM in a two-host split. Builds/serves the web GUI,
+  owns the canonical control.db (feed/subreddit identity), reads a data.db
+  replica pushed by the Pi. Set `FETCHLINKS_DB` (data.db replica) and
+  `FETCHLINKS_CONTROL_DB` (canonical control.db) in `web/.env.production`.
+- **`ingest`** — a home Raspberry Pi. Runs the sync cycle (pull control.db,
+  ingest, retain, push data.db); no Node/web build, no inbound web ports.
+
+The two-host split exists to move ingest onto a residential IP (Azure IPs are
+throttled by many RSS hosts). Its full setup — VM rsync key lockdown, Pi
+config, env — lives in [sync/README.md](sync/README.md). The rest of this
+document covers the default single-host (`all`) deployment.
 
 ## First-time install
 

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -17,6 +17,10 @@
 #   FETCHLINKS_APP_DIR  checkout directory to install/update (default: parent of this script's deploy/ dir)
 #   FETCHLINKS_REPO_URL git URL to clone/pull (default: poptart-sommelier/fetchlinks)
 #   FETCHLINKS_REPO_REF branch/tag to deploy   (default: master)
+#   FETCHLINKS_ROLE     which role to provision: all | web | ingest (default: all)
+#                       - all:    single-host (web + ingest + retain + export); one DB file.
+#                       - web:    VM web GUI; control.db canonical here; reads a pushed data.db.
+#                       - ingest: home Pi; runs the sync cycle (pull control.db, ingest, retain, push data.db).
 
 set -euo pipefail
 
@@ -36,12 +40,23 @@ CONFIG_FILE="${INGEST_DIR}/data/config/fetchlinks.toml"
 RSS_FEEDS_FILE="${INGEST_DIR}/data/config/rss_feeds.txt"
 SUBREDDITS_FILE="${INGEST_DIR}/data/config/subreddits.txt"
 WEB_ENV_FILE="${WEB_DIR}/.env.production"
+SYNC_ENV_FILE="${APP_DIR}/deploy/sync/fetchlinks-sync.env"
+SYNC_ENV_EXAMPLE="${APP_DIR}/deploy/sync/fetchlinks-sync.env.example"
 CACHE_DIR="/var/cache/fetchlinks"
 NODE_MAJOR=24
 PYTHON_BIN="/usr/bin/python3.12"
 
 REPO_URL="${FETCHLINKS_REPO_URL:-https://github.com/poptart-sommelier/fetchlinks.git}"
 REPO_REF="${FETCHLINKS_REPO_REF:-master}"
+
+ROLE="${FETCHLINKS_ROLE:-all}"
+case "${ROLE}" in
+    all|web|ingest) ;;
+    *) echo "FETCHLINKS_ROLE must be one of: all, web, ingest (got '${ROLE}')." >&2; exit 1 ;;
+esac
+
+role_has_web()    { [[ "${ROLE}" == "all" || "${ROLE}" == "web" ]]; }
+role_has_ingest() { [[ "${ROLE}" == "all" || "${ROLE}" == "ingest" ]]; }
 
 log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
 warn() { printf '\n\033[1;33m!!\033[0m %s\n' "$*" >&2; }
@@ -400,6 +415,54 @@ configure_web_admin_if_missing() {
     set_web_env_admin "${admin_user}" "${admin_pass}"
 }
 
+configure_sync_env_if_missing() {
+    local app_dir_escaped=""
+    local vm_ssh=""
+
+    if [[ -f "${SYNC_ENV_FILE}" ]]; then
+        printf '  ok - sync environment exists at %s\n' "${SYNC_ENV_FILE}"
+        return 0
+    fi
+
+    if [[ ! -f "${SYNC_ENV_EXAMPLE}" ]]; then
+        warn "Missing ${SYNC_ENV_EXAMPLE}; cannot render the sync environment."
+        return 0
+    fi
+
+    log "Configuring Pi sync environment"
+    app_dir_escaped="$(sed_escape_replacement "${APP_DIR}")"
+    sed "s|__FETCHLINKS_APP_DIR__|${app_dir_escaped}|g" \
+        "${SYNC_ENV_EXAMPLE}" >"${SYNC_ENV_FILE}"
+
+    read -r -p "VM sync SSH target (user@host) [leave blank to edit ${SYNC_ENV_FILE} later]: " vm_ssh
+    if [[ -n "${vm_ssh//[[:space:]]/}" ]]; then
+        "${PYTHON_BIN}" - "${SYNC_ENV_FILE}" "${vm_ssh}" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+target = sys.argv[2].strip()
+lines = path.read_text(encoding='utf-8').splitlines()
+out = []
+seen = False
+for line in lines:
+    if line.startswith('FETCHLINKS_VM_SSH='):
+        out.append(f'FETCHLINKS_VM_SSH={target}')
+        seen = True
+    else:
+        out.append(line)
+if not seen:
+    out.append(f'FETCHLINKS_VM_SSH={target}')
+path.write_text('\n'.join(out) + '\n', encoding='utf-8')
+PY
+    else
+        warn "FETCHLINKS_VM_SSH left unset; edit ${SYNC_ENV_FILE} before enabling the sync timer."
+    fi
+
+    chown "${APP_USER}:${APP_GROUP}" "${SYNC_ENV_FILE}"
+    chmod 0600 "${SYNC_ENV_FILE}"
+}
+
 list_enabled_ingest_sources() {
     "${PYTHON_BIN}" - "${CONFIG_FILE}" <<'PY'
 from pathlib import Path
@@ -703,11 +766,14 @@ fi
 # ---- swap -------------------------------------------------------------------
 # A 2 GB VM (B1ms) has little/no swap by default, and `next build` can spike
 # memory enough to OOM. Ensure a swap file exists before the web build.
+# Only the web role builds Next.js, so skip this for the ingest-only Pi.
 
 SWAP_FILE="/swapfile"
 SWAP_SIZE="2G"
 
-if ! swapon --show --noheadings | grep -q "${SWAP_FILE}"; then
+if ! role_has_web; then
+    log "Ingest-only role; skipping web build swap file"
+elif ! swapon --show --noheadings | grep -q "${SWAP_FILE}"; then
     log "Setting up ${SWAP_SIZE} swap file at ${SWAP_FILE}"
     if [[ ! -f "${SWAP_FILE}" ]]; then
         fallocate -l "${SWAP_SIZE}" "${SWAP_FILE}" || \
@@ -735,11 +801,18 @@ apt-get install -y \
     python3.12 python3.12-venv python3.12-dev \
     build-essential libffi-dev libssl-dev
 
-# NodeSource for current Node major
-if ! command -v node >/dev/null || [[ "$(node -v 2>/dev/null)" != v${NODE_MAJOR}.* ]]; then
-    log "Installing Node.js ${NODE_MAJOR}.x from NodeSource"
-    curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -
-    apt-get install -y nodejs
+# The ingest role ships data.db to the VM over rsync each cycle.
+if role_has_ingest; then
+    apt-get install -y rsync
+fi
+
+# NodeSource for current Node major (web role only builds/runs Next.js)
+if role_has_web; then
+    if ! command -v node >/dev/null || [[ "$(node -v 2>/dev/null)" != v${NODE_MAJOR}.* ]]; then
+        log "Installing Node.js ${NODE_MAJOR}.x from NodeSource"
+        curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash -
+        apt-get install -y nodejs
+    fi
 fi
 
 # ---- unattended-upgrades ----------------------------------------------------
@@ -768,7 +841,11 @@ grant_app_user_checkout_access
 log "Configuring ufw"
 ufw --force default deny incoming  >/dev/null
 ufw --force default allow outgoing >/dev/null
-for port in 22 80 443; do ufw allow "${port}/tcp" >/dev/null; done
+ufw allow 22/tcp >/dev/null
+# Only the web role serves HTTP(S); the ingest Pi needs no inbound web ports.
+if role_has_web; then
+    for port in 80 443; do ufw allow "${port}/tcp" >/dev/null; done
+fi
 ufw --force enable >/dev/null
 
 # ---- repo -------------------------------------------------------------------
@@ -796,10 +873,22 @@ install -d -o "${APP_USER}" -g "${APP_GROUP}" -m 0755 "${CACHE_DIR}/npm"
 
 # ---- first-install interactive setup ----------------------------------------
 
-configure_missing_credentials
-configure_web_admin_if_missing
+# Ingest credentials live wherever ingest runs (the Pi, or single-host).
+if role_has_ingest; then
+    configure_missing_credentials
+fi
+# Web admin credentials live on the web host.
+if role_has_web; then
+    configure_web_admin_if_missing
+fi
+# The Pi needs the sync environment (VM target) for its push/pull cycle.
+if [[ "${ROLE}" == "ingest" ]]; then
+    configure_sync_env_if_missing
+fi
 
 # ---- python venv + ingest deps ---------------------------------------------
+# Needed by every role: the web host runs the seed/export Python helpers, and
+# the ingest host runs the fetch/retain jobs.
 
 log "Building Python venv and installing ingest requirements"
 if [[ ! -x "${VENV_DIR}/bin/python" ]]; then
@@ -811,58 +900,115 @@ sudo -u "${APP_USER}" env PIP_CACHE_DIR="${CACHE_DIR}/pip" \
 
 # ---- web build --------------------------------------------------------------
 
-log "Building Next.js web app"
-sudo -u "${APP_USER}" env npm_config_cache="${CACHE_DIR}/npm" \
-    bash -c "cd '${WEB_DIR}' && npm ci && npm run build"
+if role_has_web; then
+    log "Building Next.js web app"
+    sudo -u "${APP_USER}" env npm_config_cache="${CACHE_DIR}/npm" \
+        bash -c "cd '${WEB_DIR}' && npm ci && npm run build"
+fi
 
 # ---- systemd units ----------------------------------------------------------
 
-log "Installing systemd units"
-render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-web.service"              /etc/systemd/system/fetchlinks-web.service
-render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-ingest.service"           /etc/systemd/system/fetchlinks-ingest.service
-install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-ingest.timer"                /etc/systemd/system/
-render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-retain.service"           /etc/systemd/system/fetchlinks-retain.service
-install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-retain.timer"                /etc/systemd/system/
-render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-export-rss-feeds.service" /etc/systemd/system/fetchlinks-export-rss-feeds.service
-install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-export-rss-feeds.timer"      /etc/systemd/system/
+log "Installing systemd units (role: ${ROLE})"
+
+if role_has_web; then
+    render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-web.service"              /etc/systemd/system/fetchlinks-web.service
+    render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-export-rss-feeds.service" /etc/systemd/system/fetchlinks-export-rss-feeds.service
+    install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-export-rss-feeds.timer"      /etc/systemd/system/
+fi
+
+# Single-host runs the standalone ingest + retain timers directly.
+if [[ "${ROLE}" == "all" ]]; then
+    render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-ingest.service"           /etc/systemd/system/fetchlinks-ingest.service
+    install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-ingest.timer"                /etc/systemd/system/
+    render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-retain.service"           /etc/systemd/system/fetchlinks-retain.service
+    install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-retain.timer"                /etc/systemd/system/
+fi
+
+# The Pi runs ingest + retention inside the one-shot sync cycle.
+if [[ "${ROLE}" == "ingest" ]]; then
+    render_systemd_unit "${APP_DIR}/deploy/systemd/fetchlinks-sync.service"             /etc/systemd/system/fetchlinks-sync.service
+    install -m 0644 "${APP_DIR}/deploy/systemd/fetchlinks-sync.timer"                  /etc/systemd/system/
+fi
+
 systemctl daemon-reload
 
-systemctl enable --now fetchlinks-web.service
-systemctl enable --now fetchlinks-ingest.timer
-systemctl enable --now fetchlinks-retain.timer
-systemctl enable --now fetchlinks-export-rss-feeds.timer
-systemctl restart   fetchlinks-export-rss-feeds.timer
-systemctl restart   fetchlinks-web.service
+if role_has_web; then
+    systemctl enable --now fetchlinks-web.service
+    systemctl enable --now fetchlinks-export-rss-feeds.timer
+    systemctl restart   fetchlinks-export-rss-feeds.timer
+    systemctl restart   fetchlinks-web.service
+fi
+if [[ "${ROLE}" == "all" ]]; then
+    systemctl enable --now fetchlinks-ingest.timer
+    systemctl enable --now fetchlinks-retain.timer
+fi
+if [[ "${ROLE}" == "ingest" ]]; then
+    systemctl enable --now fetchlinks-sync.timer
+fi
 
 # ---- one-time source table seeds. These use temporary seed-only configs so
 # missing network credentials do not block no-network seed imports.
-seed_source_tables
+# control.db (feed/subreddit identity) is canonical on the web host.
+if role_has_web; then
+    seed_source_tables
 
-log "Exporting rss_feeds table back to ${RSS_FEEDS_FILE}"
-systemctl start fetchlinks-export-rss-feeds.service || \
-    warn "rss_feeds export step reported a failure; check the journal."
+    log "Exporting rss_feeds table back to ${RSS_FEEDS_FILE}"
+    systemctl start fetchlinks-export-rss-feeds.service || \
+        warn "rss_feeds export step reported a failure; check the journal."
+fi
 
-validate_ingest_sources
+# Validate ingest sources wherever ingest actually runs.
+if role_has_ingest; then
+    validate_ingest_sources
+fi
 
 # nginx + TLS are provisioned separately by deploy/tls.sh.
+
 
 # ---- final summary ----------------------------------------------------------
 
 log "Done. Status:"
-systemctl --no-pager --lines=0 status fetchlinks-web.service                  || true
-systemctl --no-pager --lines=0 status fetchlinks-ingest.timer                 || true
-systemctl --no-pager --lines=0 status fetchlinks-retain.timer                 || true
-systemctl --no-pager --lines=0 status fetchlinks-export-rss-feeds.timer       || true
+if role_has_web; then
+    systemctl --no-pager --lines=0 status fetchlinks-web.service                  || true
+    systemctl --no-pager --lines=0 status fetchlinks-export-rss-feeds.timer       || true
+fi
+if [[ "${ROLE}" == "all" ]]; then
+    systemctl --no-pager --lines=0 status fetchlinks-ingest.timer                 || true
+    systemctl --no-pager --lines=0 status fetchlinks-retain.timer                 || true
+fi
+if [[ "${ROLE}" == "ingest" ]]; then
+    systemctl --no-pager --lines=0 status fetchlinks-sync.timer                   || true
+fi
 
 cat <<EOF
 
 ------------------------------------------------------------
-Bootstrap finished.
+Bootstrap finished (role: ${ROLE}).
+EOF
+
+if role_has_web; then
+    cat <<EOF
 
 Optional next step: provision nginx + TLS once DNS points at this VM:
   sudo FETCHLINKS_DOMAIN=fetchlinks.example.com \
        FETCHLINKS_EMAIL=you@example.com \
        ${APP_DIR}/deploy/tls.sh
+EOF
+fi
+
+if [[ "${ROLE}" == "ingest" ]]; then
+    cat <<EOF
+
+Ingest (Pi) role next steps:
+  1. Ensure ${SYNC_ENV_FILE} has FETCHLINKS_VM_SSH set (and key path).
+  2. Set distinct [paths].db and [paths].control_db in ${CONFIG_FILE}.
+  3. Add this Pi's SSH public key to the VM, rsync-restricted — see
+     ${APP_DIR}/deploy/sync/authorized_keys.example.
+  4. Trigger one cycle: systemctl start fetchlinks-sync.service
+EOF
+fi
+
+cat <<EOF
 ------------------------------------------------------------
 EOF
 

--- a/deploy/sync/README.md
+++ b/deploy/sync/README.md
@@ -1,0 +1,83 @@
+# Fetchlinks two-host sync (Pi ingest + VM web)
+
+The ingest job runs on a home-network Raspberry Pi (residential IP, to escape
+Azure-IP RSS throttling); the web GUI runs on the Azure VM. They share state
+through two SQLite files, one writer each:
+
+- **control.db** — VM-owned. Feed/subreddit *identity + on/off*. The web admin
+  writes it; the Pi only reads a pulled copy.
+- **data.db** — Pi-owned. Everything ingest produces (posts, per-feed health,
+  follows snapshots, ingest cursors). The Pi writes it; the web only reads it.
+
+Every cycle is **Pi-initiated** over SSH/rsync, so there is no inbound
+connection to the home network and no new service on the VM.
+
+## Files
+
+```
+deploy/sync/
+├── fetchlinks-sync.sh            Pi-side cycle: pull control.db, ingest, retain, snapshot, push data.db
+├── fetchlinks-sync.env.example   environment for the sync service (VM target, paths)
+└── authorized_keys.example       VM-side locked-down rsync-only SSH key
+deploy/systemd/
+├── fetchlinks-sync.service       runs fetchlinks-sync.sh (Pi)
+└── fetchlinks-sync.timer         every 30 min (Pi)
+```
+
+## One cycle (`fetchlinks-sync.sh`)
+
+1. **Pull control.db** from the VM (non-fatal on failure — a one-cycle lag is
+   acceptable; ingest continues against the existing local replica).
+2. **Ingest** — `fetch_links.py` reads the control replica, writes data.db.
+3. **Retention** — `retain.py` prunes old posts. Retention runs **only on the
+   Pi**; the VM's data.db is a pure replica.
+4. **Snapshot** — `sqlite3 VACUUM INTO` makes a consistent, compacted copy.
+5. **Push** — rsync ships the snapshot up; rsync's temp-file-then-rename lands
+   it atomically. The web opens data.db per request read-only, so the swap is
+   seamless — no web restart.
+
+## VM setup
+
+1. Pick a sync directory the web role reads from, e.g. `/var/lib/fetchlinks/sync`,
+   holding `control.db` (canonical) and `data.db` (replica). Point the web
+   service env at them:
+
+   ```
+   FETCHLINKS_CONTROL_DB=/var/lib/fetchlinks/sync/control.db
+   FETCHLINKS_DB=/var/lib/fetchlinks/sync/data.db
+   ```
+
+2. Add the Pi's public key to the VM `fetchlinks` account's
+   `~/.ssh/authorized_keys`, restricted to rsync within that directory — see
+   `authorized_keys.example`.
+
+## Pi setup
+
+1. Provision the checkout (ingest role) and a Python venv (see the role-split
+   `bootstrap.sh`).
+2. In the ingest config `fetchlinks.toml`, set:
+
+   ```toml
+   [paths]
+   db = "db/data.db"          # Pi-owned, written by ingest
+   control_db = "db/control.db"  # pulled replica, read-only to ingest
+   ```
+
+3. Copy `fetchlinks-sync.env.example` to `fetchlinks-sync.env`, set
+   `FETCHLINKS_VM_SSH` (and key path if not the default), then enable the timer:
+
+   ```bash
+   systemctl enable --now fetchlinks-sync.timer
+   ```
+
+4. Trigger one cycle and watch it:
+
+   ```bash
+   systemctl start fetchlinks-sync.service
+   journalctl -u fetchlinks-sync.service -f
+   ```
+
+## Single-host mode (no Pi)
+
+When `control_db` is unset it defaults to `db`, so a single VM keeps using one
+physical file and none of this sync machinery runs — the split is opt-in.

--- a/deploy/sync/authorized_keys.example
+++ b/deploy/sync/authorized_keys.example
@@ -1,0 +1,42 @@
+# Locking down the Pi's SSH access on the VM
+#
+# The Pi initiates every sync. On the VM, the Pi's key is restricted to rsync
+# against ONE directory so a compromised Pi can never get a shell or touch
+# anything else. This file shows the authorized_keys line to install for the
+# VM's `fetchlinks` service account.
+#
+# Layout assumed on the VM (the web role reads both files):
+#   /var/lib/fetchlinks/sync/control.db   canonical, web writes (admin edits)
+#   /var/lib/fetchlinks/sync/data.db      replica, the Pi pushes (web reads)
+#
+# So the web service env is:
+#   FETCHLINKS_CONTROL_DB=/var/lib/fetchlinks/sync/control.db
+#   FETCHLINKS_DB=/var/lib/fetchlinks/sync/data.db
+#
+# ----------------------------------------------------------------------------
+# rrsync (ships with rsync; usually /usr/share/rsync/scripts/rrsync or
+# /usr/bin/rrsync) restricts an SSH key to rsync within a single directory.
+# A single read-write entry lets the Pi pull control.db and push data.db:
+
+command="/usr/bin/rrsync /var/lib/fetchlinks/sync",restrict ssh-ed25519 AAAA...pi-key... fetchlinks-pi
+
+# `restrict` disables pty, port/agent/X11 forwarding, and exec — only the
+# forced rrsync command runs. The Pi cannot get a shell or escape the
+# /var/lib/fetchlinks/sync directory.
+#
+# Defense-in-depth (optional, stricter): use TWO keys so the Pi can only READ
+# control.db and only WRITE data.db. rrsync supports -ro / -wo:
+#
+#   command="/usr/bin/rrsync -ro /var/lib/fetchlinks/sync",restrict ssh-ed25519 AAAA...pull-key... fetchlinks-pi-pull
+#   command="/usr/bin/rrsync -wo /var/lib/fetchlinks/sync",restrict ssh-ed25519 AAAA...push-key... fetchlinks-pi-push
+#
+# With split keys, point the Pi sync script at each:
+#   pull cycle: FETCHLINKS_SSH_KEY=~/.ssh/fetchlinks_pull
+#   push cycle: FETCHLINKS_SSH_KEY=~/.ssh/fetchlinks_push
+# (The single read-write entry above is simpler and adequate for a single
+# operator; the Pi script itself never writes control.db.)
+#
+# ----------------------------------------------------------------------------
+# If your rsync build does not ship rrsync, install it (Debian/Ubuntu:
+# `apt-get install rsync` provides /usr/bin/rrsync on recent releases) or copy
+# it from the rsync source `support/rrsync`.

--- a/deploy/sync/fetchlinks-sync.env.example
+++ b/deploy/sync/fetchlinks-sync.env.example
@@ -1,0 +1,19 @@
+# Fetchlinks Pi sync environment (ingest role).
+#
+# Copy to fetchlinks-sync.env and fill in the VM target. The
+# fetchlinks-sync.service unit loads this via EnvironmentFile.
+#
+# Required:
+FETCHLINKS_VM_SSH=fetchlinks-sync@vm.example.com
+
+# Optional (defaults shown):
+#FETCHLINKS_VM_SSH_PORT=22
+#FETCHLINKS_SSH_KEY=/var/lib/fetchlinks/.ssh/fetchlinks_sync
+#FETCHLINKS_CONFIG=__FETCHLINKS_APP_DIR__/ingest/data/config/fetchlinks.toml
+# DATA_DB / CONTROL_DB default to the ingest config's [paths].db /
+# [paths].control_db; only set these to override that.
+#FETCHLINKS_DATA_DB=__FETCHLINKS_APP_DIR__/ingest/db/data.db
+#FETCHLINKS_CONTROL_DB=__FETCHLINKS_APP_DIR__/ingest/db/control.db
+#FETCHLINKS_REMOTE_CONTROL=control.db
+#FETCHLINKS_REMOTE_DATA=data.db
+#FETCHLINKS_RSYNC_TIMEOUT=120

--- a/deploy/sync/fetchlinks-sync.sh
+++ b/deploy/sync/fetchlinks-sync.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Fetchlinks Pi-side sync cycle.
+#
+# Runs ON the Pi (ingest role). One cycle, in order:
+#   1. Pull control.db down from the VM (feed/subreddit identity + on/off).
+#   2. Run ingest (writes posts/health/follows/state into the local data.db).
+#   3. Run retention (prune old posts; retention runs ONLY on the Pi).
+#   4. Snapshot data.db into a consistent, compacted file (VACUUM INTO).
+#   5. Push the snapshot up to the VM, where rsync's temp-file-then-rename
+#      lands it atomically (the web reads data.db per-request read-only, so an
+#      atomic rename is seamless — no web restart needed).
+#
+# Transport is Pi-initiated SSH/rsync: no inbound connection to the home
+# network and no new service on the VM. The VM restricts the Pi's SSH key to
+# rsync against a single directory (see deploy/sync/authorized_keys.example).
+#
+# control.db is canonical on the VM. The Pi treats its pulled copy as
+# read-only and never writes it back.
+#
+# Configuration (environment variables; sensible defaults below):
+#   FETCHLINKS_APP_DIR     checkout dir            (default: parent of deploy/)
+#   FETCHLINKS_VENV        python venv dir         (default: $APP_DIR/.venv)
+#   FETCHLINKS_CONFIG      ingest TOML config      (default: $APP_DIR/ingest/data/config/fetchlinks.toml)
+#   FETCHLINKS_DATA_DB     local Pi-owned data.db  (default: $APP_DIR/ingest/db/data.db)
+#   FETCHLINKS_CONTROL_DB  local control.db replica(default: $APP_DIR/ingest/db/control.db)
+#   FETCHLINKS_VM_SSH      ssh target user@host    (required, e.g. fetchlinks-sync@vm.example.com)
+#   FETCHLINKS_VM_SSH_PORT ssh port                (default: 22)
+#   FETCHLINKS_SSH_KEY     ssh identity file       (default: ssh default)
+#   FETCHLINKS_REMOTE_CONTROL remote control.db name within the restricted
+#                             rsync root            (default: control.db)
+#   FETCHLINKS_REMOTE_DATA    remote data.db name within the restricted
+#                             rsync root            (default: data.db)
+#   FETCHLINKS_RSYNC_TIMEOUT  per-transfer timeout seconds (default: 120)
+#
+# The ingest config's [paths] must point db -> $FETCHLINKS_DATA_DB and
+# control_db -> $FETCHLINKS_CONTROL_DB so ingest reads the pulled control
+# replica and writes only the local data.db.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+DEFAULT_APP_DIR="$(cd -- "${SCRIPT_DIR}/../.." && pwd -P)"
+
+APP_DIR="$(realpath -m "${FETCHLINKS_APP_DIR:-${DEFAULT_APP_DIR}}")"
+VENV_DIR="${FETCHLINKS_VENV:-${APP_DIR}/.venv}"
+CONFIG_FILE="${FETCHLINKS_CONFIG:-${APP_DIR}/ingest/data/config/fetchlinks.toml}"
+INGEST_DIR="${APP_DIR}/ingest"
+PYTHON_BIN="${VENV_DIR}/bin/python"
+# DATA_DB / CONTROL_DB default to the ingest config's [paths] so the snapshot
+# target always matches what ingest actually writes/reads (resolved below).
+DATA_DB="${FETCHLINKS_DATA_DB:-}"
+CONTROL_DB="${FETCHLINKS_CONTROL_DB:-}"
+
+VM_SSH="${FETCHLINKS_VM_SSH:-}"
+VM_SSH_PORT="${FETCHLINKS_VM_SSH_PORT:-22}"
+SSH_KEY="${FETCHLINKS_SSH_KEY:-}"
+REMOTE_CONTROL="${FETCHLINKS_REMOTE_CONTROL:-control.db}"
+REMOTE_DATA="${FETCHLINKS_REMOTE_DATA:-data.db}"
+RSYNC_TIMEOUT="${FETCHLINKS_RSYNC_TIMEOUT:-120}"
+
+log()  { printf '\n\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\n\033[1;33m!!\033[0m %s\n' "$*" >&2; }
+die()  { printf '\n\033[1;31m!!\033[0m %s\n' "$*" >&2; exit 1; }
+
+[[ -n "${VM_SSH}" ]]      || die "FETCHLINKS_VM_SSH is required (e.g. fetchlinks-sync@vm.example.com)."
+[[ -x "${PYTHON_BIN}" ]]  || die "Python venv not found at ${PYTHON_BIN}."
+[[ -f "${CONFIG_FILE}" ]] || die "Ingest config not found at ${CONFIG_FILE}."
+command -v rsync   >/dev/null || die "rsync is not installed."
+command -v sqlite3 >/dev/null || die "sqlite3 is not installed."
+
+# Resolve db / control_db from the ingest config unless explicitly overridden,
+# so the snapshot target always matches what ingest writes and the control
+# replica matches what ingest reads.
+if [[ -z "${DATA_DB}" || -z "${CONTROL_DB}" ]]; then
+    resolved_paths="$(cd "${INGEST_DIR}" && "${PYTHON_BIN}" -c "import config; cfg = config.load_config('${CONFIG_FILE}'); print(cfg.paths.db); print(cfg.paths.control_db)")" \
+        || die "Could not resolve [paths] from ${CONFIG_FILE}."
+    DATA_DB="${DATA_DB:-$(sed -n 1p <<<"${resolved_paths}")}"
+    CONTROL_DB="${CONTROL_DB:-$(sed -n 2p <<<"${resolved_paths}")}"
+fi
+[[ -n "${DATA_DB}" ]]    || die "Could not determine the data.db path."
+[[ -n "${CONTROL_DB}" ]] || die "Could not determine the control.db path."
+if [[ "${DATA_DB}" == "${CONTROL_DB}" ]]; then
+    die "data.db and control.db resolve to the same file (${DATA_DB}); the two-host split needs distinct [paths].db and [paths].control_db."
+fi
+
+# Build the ssh command rsync uses for transport, honouring port + identity.
+SSH_OPTS=(-p "${VM_SSH_PORT}" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+[[ -n "${SSH_KEY}" ]] && SSH_OPTS+=(-i "${SSH_KEY}")
+RSH="ssh ${SSH_OPTS[*]}"
+
+RSYNC_BASE=(rsync --timeout="${RSYNC_TIMEOUT}" -e "${RSH}")
+
+# Serialize cycles so a slow run never overlaps the next timer fire.
+LOCK_FILE="${FETCHLINKS_LOCK_FILE:-${DATA_DB}.synclock}"
+exec 9>"${LOCK_FILE}"
+if ! flock -n 9; then
+    warn "Another sync cycle is already running (${LOCK_FILE}); exiting."
+    exit 0
+fi
+
+install -d -m 0755 "$(dirname -- "${DATA_DB}")"
+install -d -m 0755 "$(dirname -- "${CONTROL_DB}")"
+
+# ---- 1. pull control.db -----------------------------------------------------
+# Non-fatal: if the pull fails we keep ingesting against the existing replica
+# (one-cycle lag is acceptable by design). Only a missing first-ever replica
+# is fatal.
+log "Pulling control.db from ${VM_SSH}:${REMOTE_CONTROL}"
+if "${RSYNC_BASE[@]}" "${VM_SSH}:${REMOTE_CONTROL}" "${CONTROL_DB}"; then
+    printf '  ok - control.db updated\n'
+else
+    if [[ -f "${CONTROL_DB}" ]]; then
+        warn "control.db pull failed; continuing with existing local replica."
+    else
+        die "control.db pull failed and no local replica exists at ${CONTROL_DB}."
+    fi
+fi
+
+# ---- 2. ingest --------------------------------------------------------------
+log "Running ingest"
+( cd "${INGEST_DIR}" && "${PYTHON_BIN}" "${INGEST_DIR}/fetch_links.py" --config "${CONFIG_FILE}" )
+
+# ---- 3. retention (Pi only) -------------------------------------------------
+log "Running retention"
+( cd "${INGEST_DIR}" && "${PYTHON_BIN}" "${INGEST_DIR}/retain.py" --config "${CONFIG_FILE}" )
+
+# ---- 4. snapshot ------------------------------------------------------------
+# VACUUM INTO produces a consistent, compacted copy without touching the live
+# DB. Write it beside data.db so the push reads a stable file.
+SNAPSHOT="${DATA_DB}.snapshot"
+log "Snapshotting data.db -> ${SNAPSHOT}"
+rm -f "${SNAPSHOT}"
+sqlite3 "${DATA_DB}" "VACUUM INTO '${SNAPSHOT}'"
+
+# ---- 5. push ----------------------------------------------------------------
+# rsync transfers to a hidden temp file in the destination directory and
+# renames it into place on completion — atomic on the VM's filesystem.
+log "Pushing snapshot to ${VM_SSH}:${REMOTE_DATA}"
+"${RSYNC_BASE[@]}" "${SNAPSHOT}" "${VM_SSH}:${REMOTE_DATA}"
+rm -f "${SNAPSHOT}"
+
+log "Sync cycle complete."

--- a/deploy/systemd/fetchlinks-sync.service
+++ b/deploy/systemd/fetchlinks-sync.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Fetchlinks Pi sync cycle (pull control.db, ingest, retain, push data.db)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=fetchlinks
+Group=fetchlinks
+WorkingDirectory=__FETCHLINKS_APP_DIR__/ingest
+EnvironmentFile=-__FETCHLINKS_APP_DIR__/deploy/sync/fetchlinks-sync.env
+ExecStart=__FETCHLINKS_APP_DIR__/deploy/sync/fetchlinks-sync.sh
+Nice=10
+TimeoutStartSec=30min
+SyslogIdentifier=fetchlinks-sync
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=false
+ReadWritePaths=__FETCHLINKS_APP_DIR__/ingest
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/fetchlinks-sync.timer
+++ b/deploy/systemd/fetchlinks-sync.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Schedule for fetchlinks Pi sync cycle
+
+[Timer]
+OnCalendar=*:0/30
+Persistent=true
+RandomizedDelaySec=60
+Unit=fetchlinks-sync.service
+
+[Install]
+WantedBy=timers.target

--- a/ingest/config.py
+++ b/ingest/config.py
@@ -30,6 +30,10 @@ class PathsConfig:
     db: Path
     log_file: Path
     log_level: str = 'INFO'
+    # Admin-owned catalog DB (rss_feeds + subreddits identity/flags). When the
+    # ingest and web roles run on one host this defaults to ``db`` (one
+    # physical file); the Pi+VM split points it at a separate file.
+    control_db: Path = field(default_factory=Path)
 
 
 @dataclass(frozen=True)
@@ -158,10 +162,18 @@ def _build_paths(section: dict, base: Path) -> PathsConfig:
     if log_level not in _VALID_LOG_LEVELS:
         raise ValueError(f'[paths] log_level must be one of {sorted(_VALID_LOG_LEVELS)}')
 
+    db = _resolve_path(section['db'], base)
+    # control_db is optional; when unset the catalog shares the data db file.
+    if 'control_db' in section:
+        control_db = _resolve_path(section['control_db'], base)
+    else:
+        control_db = db
+
     return PathsConfig(
-        db=_resolve_path(section['db'], base),
+        db=db,
         log_file=_resolve_path(section['log_file'], base),
         log_level=log_level,
+        control_db=control_db,
     )
 
 

--- a/ingest/db_setup.py
+++ b/ingest/db_setup.py
@@ -129,6 +129,75 @@ def table_rss_feeds_configure(conn):
         raise RuntimeError('Failed to configure rss_feeds table') from exc
 
 
+def table_rss_feed_health_configure(conn):
+    """Create the data-side per-feed health table, keyed by ``normalized_url``.
+
+    Part of the ingest/web DB split: feed *identity + on/off* (``rss_feeds``)
+    is admin-owned and lives in the control DB, while per-feed *health/cache*
+    state is ingest-owned and lives here in the data DB. The two tables join
+    on ``normalized_url`` (never the autoincrement id, which won't match
+    across two separate DB files). When both roles run on one host they share
+    a single physical file and the join is native.
+
+    ``backfill_rss_feed_health`` seeds this from the legacy health columns
+    still carried on ``rss_feeds`` the first time it runs; nothing reads this
+    table until the ingest/web rewiring lands.
+    """
+    try:
+        conn.execute("""
+    CREATE TABLE IF NOT EXISTS rss_feed_health (
+    normalized_url       TEXT PRIMARY KEY,
+    last_fetched_at      TEXT,
+    last_success_at      TEXT,
+    last_status          INTEGER,
+    last_error           TEXT,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    etag                 TEXT,
+    last_modified        TEXT,
+    latest_entry_at      TEXT,
+    site_link            TEXT)
+    """)
+    except sqlite3.OperationalError as exc:
+        raise RuntimeError('Failed to configure rss_feed_health table') from exc
+
+
+def backfill_rss_feed_health(conn):
+    """One-time copy of health columns from ``rss_feeds`` into
+    ``rss_feed_health``.
+
+    Idempotent and non-destructive: uses ``INSERT OR IGNORE`` keyed by
+    ``normalized_url`` so re-runs are no-ops and existing health rows are
+    never clobbered. The legacy health columns on ``rss_feeds`` are left in
+    place for now (read by the current code until the rewiring lands); a later
+    cleanup drops them once nothing reads them. Runs only when both tables
+    exist in the same connection (single-file mode); in two-file mode the
+    health table starts empty and ingest populates it.
+
+    Returns the number of rows inserted.
+    """
+    tables = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('rss_feeds', 'rss_feed_health')"
+        )
+    }
+    if 'rss_feeds' not in tables or 'rss_feed_health' not in tables:
+        return 0
+
+    cur = conn.execute(
+        'INSERT OR IGNORE INTO rss_feed_health '
+        '(normalized_url, last_fetched_at, last_success_at, last_status, '
+        ' last_error, consecutive_failures, etag, last_modified, '
+        ' latest_entry_at, site_link) '
+        'SELECT normalized_url, last_fetched_at, last_success_at, last_status, '
+        '       last_error, consecutive_failures, etag, last_modified, '
+        '       latest_entry_at, site_link '
+        'FROM rss_feeds'
+    )
+    return cur.rowcount
+
+
 def _normalize_feed_url_for_migration(url):
     """Local copy of the normalizer to avoid a circular import on db_setup.
 
@@ -289,6 +358,8 @@ def db_initial_setup(db_path):
     table_rss_feed_state_configure(conn)
     table_rss_feeds_configure(conn)
     migrate_rss_feed_state_into_rss_feeds(conn)
+    table_rss_feed_health_configure(conn)
+    backfill_rss_feed_health(conn)
     table_reddit_state_configure(conn)
     table_subreddits_configure(conn)
     table_mastodon_state_configure(conn)

--- a/ingest/db_utils.py
+++ b/ingest/db_utils.py
@@ -131,6 +131,22 @@ def _ensure_rss_feeds_table(db):
     )
 
 
+def _ensure_rss_feed_health_table(db):
+    db.execute("""
+    CREATE TABLE IF NOT EXISTS rss_feed_health (
+    normalized_url       TEXT PRIMARY KEY,
+    last_fetched_at      TEXT,
+    last_success_at      TEXT,
+    last_status          INTEGER,
+    last_error           TEXT,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    etag                 TEXT,
+    last_modified        TEXT,
+    latest_entry_at      TEXT,
+    site_link            TEXT)
+    """)
+
+
 def _ensure_reddit_state_table(db):
     db.execute("""
     CREATE TABLE IF NOT EXISTS reddit_state (
@@ -268,54 +284,80 @@ def db_insert_rss_feeds(feeds, db_location):
         raise RuntimeError(f'Could not insert rss_feeds: {exc}') from exc
 
 
-def db_get_active_rss_feeds(db_location):
+def db_get_active_rss_feeds(db_location, data_db_location=None):
     """Return live (enabled, not tombstoned) feeds for ingestion.
 
-    Each row is ``(feed_id, feed_url, etag, last_modified)``. Cache headers
-    are returned as empty strings when NULL so callers can use them directly
-    in HTTP header construction.
+    Feed *identity + on/off* lives in ``db_location`` (the control DB,
+    ``rss_feeds``); per-feed cache headers live in ``data_db_location`` (the
+    data DB, ``rss_feed_health``, keyed by ``normalized_url``). When
+    ``data_db_location`` is omitted both come from ``db_location`` (single
+    physical file). The two are merged on ``normalized_url`` -- never an
+    autoincrement id, which would not match across two separate DB files.
+
+    Each row is ``(normalized_url, feed_url, etag, last_modified)``. Cache
+    headers are returned as empty strings when NULL so callers can use them
+    directly in HTTP header construction.
     """
+    data_db_location = data_db_location or db_location
     try:
         with sqlite3.connect(db_location) as db:
             _ensure_rss_feeds_table(db)
             cur = db.execute(
-                'SELECT feed_id, feed_url, etag, last_modified '
+                'SELECT feed_url, normalized_url '
                 'FROM rss_feeds '
                 'WHERE enabled = 1 AND deleted_at IS NULL '
-                'ORDER BY feed_id'
+                'ORDER BY normalized_url'
             )
-            return [
-                (row[0], row[1], row[2] or '', row[3] or '')
-                for row in cur.fetchall()
-            ]
+            identity = [(row[0], row[1]) for row in cur.fetchall()]
     except sqlite3.Error as exc:
         raise RuntimeError(f'Could not load active rss_feeds: {exc}') from exc
 
+    try:
+        with sqlite3.connect(data_db_location) as db:
+            _ensure_rss_feed_health_table(db)
+            cur = db.execute(
+                'SELECT normalized_url, etag, last_modified FROM rss_feed_health'
+            )
+            cache = {
+                row[0]: (row[1] or '', row[2] or '')
+                for row in cur.fetchall()
+            }
+    except sqlite3.Error as exc:
+        raise RuntimeError(f'Could not load rss_feed_health: {exc}') from exc
 
-def db_update_rss_feed_after_fetch(results, db_location, auto_disable_after):
-    """Persist per-feed fetch outcomes.
+    return [
+        (normalized, feed_url, *cache.get(normalized, ('', '')))
+        for (feed_url, normalized) in identity
+    ]
+
+
+def db_update_rss_feed_after_fetch(results, db_location):
+    """Persist per-feed fetch outcomes into ``rss_feed_health``.
 
     ``results`` is an iterable of dicts with keys:
-        feed_id (int), status (int), etag (str), last_modified (str),
-        error (str|None), latest_entry_at (str|None, optional).
+        normalized_url (str), status (int), etag (str), last_modified (str),
+        error (str|None), latest_entry_at (str|None, optional),
+        site_link (str|None, optional).
 
-    Status 200 or 304 counts as success: ``consecutive_failures`` resets to
-    0, ``last_success_at`` is updated, cache headers are persisted. Any
-    other status counts as failure: ``consecutive_failures`` is incremented
-    and ``last_error`` recorded. When ``auto_disable_after`` is positive
-    and the counter reaches that threshold, ``enabled`` flips to 0.
+    Health is ingest-owned and lives in the data DB, keyed by
+    ``normalized_url``. Status 200 or 304 counts as success:
+    ``consecutive_failures`` resets to 0, ``last_success_at`` is updated,
+    cache headers are persisted. Any other status counts as failure:
+    ``consecutive_failures`` is incremented and ``last_error`` recorded.
 
-    Returns the number of feeds auto-disabled on this call.
+    Auto-disable was removed when feed on/off moved to the admin-owned
+    control DB (the ingest job can no longer flip ``enabled``); failing feeds
+    are surfaced for manual action via their health row instead.
     """
     results = list(results)
     if not results:
-        return 0
+        return
     now = datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S')
-    auto_disabled = 0
     try:
         with sqlite3.connect(db_location) as db:
-            _ensure_rss_feeds_table(db)
+            _ensure_rss_feed_health_table(db)
             for r in results:
+                normalized = r['normalized_url']
                 status = r.get('status') or 0
                 success = status in (200, 304)
                 etag = r.get('etag') or None
@@ -326,66 +368,95 @@ def db_update_rss_feed_after_fetch(results, db_location, auto_disable_after):
 
                 if success:
                     db.execute(
-                        'UPDATE rss_feeds SET '
-                        '  last_fetched_at = ?, '
-                        '  last_success_at = ?, '
-                        '  last_status     = ?, '
+                        'INSERT INTO rss_feed_health '
+                        '(normalized_url, last_fetched_at, last_success_at, '
+                        ' last_status, last_error, consecutive_failures, '
+                        ' etag, last_modified, latest_entry_at, site_link) '
+                        'VALUES (?, ?, ?, ?, NULL, 0, ?, ?, ?, ?) '
+                        'ON CONFLICT(normalized_url) DO UPDATE SET '
+                        '  last_fetched_at = excluded.last_fetched_at, '
+                        '  last_success_at = excluded.last_success_at, '
+                        '  last_status     = excluded.last_status, '
                         '  last_error      = NULL, '
                         '  consecutive_failures = 0, '
-                        '  etag            = ?, '
-                        '  last_modified   = ?, '
-                        '  latest_entry_at = COALESCE(?, latest_entry_at), '
-                        '  site_link       = COALESCE(?, site_link) '
-                        'WHERE feed_id = ?',
-                        (now, now, status, etag, last_mod,
-                         latest_entry, site_link, r['feed_id']),
+                        '  etag            = excluded.etag, '
+                        '  last_modified   = excluded.last_modified, '
+                        '  latest_entry_at = COALESCE(excluded.latest_entry_at, '
+                        '                             rss_feed_health.latest_entry_at), '
+                        '  site_link       = COALESCE(excluded.site_link, '
+                        '                             rss_feed_health.site_link)',
+                        (normalized, now, now, status, etag, last_mod,
+                         latest_entry, site_link),
                     )
                 else:
                     db.execute(
-                        'UPDATE rss_feeds SET '
-                        '  last_fetched_at = ?, '
-                        '  last_status     = ?, '
-                        '  last_error      = ?, '
-                        '  consecutive_failures = consecutive_failures + 1 '
-                        'WHERE feed_id = ?',
-                        (now, status, error, r['feed_id']),
+                        'INSERT INTO rss_feed_health '
+                        '(normalized_url, last_fetched_at, last_status, '
+                        ' last_error, consecutive_failures) '
+                        'VALUES (?, ?, ?, ?, 1) '
+                        'ON CONFLICT(normalized_url) DO UPDATE SET '
+                        '  last_fetched_at = excluded.last_fetched_at, '
+                        '  last_status     = excluded.last_status, '
+                        '  last_error      = excluded.last_error, '
+                        '  consecutive_failures = '
+                        '      rss_feed_health.consecutive_failures + 1',
+                        (normalized, now, status, error),
                     )
-                    if auto_disable_after and auto_disable_after > 0:
-                        cur = db.execute(
-                            'UPDATE rss_feeds SET enabled = 0 '
-                            'WHERE feed_id = ? '
-                            '  AND enabled = 1 '
-                            '  AND consecutive_failures >= ?',
-                            (r['feed_id'], auto_disable_after),
-                        )
-                        if cur.rowcount:
-                            auto_disabled += cur.rowcount
             db.commit()
-            return auto_disabled
     except sqlite3.Error as exc:
-        raise RuntimeError(f'Could not update rss_feeds health: {exc}') from exc
+        raise RuntimeError(f'Could not update rss_feed_health: {exc}') from exc
 
 
-def db_get_all_rss_feeds(db_location):
+def db_get_all_rss_feeds(db_location, data_db_location=None):
     """Return every feed row, including disabled and tombstoned.
 
-    Used by the exporter and any future admin tooling. Each row is a dict
-    with all canonical columns from ``rss_feeds``.
+    Merges feed *identity* (control DB ``rss_feeds``) with per-feed *health*
+    (data DB ``rss_feed_health``) on ``normalized_url``. When
+    ``data_db_location`` is omitted both come from ``db_location``. Each row
+    is a dict carrying the full set of identity + health columns; feeds with
+    no health row yet get NULL health values (and ``consecutive_failures``
+    of 0). Used by the exporter and admin tooling.
     """
-    cols = ['feed_id', 'feed_url', 'normalized_url', 'enabled', 'added_at',
-            'deleted_at', 'last_fetched_at', 'last_success_at', 'last_status',
-            'last_error', 'consecutive_failures', 'etag', 'last_modified',
-            'latest_entry_at', 'site_link']
+    data_db_location = data_db_location or db_location
+    id_cols = ['feed_id', 'feed_url', 'normalized_url', 'enabled',
+               'added_at', 'deleted_at']
+    health_cols = ['last_fetched_at', 'last_success_at', 'last_status',
+                   'last_error', 'consecutive_failures', 'etag',
+                   'last_modified', 'latest_entry_at', 'site_link']
     try:
         with sqlite3.connect(db_location) as db:
             _ensure_rss_feeds_table(db)
             cur = db.execute(
-                f'SELECT {", ".join(cols)} FROM rss_feeds '
+                f'SELECT {", ".join(id_cols)} FROM rss_feeds '
                 'ORDER BY normalized_url'
             )
-            return [dict(zip(cols, row)) for row in cur.fetchall()]
+            feeds = [dict(zip(id_cols, row)) for row in cur.fetchall()]
     except sqlite3.Error as exc:
         raise RuntimeError(f'Could not load rss_feeds: {exc}') from exc
+
+    try:
+        with sqlite3.connect(data_db_location) as db:
+            _ensure_rss_feed_health_table(db)
+            cur = db.execute(
+                f'SELECT normalized_url, {", ".join(health_cols)} '
+                'FROM rss_feed_health'
+            )
+            health = {
+                row[0]: dict(zip(health_cols, row[1:]))
+                for row in cur.fetchall()
+            }
+    except sqlite3.Error as exc:
+        raise RuntimeError(f'Could not load rss_feed_health: {exc}') from exc
+
+    for feed in feeds:
+        h = health.get(feed['normalized_url'])
+        for col in health_cols:
+            if h is not None:
+                feed[col] = h[col]
+            else:
+                feed[col] = 0 if col == 'consecutive_failures' else None
+    return feeds
+
 
 
 def db_get_reddit_states(db_location):

--- a/ingest/export_rss_feeds.py
+++ b/ingest/export_rss_feeds.py
@@ -37,6 +37,7 @@ _LOG_LEVEL_VALUES = {'CRITICAL': 50, 'ERROR': 40, 'WARNING': 30, 'INFO': 20, 'DE
 @dataclass(frozen=True)
 class ExportConfig:
     db_path: Path
+    control_db_path: Path
     log_file: Path
     log_level: str
     export_path: Path | None
@@ -97,8 +98,15 @@ def load_export_config(config_path: Path) -> ExportConfig:
 
     log_file = _resolve_config_path(paths['log_file'], base)
     log_file.parent.mkdir(parents=True, exist_ok=True)
+    db_path = _resolve_config_path(paths['db'], base)
+    # control_db is optional; when unset the catalog shares the data db file.
+    if 'control_db' in paths:
+        control_db_path = _resolve_config_path(paths['control_db'], base)
+    else:
+        control_db_path = db_path
     return ExportConfig(
-        db_path=_resolve_config_path(paths['db'], base),
+        db_path=db_path,
+        control_db_path=control_db_path,
         log_file=log_file,
         log_level=log_level,
         export_path=_resolve_config_path(export_value, base) if export_value else None,
@@ -174,12 +182,16 @@ def write_atomic(output_path: Path, text: str) -> None:
         output_path.write_text(text, encoding='utf-8')
 
 
-def export_rss_feeds(db_path: Path, output_path: Path) -> dict:
+def export_rss_feeds(db_path: Path, output_path: Path,
+                     control_db_path: Path | None = None) -> dict:
     """Read every feed from the DB and write a snapshot to ``output_path``.
+
+    Identity comes from ``control_db_path`` (defaults to ``db_path``) and
+    health from ``db_path``; in single-host mode they are the same file.
 
     Returns ``{'total', 'active', 'disabled', 'removed', 'output_path'}``.
     """
-    rows = db_utils.db_get_all_rss_feeds(db_path)
+    rows = db_utils.db_get_all_rss_feeds(control_db_path or db_path, db_path)
     active, disabled, removed = _classify(rows)
     text = render_snapshot(rows, datetime.now(UTC), output_path)
     write_atomic(output_path, text)
@@ -217,7 +229,7 @@ def main(argv: list[str] | None = None) -> int:
                 '--output not given and [sources.rss].export_path is not set'
             )
 
-        stats = export_rss_feeds(cfg.db_path, output_path)
+        stats = export_rss_feeds(cfg.db_path, output_path, cfg.control_db_path)
         logger.info(
             'Exported rss_feeds: total=%s active=%s disabled=%s removed=%s -> %s',
             stats['total'], stats['active'], stats['disabled'],

--- a/ingest/fetch_links.py
+++ b/ingest/fetch_links.py
@@ -31,15 +31,18 @@ def configure_logging(cfg: app_config.AppConfig) -> None:
 def fetch_links(cfg: app_config.AppConfig) -> None:
     """Run every enabled ingest source."""
     db_path = cfg.paths.db
+    control_db_path = cfg.paths.control_db
     max_age = cfg.ingest.max_post_age_months
     host_kw = list(cfg.ingest.excluded_url_host_keywords)
     desc_kw = list(cfg.ingest.excluded_url_or_description_keywords)
 
     if cfg.sources.rss and cfg.sources.rss.enabled:
-        rss_links.run(cfg.sources.rss, db_path, max_age, host_kw, desc_kw)
+        rss_links.run(cfg.sources.rss, db_path, max_age, host_kw, desc_kw,
+                      control_db_path=control_db_path)
 
     if cfg.sources.reddit and cfg.sources.reddit.enabled:
-        reddit_links.run(cfg.sources.reddit, db_path, max_age, host_kw, desc_kw)
+        reddit_links.run(cfg.sources.reddit, db_path, max_age, host_kw, desc_kw,
+                         control_db_path=control_db_path)
 
     if cfg.sources.bluesky and cfg.sources.bluesky.enabled:
         bluesky_links.run(cfg.sources.bluesky, db_path, max_age, host_kw, desc_kw)

--- a/ingest/reddit_links.py
+++ b/ingest/reddit_links.py
@@ -48,10 +48,11 @@ def _log_rate_limit(response):
         logger.debug('Reddit rate limit remaining=%s reset=%s', remaining, reset)
 
 
-def get_subreddits(reddit_config: RedditSource, db_path: Path) -> tuple[list[dict], list[tuple[str, str]]]:
+def get_subreddits(reddit_config: RedditSource, db_path: Path, control_db_path: Path | None = None) -> tuple[list[dict], list[tuple[str, str]]]:
     subreddit_posts = []
     state_updates = []
-    active_subreddits = db_utils.db_get_active_subreddits(db_path)
+    control_db_path = control_db_path or db_path
+    active_subreddits = db_utils.db_get_active_subreddits(control_db_path)
     reddit_states = db_utils.db_get_reddit_states(db_path)
 
     reddit_auth = RedditAuth(str(reddit_config.credential_location))
@@ -168,8 +169,9 @@ def run(
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
     excluded_url_host_keywords: list[str] | None = None,
     excluded_url_or_description_keywords: list[str] | None = None,
+    control_db_path: Path | None = None,
 ):
-    subreddit_posts, state_updates = get_subreddits(reddit_config, db_path)
+    subreddit_posts, state_updates = get_subreddits(reddit_config, db_path, control_db_path)
     parsed_posts = parse_posts(subreddit_posts)
     recent_posts = ingest_limits.filter_posts_by_age(parsed_posts, max_post_age_months, 'Reddit')
     recent_posts = url_filters.filter_posts_by_url_host_keywords(

--- a/ingest/rss_feed_import.py
+++ b/ingest/rss_feed_import.py
@@ -589,7 +589,9 @@ def parse_args(argv: list[str]):
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     cfg = app_config.load_config(args.config)
-    db_path = cfg.paths.db
+    # rss_feeds is a control-owned identity table; seed it into control_db
+    # (which equals paths.db in single-host mode).
+    db_path = cfg.paths.control_db
     if args.seed_if_empty:
         inserted = seed_if_empty(args.seed_if_empty, db_path)
         if inserted:

--- a/ingest/rss_links.py
+++ b/ingest/rss_links.py
@@ -1,13 +1,14 @@
 """RSS ingestion using requests + ETag/Last-Modified caching.
 
-- Active feeds are read from the ``rss_feeds`` DB table (enabled = 1 and
-  not tombstoned). The seed file is only consulted at first bootstrap by
+- Active feeds are read from the control DB ``rss_feeds`` table (enabled = 1
+  and not tombstoned). The seed file is only consulted at first bootstrap by
   ``rss_feed_import.py --seed-if-empty``.
 - Uses requests with explicit timeouts so a single slow feed can't hang a worker.
 - Sends If-None-Match / If-Modified-Since headers; 304 responses skip parsing.
 - Per-feed health (etag, last_modified, last_status, consecutive_failures)
-  is persisted back into ``rss_feeds``; feeds whose failure count crosses
-  ``auto_disable_after_failures`` are auto-disabled.
+  is persisted into the data DB ``rss_feed_health`` table, keyed by
+  ``normalized_url``. Feeds are never auto-disabled by ingest; the failure
+  count is surfaced to the admin for manual removal.
 - Connection pooling via shared requests.Session.
 - Hands raw bytes to feedparser.parse() (no second network round-trip).
 """
@@ -29,16 +30,18 @@ THREADS = 50
 USER_AGENT = 'fetchlinks-rss/0.1 (+https://github.com/poptart-sommelier/fetchlinks)'
 
 # What we pass between fetch and parse:
-#   (feed_id, feed_url, parsed_feed_or_none, new_etag, new_last_modified,
-#    status_code, error_message_or_none)
+#   (normalized_url, feed_url, parsed_feed_or_none, new_etag,
+#    new_last_modified, status_code, error_message_or_none)
+# The natural key is ``normalized_url`` (not an autoincrement id), so health
+# updates can be written to the data DB without consulting the control DB.
 FetchResult = tuple[
-    int, str, feedparser.FeedParserDict | None, str, str, int, str | None,
+    str, str, feedparser.FeedParserDict | None, str, str, int, str | None,
 ]
 
 
 def _fetch_one(
     session: requests.Session,
-    feed_id: int,
+    normalized_url: str,
     url: str,
     cached_etag: str,
     cached_last_mod: str,
@@ -46,9 +49,10 @@ def _fetch_one(
 ) -> FetchResult:
     """Fetch a single feed using cached ETag/Last-Modified if present.
 
-    Returns ``(feed_id, url, feed_or_none, etag, last_modified, status, error)``.
-    ``feed_or_none`` is None for 304 / error cases (no parsing needed/possible).
-    ``error`` is None on 200/304 and a short label otherwise.
+    Returns ``(normalized_url, url, feed_or_none, etag, last_modified, status,
+    error)``. ``feed_or_none`` is None for 304 / error cases (no parsing
+    needed/possible). ``error`` is None on 200/304 and a short label
+    otherwise.
     """
     headers = {}
     if cached_etag:
@@ -61,7 +65,7 @@ def _fetch_one(
     except requests.RequestException as exc:
         logger.warning('Failed to fetch %s: %s', url, type(exc).__name__)
         # Preserve cached values so we keep retrying with conditional headers.
-        return (feed_id, url, None, cached_etag, cached_last_mod, 0,
+        return (normalized_url, url, None, cached_etag, cached_last_mod, 0,
                 type(exc).__name__)
 
     new_etag = resp.headers.get('ETag', cached_etag)
@@ -69,34 +73,35 @@ def _fetch_one(
 
     if resp.status_code == 304:
         logger.debug('Feed unchanged (304): %s', url)
-        return (feed_id, url, None, new_etag, new_last_mod, 304, None)
+        return (normalized_url, url, None, new_etag, new_last_mod, 304, None)
 
     if resp.status_code != 200:
         logger.warning('Feed %s returned HTTP %s', url, resp.status_code)
-        return (feed_id, url, None, new_etag, new_last_mod, resp.status_code,
-                f'HTTP {resp.status_code}')
+        return (normalized_url, url, None, new_etag, new_last_mod,
+                resp.status_code, f'HTTP {resp.status_code}')
 
     try:
         feed = feedparser.parse(resp.content)
     except Exception as exc:
         logger.error('Failed to parse %s: %s', url, exc)
-        return (feed_id, url, None, new_etag, new_last_mod, 200,
+        return (normalized_url, url, None, new_etag, new_last_mod, 200,
                 f'parse error: {exc}')
 
     if feed.bozo and not feed.entries:
         logger.warning('Feed %s parse error with no entries: %s',
                        url, feed.bozo_exception)
-        return (feed_id, url, None, new_etag, new_last_mod, 200,
+        return (normalized_url, url, None, new_etag, new_last_mod, 200,
                 f'parse error: {feed.bozo_exception}')
 
-    return (feed_id, url, feed, new_etag, new_last_mod, 200, None)
+    return (normalized_url, url, feed, new_etag, new_last_mod, 200, None)
 
 
 def fetch_feeds(feeds, timeout):
     """Fetch every feed in parallel.
 
-    ``feeds`` is an iterable of ``(feed_id, feed_url, etag, last_modified)``
-    tuples (typically from ``db_utils.db_get_active_rss_feeds``).
+    ``feeds`` is an iterable of
+    ``(normalized_url, feed_url, etag, last_modified)`` tuples (typically from
+    ``db_utils.db_get_active_rss_feeds``).
     """
     results: list[FetchResult] = []
     with requests.Session() as session:
@@ -104,9 +109,9 @@ def fetch_feeds(feeds, timeout):
         session.headers['Accept-Encoding'] = 'gzip, deflate'
         with concurrent.futures.ThreadPoolExecutor(max_workers=THREADS) as pool:
             futures = [
-                pool.submit(_fetch_one, session, feed_id, url,
+                pool.submit(_fetch_one, session, normalized_url, url,
                             etag, last_mod, timeout)
-                for (feed_id, url, etag, last_mod) in feeds
+                for (normalized_url, url, etag, last_mod) in feeds
             ]
             for future in concurrent.futures.as_completed(futures):
                 results.append(future.result())
@@ -115,7 +120,7 @@ def fetch_feeds(feeds, timeout):
 
 def parse_posts(fetch_results):
     posts: list[RssPost] = []
-    for _fid, url, feed, _etag, _lm, _status, _err in fetch_results:
+    for _norm, url, feed, _etag, _lm, _status, _err in fetch_results:
         if feed is None:
             continue
         feed_meta = feed.feed if hasattr(feed, 'feed') else {}
@@ -195,13 +200,17 @@ def run(
     max_post_age_months: int = ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
     excluded_url_host_keywords: list[str] | None = None,
     excluded_url_or_description_keywords: list[str] | None = None,
+    control_db_path: Path | None = None,
 ):
     """Fetch every active RSS feed, parse + filter posts, persist health.
 
-    ``rss_source`` is a ``config.RssSource``. Active feeds come from the
-    ``rss_feeds`` DB table; the seed file is *not* consulted here.
+    ``rss_source`` is a ``config.RssSource``. Feed *identity + on/off* lives
+    in the control DB (``control_db_path``; defaults to ``db_path`` for
+    single-host installs); posts and per-feed health are written to the data
+    DB (``db_path``). The seed file is *not* consulted here.
     """
-    active = db_utils.db_get_active_rss_feeds(db_path)
+    control_db_path = control_db_path or db_path
+    active = db_utils.db_get_active_rss_feeds(control_db_path, db_path)
     if not active:
         logger.info('RSS: no active feeds (rss_feeds table is empty or all disabled)')
         return
@@ -210,21 +219,17 @@ def run(
 
     health_updates = [
         {
-            'feed_id': fid,
+            'normalized_url': normalized_url,
             'status': status,
             'etag': etag,
             'last_modified': last_mod,
             'error': err,
             'site_link': pick_site_link(feed),
         }
-        for (fid, _url, feed, etag, last_mod, status, err) in fetch_results
+        for (normalized_url, _url, feed, etag, last_mod, status, err)
+        in fetch_results
     ]
-    auto_disabled = db_utils.db_update_rss_feed_after_fetch(
-        health_updates, db_path, rss_source.auto_disable_after_failures,
-    )
-    if auto_disabled:
-        logger.warning('RSS: auto-disabled %s feed(s) after consecutive failures',
-                       auto_disabled)
+    db_utils.db_update_rss_feed_after_fetch(health_updates, db_path)
 
     parsed_posts = parse_posts(fetch_results)
     recent_posts = ingest_limits.filter_posts_by_age(
@@ -235,7 +240,8 @@ def run(
         recent_posts, excluded_url_or_description_keywords or [], 'RSS')
 
     counts = {200: 0, 304: 0, 'error': 0}
-    for _fid, _u, _f, _e, _l, status, _err in fetch_results:
+    for _norm, _u, _f, _e, _l, status, _err in fetch_results:
+
         if status == 200:
             counts[200] += 1
         elif status == 304:

--- a/ingest/subreddit_import.py
+++ b/ingest/subreddit_import.py
@@ -92,7 +92,9 @@ def parse_args(argv: list[str]):
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     cfg = app_config.load_config(args.config)
-    db_path = cfg.paths.db
+    # subreddits is a control-owned identity table; seed it into control_db
+    # (which equals paths.db in single-host mode).
+    db_path = cfg.paths.control_db
 
     subreddits = resolve_seed_names(cfg.sources.reddit)
     inserted = seed_if_empty(subreddits, db_path)

--- a/ingest/tests/test_config.py
+++ b/ingest/tests/test_config.py
@@ -41,6 +41,27 @@ class LoadConfigTests(unittest.TestCase):
             self.assertEqual(cfg.sources.bluesky, None)
             self.assertEqual(cfg.sources.mastodon, None)
 
+    def test_control_db_defaults_to_data_db_when_unset(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cfg_path = _toml(tmp_path)
+
+            cfg = app_config.load_config(cfg_path)
+
+            self.assertEqual(cfg.paths.control_db, cfg.paths.db)
+
+    def test_control_db_resolves_separately_when_set(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            cfg_path = _toml(tmp_path, extra='control_db = "control.db"\n')
+
+            cfg = app_config.load_config(cfg_path)
+
+            self.assertEqual(
+                cfg.paths.control_db, (tmp_path / 'control.db').resolve()
+            )
+            self.assertNotEqual(cfg.paths.control_db, cfg.paths.db)
+
     def test_missing_file_raises(self):
         with self.assertRaises(FileNotFoundError):
             app_config.load_config(Path('/tmp/does-not-exist.toml'))

--- a/ingest/tests/test_db_setup.py
+++ b/ingest/tests/test_db_setup.py
@@ -29,6 +29,71 @@ class DbSetupTests(unittest.TestCase):
             self.assertIn("posts", tables)
             self.assertIn("post_urls", tables)
 
+    def test_rss_feed_health_table_created(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "db" / "fetchlinks.db"
+
+            db_setup.db_initial_setup(db_path)
+
+            with sqlite3.connect(db_path) as conn:
+                columns = {
+                    row[1]
+                    for row in conn.execute("PRAGMA table_info(rss_feed_health)")
+                }
+
+            self.assertEqual(
+                columns,
+                {
+                    "normalized_url",
+                    "last_fetched_at",
+                    "last_success_at",
+                    "last_status",
+                    "last_error",
+                    "consecutive_failures",
+                    "etag",
+                    "last_modified",
+                    "latest_entry_at",
+                    "site_link",
+                },
+            )
+
+    def test_backfill_rss_feed_health_copies_and_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "db" / "fetchlinks.db"
+            db_setup.db_initial_setup(db_path)
+
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    "INSERT INTO rss_feeds "
+                    "(feed_url, normalized_url, enabled, added_at, "
+                    " last_status, consecutive_failures, etag, site_link) "
+                    "VALUES (?, ?, 1, ?, ?, ?, ?, ?)",
+                    (
+                        "https://example.com/feed",
+                        "https://example.com/feed",
+                        "2026-06-10 00:00:00",
+                        200,
+                        3,
+                        '"abc"',
+                        "https://example.com",
+                    ),
+                )
+                conn.commit()
+
+                first = db_setup.backfill_rss_feed_health(conn)
+                second = db_setup.backfill_rss_feed_health(conn)
+                conn.commit()
+
+                row = conn.execute(
+                    "SELECT last_status, consecutive_failures, etag, site_link "
+                    "FROM rss_feed_health WHERE normalized_url = ?",
+                    ("https://example.com/feed",),
+                ).fetchone()
+
+            self.assertEqual(first, 1)
+            self.assertEqual(second, 0)
+            self.assertEqual(row, (200, 3, '"abc"', "https://example.com"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ingest/tests/test_db_utils_rss_feeds.py
+++ b/ingest/tests/test_db_utils_rss_feeds.py
@@ -24,6 +24,24 @@ def _row_by_id(db_path: Path, feed_id: int) -> dict:
         ).fetchone())
 
 
+def _normalized_for(db_path: Path, feed_id: int) -> str:
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute(
+            'SELECT normalized_url FROM rss_feeds WHERE feed_id = ?', (feed_id,)
+        ).fetchone()[0]
+
+
+def _health_row(db_path: Path, normalized_url: str) -> dict | None:
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            'SELECT * FROM rss_feed_health WHERE normalized_url = ?',
+            (normalized_url,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+
+
 class CountAndInsertTests(unittest.TestCase):
     def test_count_empty(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -70,6 +88,8 @@ class GetActiveTests(unittest.TestCase):
             active = db_utils.db_get_active_rss_feeds(db_path)
             urls = {row[1] for row in active}
             self.assertEqual(urls, {'https://a/'})
+            # First element is now the natural key (normalized_url).
+            self.assertEqual(active[0][0], 'https://a/')
             # Cache headers normalised to empty string.
             self.assertEqual(active[0][2], '')
             self.assertEqual(active[0][3], '')
@@ -90,20 +110,22 @@ class UpdateAfterFetchTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             db_path = _fresh_db(Path(tmp))
             fid_a, _ = self._setup_two(db_path)
-            # Pre-set a failure count.
-            with sqlite3.connect(db_path) as conn:
-                conn.execute('UPDATE rss_feeds SET consecutive_failures = 5 '
-                             'WHERE feed_id = ?', (fid_a,))
-                conn.commit()
-
-            disabled = db_utils.db_update_rss_feed_after_fetch(
-                [{'feed_id': fid_a, 'status': 200, 'etag': 'e1',
-                  'last_modified': 'lm1', 'error': None}],
-                db_path, 10,
+            norm_a = _normalized_for(db_path, fid_a)
+            # Pre-set a failure count in the health table.
+            db_utils.db_update_rss_feed_after_fetch(
+                [{'normalized_url': norm_a, 'status': 500, 'etag': '',
+                  'last_modified': '', 'error': 'HTTP 500'}],
+                db_path,
             )
 
-            self.assertEqual(disabled, 0)
-            row = _row_by_id(db_path, fid_a)
+            result = db_utils.db_update_rss_feed_after_fetch(
+                [{'normalized_url': norm_a, 'status': 200, 'etag': 'e1',
+                  'last_modified': 'lm1', 'error': None}],
+                db_path,
+            )
+
+            self.assertIsNone(result)
+            row = _health_row(db_path, norm_a)
             self.assertEqual(row['consecutive_failures'], 0)
             self.assertEqual(row['etag'], 'e1')
             self.assertEqual(row['last_modified'], 'lm1')
@@ -115,12 +137,13 @@ class UpdateAfterFetchTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             db_path = _fresh_db(Path(tmp))
             fid_a, _ = self._setup_two(db_path)
+            norm_a = _normalized_for(db_path, fid_a)
             db_utils.db_update_rss_feed_after_fetch(
-                [{'feed_id': fid_a, 'status': 304, 'etag': 'e2',
+                [{'normalized_url': norm_a, 'status': 304, 'etag': 'e2',
                   'last_modified': 'lm2', 'error': None}],
-                db_path, 10,
+                db_path,
             )
-            row = _row_by_id(db_path, fid_a)
+            row = _health_row(db_path, norm_a)
             self.assertEqual(row['last_status'], 304)
             self.assertEqual(row['consecutive_failures'], 0)
 
@@ -128,56 +151,42 @@ class UpdateAfterFetchTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             db_path = _fresh_db(Path(tmp))
             fid_a, _ = self._setup_two(db_path)
+            norm_a = _normalized_for(db_path, fid_a)
 
             db_utils.db_update_rss_feed_after_fetch(
-                [{'feed_id': fid_a, 'status': 500, 'etag': '',
+                [{'normalized_url': norm_a, 'status': 500, 'etag': '',
                   'last_modified': '', 'error': 'HTTP 500'}],
-                db_path, 10,
+                db_path,
             )
-            row = _row_by_id(db_path, fid_a)
+            row = _health_row(db_path, norm_a)
             self.assertEqual(row['consecutive_failures'], 1)
             self.assertEqual(row['last_status'], 500)
             self.assertEqual(row['last_error'], 'HTTP 500')
-            self.assertEqual(row['enabled'], 1)
+            # Feed identity (enabled) is never touched by health updates.
+            self.assertEqual(_row_by_id(db_path, fid_a)['enabled'], 1)
 
-    def test_auto_disables_when_threshold_reached(self):
+    def test_repeated_failures_keep_incrementing_without_disabling(self):
         with tempfile.TemporaryDirectory() as tmp:
             db_path = _fresh_db(Path(tmp))
             fid_a, _ = self._setup_two(db_path)
-            with sqlite3.connect(db_path) as conn:
-                conn.execute('UPDATE rss_feeds SET consecutive_failures = 9 '
-                             'WHERE feed_id = ?', (fid_a,))
-                conn.commit()
+            norm_a = _normalized_for(db_path, fid_a)
+            for _ in range(15):
+                db_utils.db_update_rss_feed_after_fetch(
+                    [{'normalized_url': norm_a, 'status': 0, 'etag': '',
+                      'last_modified': '', 'error': 'ConnectionError'}],
+                    db_path,
+                )
 
-            disabled = db_utils.db_update_rss_feed_after_fetch(
-                [{'feed_id': fid_a, 'status': 0, 'etag': '',
-                  'last_modified': '', 'error': 'ConnectionError'}],
-                db_path, 10,
-            )
+            self.assertEqual(
+                _health_row(db_path, norm_a)['consecutive_failures'], 15)
+            # enabled stays 1 -- ingest never auto-disables.
+            self.assertEqual(_row_by_id(db_path, fid_a)['enabled'], 1)
 
-            self.assertEqual(disabled, 1)
-            row = _row_by_id(db_path, fid_a)
-            self.assertEqual(row['enabled'], 0)
-            self.assertEqual(row['consecutive_failures'], 10)
-
-    def test_auto_disable_threshold_zero_means_never(self):
+    def test_empty_results_is_noop(self):
         with tempfile.TemporaryDirectory() as tmp:
             db_path = _fresh_db(Path(tmp))
-            fid_a, _ = self._setup_two(db_path)
-            with sqlite3.connect(db_path) as conn:
-                conn.execute('UPDATE rss_feeds SET consecutive_failures = 999 '
-                             'WHERE feed_id = ?', (fid_a,))
-                conn.commit()
-
-            disabled = db_utils.db_update_rss_feed_after_fetch(
-                [{'feed_id': fid_a, 'status': 500, 'etag': '',
-                  'last_modified': '', 'error': 'HTTP 500'}],
-                db_path, 0,
-            )
-
-            self.assertEqual(disabled, 0)
-            row = _row_by_id(db_path, fid_a)
-            self.assertEqual(row['enabled'], 1)
+            self.assertIsNone(
+                db_utils.db_update_rss_feed_after_fetch([], db_path))
 
 
 class GetAllRssFeedsTests(unittest.TestCase):
@@ -196,6 +205,63 @@ class GetAllRssFeedsTests(unittest.TestCase):
                         'latest_entry_at'):
                 self.assertIn(key, row)
             self.assertEqual(row['feed_url'], 'https://a/')
+
+    def test_merges_health_when_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = _fresh_db(Path(tmp))
+            db_utils.db_insert_rss_feeds([('https://a/', 'https://a/')], db_path)
+            db_utils.db_update_rss_feed_after_fetch(
+                [{'normalized_url': 'https://a/', 'status': 200, 'etag': 'e1',
+                  'last_modified': 'lm1', 'error': None}],
+                db_path,
+            )
+            row = db_utils.db_get_all_rss_feeds(db_path)[0]
+            self.assertEqual(row['etag'], 'e1')
+            self.assertEqual(row['last_status'], 200)
+            self.assertEqual(row['consecutive_failures'], 0)
+
+    def test_feeds_without_health_default_to_null(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = _fresh_db(Path(tmp))
+            db_utils.db_insert_rss_feeds([('https://a/', 'https://a/')], db_path)
+            row = db_utils.db_get_all_rss_feeds(db_path)[0]
+            self.assertIsNone(row['etag'])
+            self.assertIsNone(row['last_status'])
+            self.assertEqual(row['consecutive_failures'], 0)
+
+
+class TwoFileModeTests(unittest.TestCase):
+    """Identity in the control DB, health in a separate data DB."""
+
+    def test_active_and_all_merge_across_separate_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            control_db = Path(tmp) / 'control.db'
+            data_db = Path(tmp) / 'data.db'
+            db_setup.db_initial_setup(control_db)
+            db_setup.db_initial_setup(data_db)
+
+            # Identity lives only in the control DB.
+            db_utils.db_insert_rss_feeds([('https://a/', 'https://a/')], control_db)
+            # Health lives only in the data DB.
+            db_utils.db_update_rss_feed_after_fetch(
+                [{'normalized_url': 'https://a/', 'status': 200, 'etag': 'e1',
+                  'last_modified': 'lm1', 'error': None}],
+                data_db,
+            )
+
+            active = db_utils.db_get_active_rss_feeds(control_db, data_db)
+            self.assertEqual(len(active), 1)
+            normalized, feed_url, etag, last_mod = active[0]
+            self.assertEqual(normalized, 'https://a/')
+            self.assertEqual(feed_url, 'https://a/')
+            self.assertEqual(etag, 'e1')
+            self.assertEqual(last_mod, 'lm1')
+
+            row = db_utils.db_get_all_rss_feeds(control_db, data_db)[0]
+            self.assertEqual(row['feed_url'], 'https://a/')
+            self.assertEqual(row['etag'], 'e1')
+            self.assertEqual(row['last_status'], 200)
+
 
 
 if __name__ == '__main__':

--- a/ingest/tests/test_fetch_links.py
+++ b/ingest/tests/test_fetch_links.py
@@ -19,7 +19,8 @@ from config import (
 
 
 def _paths(tmp: Path) -> PathsConfig:
-    return PathsConfig(db=tmp / 'fetchlinks.db', log_file=tmp / 'fetchlinks.log', log_level='INFO')
+    db = tmp / 'fetchlinks.db'
+    return PathsConfig(db=db, control_db=db, log_file=tmp / 'fetchlinks.log', log_level='INFO')
 
 
 def _cfg(
@@ -62,8 +63,8 @@ class FetchLinksRoutingTests(unittest.TestCase):
              patch.object(fetch_links.mastodon_links, 'sync_follows') as mastodon_sync:
             fetch_links.fetch_links(cfg)
 
-        rss_run.assert_called_once_with(rss, db_path, default_age, [], [])
-        reddit_run.assert_called_once_with(reddit, db_path, default_age, [], [])
+        rss_run.assert_called_once_with(rss, db_path, default_age, [], [], control_db_path=db_path)
+        reddit_run.assert_called_once_with(reddit, db_path, default_age, [], [], control_db_path=db_path)
         bluesky_run.assert_called_once_with(bluesky, db_path, default_age, [], [])
         mastodon_run.assert_called_once_with(mastodon, db_path, default_age, [], [])
         bluesky_sync.assert_called_once_with(bluesky, db_path)
@@ -78,7 +79,7 @@ class FetchLinksRoutingTests(unittest.TestCase):
         with patch.object(fetch_links.reddit_links, 'run') as reddit_run:
             fetch_links.fetch_links(cfg)
 
-        reddit_run.assert_called_once_with(reddit, cfg.paths.db, 6, [], [])
+        reddit_run.assert_called_once_with(reddit, cfg.paths.db, 6, [], [], control_db_path=cfg.paths.control_db)
 
     def test_passes_keyword_filters_to_sources(self):
         tmp = Path('/tmp/fl-test')
@@ -97,6 +98,7 @@ class FetchLinksRoutingTests(unittest.TestCase):
             ingest_limits.DEFAULT_MAX_POST_AGE_MONTHS,
             ['insider'],
             ['politics'],
+            control_db_path=cfg.paths.control_db,
         )
 
     def test_skips_disabled_sources(self):

--- a/ingest/tests/test_reddit_links.py
+++ b/ingest/tests/test_reddit_links.py
@@ -205,7 +205,7 @@ class RedditRunTests(unittest.TestCase):
              patch.object(reddit_links.db_utils, 'db_set_reddit_states') as set_states:
             reddit_links.run(self.reddit_config, self.db_path)
 
-        get_subreddits.assert_called_once_with(self.reddit_config, self.db_path)
+        get_subreddits.assert_called_once_with(self.reddit_config, self.db_path, None)
         parse_posts.assert_called_once()
         db_insert.assert_not_called()
         set_states.assert_called_once_with(state_updates, self.db_path)

--- a/ingest/tests/test_rss_links.py
+++ b/ingest/tests/test_rss_links.py
@@ -270,18 +270,22 @@ class RunTests(unittest.TestCase):
                           'db_update_rss_feed_after_fetch') as update:
             rss_links.run(_rss_source(), self.db_path)
 
-        get_active.assert_called_once_with(self.db_path)
+        # control_db_path defaults to db_path for single-host installs.
+        get_active.assert_called_once_with(self.db_path, self.db_path)
         fetch_feeds.assert_not_called()
         update.assert_not_called()
 
     def test_run_persists_health_even_when_no_posts(self):
         active = [
-            (1, 'https://a.example/feed.xml', 'old-etag', 'old-lm'),
-            (2, 'https://b.example/feed.xml', '', ''),
+            ('https://a.example/feed.xml', 'https://a.example/feed.xml',
+             'old-etag', 'old-lm'),
+            ('https://b.example/feed.xml', 'https://b.example/feed.xml', '', ''),
         ]
         fetch_results = [
-            (1, 'https://a.example/feed.xml', None, 'new-etag', 'new-lm', 304, None),
-            (2, 'https://b.example/feed.xml', None, '', '', 0, 'ConnectionError'),
+            ('https://a.example/feed.xml', 'https://a.example/feed.xml',
+             None, 'new-etag', 'new-lm', 304, None),
+            ('https://b.example/feed.xml', 'https://b.example/feed.xml',
+             None, '', '', 0, 'ConnectionError'),
         ]
 
         with patch.object(rss_links.db_utils, 'db_get_active_rss_feeds',
@@ -289,33 +293,48 @@ class RunTests(unittest.TestCase):
              patch.object(rss_links, 'fetch_feeds',
                           return_value=fetch_results) as fetch_feeds, \
              patch.object(rss_links.db_utils,
-                          'db_update_rss_feed_after_fetch',
-                          return_value=0) as update, \
+                          'db_update_rss_feed_after_fetch') as update, \
              patch.object(rss_links, 'parse_posts', return_value=[]), \
              patch.object(rss_links.db_utils, 'db_insert') as db_insert:
             rss_links.run(_rss_source(request_timeout_seconds=20), self.db_path)
 
-        get_active.assert_called_once_with(self.db_path)
+        get_active.assert_called_once_with(self.db_path, self.db_path)
         fetch_feeds.assert_called_once_with(active, 20)
         update.assert_called_once()
-        rows, db_path_arg, auto_disable = update.call_args.args
+        rows, db_path_arg = update.call_args.args
         self.assertEqual(db_path_arg, self.db_path)
-        self.assertEqual(auto_disable, 10)
         self.assertEqual(len(rows), 2)
-        self.assertEqual(rows[0]['feed_id'], 1)
+        self.assertEqual(rows[0]['normalized_url'], 'https://a.example/feed.xml')
         self.assertEqual(rows[0]['status'], 304)
         self.assertEqual(rows[1]['error'], 'ConnectionError')
         db_insert.assert_not_called()
 
+    def test_run_uses_separate_control_db_when_provided(self):
+        control_db = Path('/tmp/db/control.db')
+        active = [('https://a/', 'https://a/', '', '')]
+
+        with patch.object(rss_links.db_utils, 'db_get_active_rss_feeds',
+                          return_value=active) as get_active, \
+             patch.object(rss_links, 'fetch_feeds', return_value=[]), \
+             patch.object(rss_links.db_utils,
+                          'db_update_rss_feed_after_fetch'), \
+             patch.object(rss_links, 'parse_posts', return_value=[]), \
+             patch.object(rss_links.db_utils, 'db_insert'):
+            rss_links.run(_rss_source(), self.db_path,
+                          control_db_path=control_db)
+
+        get_active.assert_called_once_with(control_db, self.db_path)
+
     def test_run_inserts_parsed_posts(self):
-        active = [(1, 'https://feed.example/rss.xml', '', '')]
+        active = [('https://feed.example/rss.xml', 'https://feed.example/rss.xml',
+                   '', '')]
         parsed_posts = [object()]
 
         with patch.object(rss_links.db_utils, 'db_get_active_rss_feeds',
                           return_value=active), \
              patch.object(rss_links, 'fetch_feeds', return_value=[]), \
              patch.object(rss_links.db_utils,
-                          'db_update_rss_feed_after_fetch', return_value=0), \
+                          'db_update_rss_feed_after_fetch'), \
              patch.object(rss_links, 'parse_posts', return_value=parsed_posts), \
              patch.object(rss_links.db_utils, 'db_insert',
                           return_value=1) as db_insert:
@@ -324,7 +343,8 @@ class RunTests(unittest.TestCase):
         db_insert.assert_called_once_with(parsed_posts, self.db_path)
 
     def test_run_filters_old_posts_before_insert(self):
-        active = [(1, 'https://feed.example/rss.xml', '', '')]
+        active = [('https://feed.example/rss.xml', 'https://feed.example/rss.xml',
+                   '', '')]
         old_post = SimpleNamespace(date_created='2000-01-01 00:00:00')
         recent_post = SimpleNamespace(date_created='2999-01-01 00:00:00')
 
@@ -332,12 +352,13 @@ class RunTests(unittest.TestCase):
                           return_value=active), \
              patch.object(rss_links, 'fetch_feeds', return_value=[]), \
              patch.object(rss_links.db_utils,
-                          'db_update_rss_feed_after_fetch', return_value=0), \
+                          'db_update_rss_feed_after_fetch'), \
              patch.object(rss_links, 'parse_posts',
                           return_value=[old_post, recent_post]), \
              patch.object(rss_links.db_utils, 'db_insert',
                           return_value=1) as db_insert:
             rss_links.run(_rss_source(), self.db_path, max_post_age_months=3)
+
 
         db_insert.assert_called_once_with([recent_post], self.db_path)
 

--- a/web/src/server/bluesky.ts
+++ b/web/src/server/bluesky.ts
@@ -12,7 +12,8 @@ import type {
   BlueskyFollowsSnapshot,
 } from "../models/bluesky-follows";
 
-type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
+type DbConfig = Pick<AppConfig, "fetchlinksDbPath"> &
+  Partial<Pick<AppConfig, "controlDbPath">>;
 
 type Env = Partial<Record<string, string | undefined>>;
 
@@ -33,51 +34,29 @@ const SELECT_COLUMNS = `
   f.display_name AS displayName,
   f.synced_at    AS syncedAt,
   (
-    SELECT MAX(p.date_created) FROM posts p
+    SELECT MAX(p.date_created) FROM data.posts p
     WHERE p.source_type = 'bluesky'
       AND LOWER(p.source) = '${BLUESKY_PROFILE_PREFIX}' || LOWER(f.handle)
   )              AS latestPostAt,
   (
-    SELECT p.source FROM posts p
+    SELECT p.source FROM data.posts p
     WHERE p.source_type = 'bluesky'
       AND LOWER(p.source) = '${BLUESKY_PROFILE_PREFIX}' || LOWER(f.handle)
     LIMIT 1
   )              AS postSource
 `;
 
-// Idempotent guard so the web admin can read the snapshot even if the
-// ingest bootstrap hasn't created the table yet. Mirrors
-// table_bluesky_follows_configure in ingest/db_setup.py.
-function ensureBlueskyFollowsSchema(database: WritableFetchlinksDatabase): void {
-  database.exec(`
-    CREATE TABLE IF NOT EXISTS bluesky_follows (
-      did          TEXT PRIMARY KEY,
-      handle       TEXT NOT NULL,
-      display_name TEXT,
-      synced_at    TEXT NOT NULL
-    )
-  `);
-  database.exec(
-    "CREATE INDEX IF NOT EXISTS idx_bluesky_follows_handle ON bluesky_follows(handle)",
-  );
-}
-
 export function openWritableBlueskyDatabase(
   config: DbConfig,
 ): WritableFetchlinksDatabase {
-  const database = openWritableFetchlinksDatabase(config);
-  ensureBlueskyFollowsSchema(database);
-  return database;
+  return openWritableFetchlinksDatabase(config);
 }
 
 export function withWritableBlueskyDatabase<T>(
   config: DbConfig,
   callback: (database: WritableFetchlinksDatabase) => T,
 ): T {
-  return withWritableFetchlinksDatabase(config, (database) => {
-    ensureBlueskyFollowsSchema(database);
-    return callback(database);
-  });
+  return withWritableFetchlinksDatabase(config, callback);
 }
 
 export function openConfiguredWritableBlueskyDatabase(
@@ -100,7 +79,7 @@ function rowToFollow(row: BlueskyFollowRow): BlueskyFollow {
 export function getBlueskyFollows(database: DatabaseSync): BlueskyFollowsSnapshot {
   const rows = database
     .prepare(
-      `SELECT ${SELECT_COLUMNS} FROM bluesky_follows f ORDER BY LOWER(f.handle) ASC`,
+      `SELECT ${SELECT_COLUMNS} FROM data.bluesky_follows f ORDER BY LOWER(f.handle) ASC`,
     )
     .all() as BlueskyFollowRow[];
   const follows = rows.map(rowToFollow);

--- a/web/src/server/config.test.ts
+++ b/web/src/server/config.test.ts
@@ -28,7 +28,35 @@ describe("loadAppConfig", () => {
     expect(config).toEqual({
       fetchlinksDbPath: "/home/ubuntu/fetchlinks/ingest/db/fetchlinks.db",
       fetchlinksDbReadOnlyUri: "file:///home/ubuntu/fetchlinks/ingest/db/fetchlinks.db?mode=ro",
+      controlDbPath: "/home/ubuntu/fetchlinks/ingest/db/fetchlinks.db",
     });
+  });
+
+  it("defaults the control DB to the data DB when FETCHLINKS_CONTROL_DB is unset", () => {
+    const config = loadAppConfig({
+      FETCHLINKS_DB: "/srv/fetchlinks/data.db",
+    });
+
+    expect(config.controlDbPath).toBe("/srv/fetchlinks/data.db");
+  });
+
+  it("resolves a separate control DB when FETCHLINKS_CONTROL_DB is set", () => {
+    const config = loadAppConfig({
+      FETCHLINKS_DB: "/srv/fetchlinks/data.db",
+      FETCHLINKS_CONTROL_DB: "/srv/fetchlinks/control.db",
+    });
+
+    expect(config.fetchlinksDbPath).toBe("/srv/fetchlinks/data.db");
+    expect(config.controlDbPath).toBe("/srv/fetchlinks/control.db");
+  });
+
+  it("rejects a relative FETCHLINKS_CONTROL_DB", () => {
+    expect(() =>
+      loadAppConfig({
+        FETCHLINKS_DB: "/srv/fetchlinks/data.db",
+        FETCHLINKS_CONTROL_DB: "control.db",
+      }),
+    ).toThrowError(/FETCHLINKS_CONTROL_DB must be an absolute path/);
   });
 });
 

--- a/web/src/server/config.ts
+++ b/web/src/server/config.ts
@@ -6,6 +6,7 @@ type Env = Partial<Record<string, string | undefined>>;
 export type AppConfig = {
   fetchlinksDbPath: string;
   fetchlinksDbReadOnlyUri: string;
+  controlDbPath: string;
 };
 
 export class ConfigError extends Error {
@@ -18,10 +19,17 @@ export class ConfigError extends Error {
 
 export function loadAppConfig(env: Env = process.env): AppConfig {
   const fetchlinksDbPath = readRequiredAbsolutePath(env, "FETCHLINKS_DB");
+  // The control DB holds the admin-edited catalog (rss_feeds + subreddits
+  // identity). It defaults to the data DB so single-host installs keep
+  // using one physical file; set FETCHLINKS_CONTROL_DB to split it out for
+  // a two-host (Pi ingest + VM web) deployment.
+  const controlDbPath =
+    readOptionalAbsolutePath(env, "FETCHLINKS_CONTROL_DB") ?? fetchlinksDbPath;
 
   return {
     fetchlinksDbPath,
     fetchlinksDbReadOnlyUri: toReadOnlySqliteUri(fetchlinksDbPath),
+    controlDbPath,
   };
 }
 
@@ -45,6 +53,20 @@ function readRequiredAbsolutePath(env: Env, name: string): string {
     throw new ConfigError(
       `${name} is required. Set it to the absolute path of the fetchlinks SQLite database.`,
     );
+  }
+
+  if (!path.isAbsolute(value)) {
+    throw new ConfigError(`${name} must be an absolute path.`);
+  }
+
+  return value;
+}
+
+function readOptionalAbsolutePath(env: Env, name: string): string | undefined {
+  const value = env[name]?.trim();
+
+  if (!value) {
+    return undefined;
   }
 
   if (!path.isAbsolute(value)) {

--- a/web/src/server/feeds.test.ts
+++ b/web/src/server/feeds.test.ts
@@ -50,6 +50,25 @@ function createFeedsFixture(): Fixture {
       (1, 'https://a.example/feed', 'https://a.example/feed', 1, '2026-01-01 00:00:00', NULL, NULL, 0, 'https://a.example/'),
       (2, 'https://b.example/feed', 'https://b.example/feed', 0, '2026-01-02 00:00:00', NULL, 'HTTP 500', 10, NULL),
       (3, 'https://c.example/feed', 'https://c.example/feed', 0, '2026-01-03 00:00:00', '2026-02-01 00:00:00', NULL, 0, NULL);
+
+    CREATE TABLE rss_feed_health (
+      normalized_url       TEXT PRIMARY KEY,
+      last_fetched_at      TEXT,
+      last_success_at      TEXT,
+      last_status          INTEGER,
+      last_error           TEXT,
+      consecutive_failures INTEGER NOT NULL DEFAULT 0,
+      etag                 TEXT,
+      last_modified        TEXT,
+      latest_entry_at      TEXT,
+      site_link            TEXT
+    );
+
+    INSERT INTO rss_feed_health
+      (normalized_url, last_error, consecutive_failures, site_link)
+    VALUES
+      ('https://a.example/feed', NULL, 0, 'https://a.example/'),
+      ('https://b.example/feed', 'HTTP 500', 10, NULL);
   `);
   database.close();
   return {
@@ -180,6 +199,26 @@ describe("countRssFeedsByStatus", () => {
         (2, 'https://fails.example/feed',  'https://fails.example/feed',  1, 'x', 200, 3),
         (3, 'https://http500.example/feed','https://http500.example/feed',1, 'x', 500, 0),
         (4, 'https://disabled.example/feed','https://disabled.example/feed',0,'x',500, 5);
+
+      CREATE TABLE rss_feed_health (
+        normalized_url       TEXT PRIMARY KEY,
+        last_fetched_at      TEXT,
+        last_success_at      TEXT,
+        last_status          INTEGER,
+        last_error           TEXT,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0,
+        etag                 TEXT,
+        last_modified        TEXT,
+        latest_entry_at      TEXT,
+        site_link            TEXT
+      );
+      INSERT INTO rss_feed_health
+        (normalized_url, last_status, consecutive_failures)
+      VALUES
+        ('https://ok.example/feed',      200, 0),
+        ('https://fails.example/feed',   200, 3),
+        ('https://http500.example/feed', 500, 0),
+        ('https://disabled.example/feed',500, 5);
     `);
     database.close();
     try {
@@ -361,6 +400,138 @@ describe("openWritableFetchlinksDatabase", () => {
         );
       } finally {
         database.close();
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("two-file mode (separate control.db and data.db)", () => {
+  type TwoFileFixture = {
+    controlPath: string;
+    dataPath: string;
+    cleanup: () => void;
+  };
+
+  function createTwoFileFixture(): TwoFileFixture {
+    const directory = mkdtempSync(path.join(tmpdir(), "fetchlinks-split-"));
+    const controlPath = path.join(directory, "control.db");
+    const dataPath = path.join(directory, "data.db");
+
+    const control = new DatabaseSync(controlPath);
+    control.exec(`
+      CREATE TABLE rss_feeds (
+        feed_id        INTEGER PRIMARY KEY,
+        feed_url       TEXT NOT NULL,
+        normalized_url TEXT NOT NULL UNIQUE,
+        enabled        INTEGER NOT NULL DEFAULT 1,
+        added_at       TEXT NOT NULL,
+        deleted_at     TEXT
+      );
+      INSERT INTO rss_feeds (feed_id, feed_url, normalized_url, enabled, added_at)
+      VALUES
+        (1, 'https://ok.example/feed',    'https://ok.example/feed',    1, 'x'),
+        (2, 'https://fails.example/feed', 'https://fails.example/feed', 1, 'x');
+    `);
+    control.close();
+
+    const data = new DatabaseSync(dataPath);
+    data.exec(`
+      CREATE TABLE rss_feed_health (
+        normalized_url       TEXT PRIMARY KEY,
+        last_fetched_at      TEXT,
+        last_success_at      TEXT,
+        last_status          INTEGER,
+        last_error           TEXT,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0,
+        etag                 TEXT,
+        last_modified        TEXT,
+        latest_entry_at      TEXT,
+        site_link            TEXT
+      );
+      INSERT INTO rss_feed_health
+        (normalized_url, last_status, last_error, consecutive_failures, site_link)
+      VALUES
+        ('https://ok.example/feed',    200, NULL,       0, 'https://ok.example/'),
+        ('https://fails.example/feed', 200, 'timeout',  4, NULL);
+    `);
+    data.close();
+
+    return {
+      controlPath,
+      dataPath,
+      cleanup: () => rmSync(directory, { force: true, recursive: true }),
+    };
+  }
+
+  it("merges control identity with attached read-only data health", () => {
+    const fixture = createTwoFileFixture();
+    try {
+      const feeds = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dataPath, controlDbPath: fixture.controlPath },
+        (db) => listRssFeeds(db),
+      );
+      const byUrl = Object.fromEntries(
+        feeds.map((f) => [
+          f.feedUrl,
+          { siteLink: f.siteLink, consecutiveFailures: f.consecutiveFailures },
+        ]),
+      );
+      expect(byUrl).toEqual({
+        "https://ok.example/feed": {
+          siteLink: "https://ok.example/",
+          consecutiveFailures: 0,
+        },
+        "https://fails.example/feed": {
+          siteLink: null,
+          consecutiveFailures: 4,
+        },
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("counts attached health failures as errors", () => {
+    const fixture = createTwoFileFixture();
+    try {
+      const counts = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dataPath, controlDbPath: fixture.controlPath },
+        (db) => countRssFeedsByStatus(db),
+      );
+      expect(counts).toEqual({
+        active: 2,
+        disabled: 0,
+        removed: 0,
+        errors: 1,
+        total: 2,
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("writes admin changes to control.db while data.db stays read-only", () => {
+    const fixture = createTwoFileFixture();
+    try {
+      const result = withWritableFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dataPath, controlDbPath: fixture.controlPath },
+        (db) => addRssFeed(db, "https://new.example/feed"),
+      );
+      expect(result.status).toBe("added");
+
+      // The new identity row must land in control.db, not data.db.
+      const control = new DatabaseSync(fixture.controlPath);
+      try {
+        const row = control
+          .prepare(
+            "SELECT COUNT(*) AS n FROM rss_feeds WHERE normalized_url = ?",
+          )
+          .get("https://new.example/feed") as { n: number };
+        expect(row.n).toBe(1);
+      } finally {
+        control.close();
       }
     } finally {
       fixture.cleanup();

--- a/web/src/server/feeds.ts
+++ b/web/src/server/feeds.ts
@@ -1,14 +1,16 @@
+import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
 import type { AppConfig } from "./config";
-import { loadAppConfig } from "./config";
+import { loadAppConfig, toReadOnlySqliteUri } from "./config";
 import type {
   RssFeed,
   RssFeedListFilters,
   RssFeedStatus,
 } from "../models/rss-feeds";
 
-type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
+type DbConfig = Pick<AppConfig, "fetchlinksDbPath"> &
+  Partial<Pick<AppConfig, "controlDbPath">>;
 
 type Env = Partial<Record<string, string | undefined>>;
 
@@ -32,55 +34,157 @@ type RssFeedRow = {
 
 export type WritableFetchlinksDatabase = DatabaseSync;
 
+// Feed identity lives in the control DB (main schema). Per-feed health lives
+// in the data DB, attached read-only as `data` and joined on normalized_url
+// (the natural key, never an autoincrement id). In single-host installs the
+// control and data paths are the same physical file, so the join resolves
+// within one file; the ATTACH is still issued so the SQL is identical in
+// both modes.
 const SELECT_COLUMNS = `
-  feed_id              AS id,
-  feed_url             AS feedUrl,
-  normalized_url       AS normalizedUrl,
-  enabled              AS enabled,
-  added_at             AS addedAt,
-  deleted_at           AS deletedAt,
-  last_fetched_at      AS lastFetchedAt,
-  last_success_at      AS lastSuccessAt,
-  last_status          AS lastStatus,
-  last_error           AS lastError,
-  consecutive_failures AS consecutiveFailures,
-  etag                 AS etag,
-  last_modified        AS lastModified,
-  latest_entry_at      AS latestEntryAt,
-  site_link            AS siteLink
+  f.feed_id                          AS id,
+  f.feed_url                         AS feedUrl,
+  f.normalized_url                   AS normalizedUrl,
+  f.enabled                          AS enabled,
+  f.added_at                         AS addedAt,
+  f.deleted_at                       AS deletedAt,
+  h.last_fetched_at                  AS lastFetchedAt,
+  h.last_success_at                  AS lastSuccessAt,
+  h.last_status                      AS lastStatus,
+  h.last_error                       AS lastError,
+  COALESCE(h.consecutive_failures, 0) AS consecutiveFailures,
+  h.etag                             AS etag,
+  h.last_modified                    AS lastModified,
+  h.latest_entry_at                  AS latestEntryAt,
+  h.site_link                        AS siteLink
 `;
+
+const FROM_CLAUSE =
+  "FROM rss_feeds f " +
+  "LEFT JOIN data.rss_feed_health h ON h.normalized_url = f.normalized_url";
+
+// Control-DB schema (admin-owned identity). Safe to create on the writable
+// connection in any mode. Mirrors the identity columns in
+// ingest/db_setup.py; the health columns are kept for single-host
+// compatibility with older databases (ingest now writes them to
+// rss_feed_health instead).
+function ensureControlSchema(database: WritableFetchlinksDatabase): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS rss_feeds (
+      feed_id              INTEGER PRIMARY KEY,
+      feed_url             TEXT NOT NULL,
+      normalized_url       TEXT NOT NULL UNIQUE,
+      enabled              INTEGER NOT NULL DEFAULT 1,
+      added_at             TEXT NOT NULL,
+      deleted_at           TEXT,
+      last_fetched_at      TEXT,
+      last_success_at      TEXT,
+      last_status          INTEGER,
+      last_error           TEXT,
+      consecutive_failures INTEGER NOT NULL DEFAULT 0,
+      etag                 TEXT,
+      last_modified        TEXT,
+      latest_entry_at      TEXT,
+      site_link            TEXT
+    )
+  `);
+  database.exec(
+    "CREATE INDEX IF NOT EXISTS idx_rss_feeds_live ON rss_feeds(enabled, deleted_at)",
+  );
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS subreddits (
+      subreddit_id    INTEGER PRIMARY KEY,
+      name            TEXT NOT NULL,
+      normalized_name TEXT NOT NULL UNIQUE,
+      enabled         INTEGER NOT NULL DEFAULT 1,
+      added_at        TEXT NOT NULL,
+      deleted_at      TEXT
+    )
+  `);
+  database.exec(
+    "CREATE INDEX IF NOT EXISTS idx_subreddits_live ON subreddits(enabled, deleted_at)",
+  );
+}
+
+// Data-DB tables the admin reads (health, ingest state, follows). Only
+// created when control and data are the same physical file (single-host),
+// since the data DB is attached read-only in two-host mode. Mirrors
+// ingest/db_setup.py so the web admin doesn't error on a not-yet-ingested
+// single-host DB. `posts` is intentionally not created here (it is owned by
+// ingest and the read paths assume it exists, matching prior behaviour).
+function ensureDataSchema(database: WritableFetchlinksDatabase): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS rss_feed_health (
+      normalized_url       TEXT PRIMARY KEY,
+      last_fetched_at      TEXT,
+      last_success_at      TEXT,
+      last_status          INTEGER,
+      last_error           TEXT,
+      consecutive_failures INTEGER NOT NULL DEFAULT 0,
+      etag                 TEXT,
+      last_modified        TEXT,
+      latest_entry_at      TEXT,
+      site_link            TEXT
+    )
+  `);
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS reddit_state (
+      subreddit          TEXT PRIMARY KEY,
+      last_seen_fullname TEXT,
+      time_created       TEXT
+    )
+  `);
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS bluesky_follows (
+      did          TEXT PRIMARY KEY,
+      handle       TEXT NOT NULL,
+      display_name TEXT,
+      synced_at    TEXT NOT NULL
+    )
+  `);
+  database.exec(
+    "CREATE INDEX IF NOT EXISTS idx_bluesky_follows_handle ON bluesky_follows(handle)",
+  );
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS mastodon_follows (
+      instance_name TEXT NOT NULL,
+      account_id    TEXT NOT NULL,
+      acct          TEXT NOT NULL,
+      display_name  TEXT,
+      url           TEXT,
+      synced_at     TEXT NOT NULL,
+      PRIMARY KEY (instance_name, account_id)
+    )
+  `);
+  database.exec(
+    "CREATE INDEX IF NOT EXISTS idx_mastodon_follows_instance ON mastodon_follows(instance_name)",
+  );
+}
 
 export function openWritableFetchlinksDatabase(
   config: DbConfig,
 ): WritableFetchlinksDatabase {
-  const database = new DatabaseSync(config.fetchlinksDbPath, {
+  const dataPath = config.fetchlinksDbPath;
+  const controlPath = config.controlDbPath ?? dataPath;
+  const singleHost = path.resolve(controlPath) === path.resolve(dataPath);
+
+  const database = new DatabaseSync(controlPath, {
     timeout: 5000,
   });
   // Make sure we honour foreign keys and don't block forever on a writer.
   database.exec("PRAGMA foreign_keys = ON");
   database.exec("PRAGMA busy_timeout = 5000");
-  ensureRssFeedsSchema(database);
+  ensureControlSchema(database);
+  if (singleHost) {
+    // Same file: create the data-side tables here before attaching, so the
+    // joins below resolve on a fresh DB.
+    ensureDataSchema(database);
+  }
+  // Attach the data DB read-only so identity/health joins use one connection
+  // and the web can never write to the Pi-owned replica.
+  database
+    .prepare("ATTACH DATABASE ? AS data")
+    .run(toReadOnlySqliteUri(dataPath));
   return database;
-}
-
-// Idempotent in-place upgrade for DBs created before site_link existed.
-// Mirrors the ingest-side ALTER in ingest/db_setup.py so the
-// web admin doesn't 500 when a fresh column hasn't been added by ingest
-// yet. Safe to call on every writable open; the PRAGMA lookup is cheap
-// and the ALTER only fires once per DB.
-function ensureRssFeedsSchema(database: WritableFetchlinksDatabase): void {
-  const columns = database
-    .prepare("PRAGMA table_info(rss_feeds)")
-    .all() as { name: string }[];
-  if (columns.length === 0) {
-    // Table doesn't exist yet (e.g. fresh DB before ingest bootstrap).
-    // Nothing to upgrade.
-    return;
-  }
-  const hasSiteLink = columns.some((c) => c.name === "site_link");
-  if (!hasSiteLink) {
-    database.exec("ALTER TABLE rss_feeds ADD COLUMN site_link TEXT");
-  }
 }
 
 export function openConfiguredWritableFetchlinksDatabase(
@@ -138,16 +242,17 @@ export function listRssFeeds(
   const status = filters.status ?? "all";
 
   if (status === "active") {
-    clauses.push("enabled = 1 AND deleted_at IS NULL");
+    clauses.push("f.enabled = 1 AND f.deleted_at IS NULL");
   } else if (status === "disabled") {
-    clauses.push("enabled = 0 AND deleted_at IS NULL");
+    clauses.push("f.enabled = 0 AND f.deleted_at IS NULL");
   } else if (status === "removed") {
-    clauses.push("deleted_at IS NOT NULL");
+    clauses.push("f.deleted_at IS NOT NULL");
   }
 
   if (filters.errors) {
     clauses.push(
-      "enabled = 1 AND deleted_at IS NULL AND (consecutive_failures > 0 OR last_status >= 400)",
+      "f.enabled = 1 AND f.deleted_at IS NULL AND " +
+        "(COALESCE(h.consecutive_failures, 0) > 0 OR COALESCE(h.last_status, 0) >= 400)",
     );
   }
 
@@ -155,7 +260,7 @@ export function listRssFeeds(
   if (q) {
     const pattern = `%${escapeLikeValue(q.toLowerCase())}%`;
     clauses.push(
-      "(LOWER(feed_url) LIKE ? ESCAPE '\\' OR LOWER(normalized_url) LIKE ? ESCAPE '\\')",
+      "(LOWER(f.feed_url) LIKE ? ESCAPE '\\' OR LOWER(f.normalized_url) LIKE ? ESCAPE '\\')",
     );
     params.push(pattern, pattern);
   }
@@ -163,7 +268,7 @@ export function listRssFeeds(
   const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
   const rows = database
     .prepare(
-      `SELECT ${SELECT_COLUMNS} FROM rss_feeds ${where} ORDER BY enabled DESC, deleted_at IS NOT NULL ASC, feed_url ASC`,
+      `SELECT ${SELECT_COLUMNS} ${FROM_CLAUSE} ${where} ORDER BY f.enabled DESC, f.deleted_at IS NOT NULL ASC, f.feed_url ASC`,
     )
     .all(...params) as RssFeedRow[];
   return rows.map(rowToFeed);
@@ -181,17 +286,17 @@ export function countRssFeedsByStatus(database: DatabaseSync): RssFeedCounts {
   const row = database
     .prepare(
       `SELECT
-        SUM(CASE WHEN deleted_at IS NULL AND enabled = 1 THEN 1 ELSE 0 END) AS active,
-        SUM(CASE WHEN deleted_at IS NULL AND enabled = 0 THEN 1 ELSE 0 END) AS disabled,
-        SUM(CASE WHEN deleted_at IS NOT NULL THEN 1 ELSE 0 END) AS removed,
+        SUM(CASE WHEN f.deleted_at IS NULL AND f.enabled = 1 THEN 1 ELSE 0 END) AS active,
+        SUM(CASE WHEN f.deleted_at IS NULL AND f.enabled = 0 THEN 1 ELSE 0 END) AS disabled,
+        SUM(CASE WHEN f.deleted_at IS NOT NULL THEN 1 ELSE 0 END) AS removed,
         SUM(CASE
-              WHEN deleted_at IS NULL
-                AND enabled = 1
-                AND (consecutive_failures > 0 OR last_status >= 400)
+              WHEN f.deleted_at IS NULL
+                AND f.enabled = 1
+                AND (COALESCE(h.consecutive_failures, 0) > 0 OR COALESCE(h.last_status, 0) >= 400)
               THEN 1 ELSE 0
             END) AS errors,
         COUNT(*) AS total
-      FROM rss_feeds`,
+      ${FROM_CLAUSE}`,
     )
     .get() as {
       active: number | null;
@@ -250,7 +355,7 @@ export function addRssFeed(
   }
 
   const existing = database
-    .prepare(`SELECT ${SELECT_COLUMNS} FROM rss_feeds WHERE normalized_url = ?`)
+    .prepare(`SELECT ${SELECT_COLUMNS} ${FROM_CLAUSE} WHERE f.normalized_url = ?`)
     .get(normalized) as RssFeedRow | undefined;
   if (existing) {
     return { status: "exists", feed: rowToFeed(existing) };
@@ -266,7 +371,7 @@ export function addRssFeed(
     .run(trimmed, normalized, addedAt);
 
   const inserted = database
-    .prepare(`SELECT ${SELECT_COLUMNS} FROM rss_feeds WHERE normalized_url = ?`)
+    .prepare(`SELECT ${SELECT_COLUMNS} ${FROM_CLAUSE} WHERE f.normalized_url = ?`)
     .get(normalized) as RssFeedRow;
   return { status: "added", feed: rowToFeed(inserted) };
 }
@@ -290,12 +395,13 @@ export function restoreRssFeed(
   database: WritableFetchlinksDatabase,
   feedId: number,
 ): boolean {
+  // Identity only: the failure counter lives in the (read-only) data DB and
+  // resets naturally on the next successful ingest fetch.
   const result = database
     .prepare(
       `UPDATE rss_feeds
        SET deleted_at = NULL,
-           enabled = 1,
-           consecutive_failures = 0
+           enabled = 1
        WHERE feed_id = ? AND deleted_at IS NOT NULL`,
     )
     .run(feedId);

--- a/web/src/server/mastodon.ts
+++ b/web/src/server/mastodon.ts
@@ -12,7 +12,8 @@ import type {
   MastodonFollowsSnapshot,
 } from "../models/mastodon-follows";
 
-type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
+type DbConfig = Pick<AppConfig, "fetchlinksDbPath"> &
+  Partial<Pick<AppConfig, "controlDbPath">>;
 
 type Env = Partial<Record<string, string | undefined>>;
 
@@ -35,56 +36,29 @@ const SELECT_COLUMNS = `
   f.url           AS url,
   f.synced_at     AS syncedAt,
   (
-    SELECT MAX(p.date_created) FROM posts p
+    SELECT MAX(p.date_created) FROM data.posts p
     WHERE p.source_type = 'mastodon'
       AND p.source = f.url
   )               AS latestPostAt,
   (
-    SELECT p.source FROM posts p
+    SELECT p.source FROM data.posts p
     WHERE p.source_type = 'mastodon'
       AND p.source = f.url
     LIMIT 1
   )               AS postSource
 `;
 
-// Idempotent guard so the web admin can read the snapshot even if the
-// ingest bootstrap hasn't created the table yet. Mirrors
-// table_mastodon_follows_configure in ingest/db_setup.py.
-function ensureMastodonFollowsSchema(
-  database: WritableFetchlinksDatabase,
-): void {
-  database.exec(`
-    CREATE TABLE IF NOT EXISTS mastodon_follows (
-      instance_name TEXT NOT NULL,
-      account_id    TEXT NOT NULL,
-      acct          TEXT NOT NULL,
-      display_name  TEXT,
-      url           TEXT,
-      synced_at     TEXT NOT NULL,
-      PRIMARY KEY (instance_name, account_id)
-    )
-  `);
-  database.exec(
-    "CREATE INDEX IF NOT EXISTS idx_mastodon_follows_instance ON mastodon_follows(instance_name)",
-  );
-}
-
 export function openWritableMastodonDatabase(
   config: DbConfig,
 ): WritableFetchlinksDatabase {
-  const database = openWritableFetchlinksDatabase(config);
-  ensureMastodonFollowsSchema(database);
-  return database;
+  return openWritableFetchlinksDatabase(config);
 }
 
 export function withWritableMastodonDatabase<T>(
   config: DbConfig,
   callback: (database: WritableFetchlinksDatabase) => T,
 ): T {
-  return withWritableFetchlinksDatabase(config, (database) => {
-    ensureMastodonFollowsSchema(database);
-    return callback(database);
-  });
+  return withWritableFetchlinksDatabase(config, callback);
 }
 
 export function openConfiguredWritableMastodonDatabase(
@@ -111,7 +85,7 @@ export function getMastodonFollows(
 ): MastodonFollowsSnapshot {
   const rows = database
     .prepare(
-      `SELECT ${SELECT_COLUMNS} FROM mastodon_follows f ` +
+      `SELECT ${SELECT_COLUMNS} FROM data.mastodon_follows f ` +
         "ORDER BY f.instance_name ASC, LOWER(f.acct) ASC",
     )
     .all() as MastodonFollowRow[];

--- a/web/src/server/subreddits.ts
+++ b/web/src/server/subreddits.ts
@@ -13,7 +13,8 @@ import type {
   SubredditStatus,
 } from "../models/subreddits";
 
-type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
+type DbConfig = Pick<AppConfig, "fetchlinksDbPath"> &
+  Partial<Pick<AppConfig, "controlDbPath">>;
 
 type Env = Partial<Record<string, string | undefined>>;
 
@@ -40,12 +41,12 @@ const SELECT_COLUMNS = `
   s.deleted_at      AS deletedAt,
   rs.time_created   AS lastFetchedAt,
   (
-    SELECT MAX(p.date_created) FROM posts p
+    SELECT MAX(p.date_created) FROM data.posts p
     WHERE p.source_type = 'reddit'
       AND LOWER(p.source) = '${REDDIT_URL_PREFIX}' || s.normalized_name
   )                 AS latestPostAt,
   (
-    SELECT p.source FROM posts p
+    SELECT p.source FROM data.posts p
     WHERE p.source_type = 'reddit'
       AND LOWER(p.source) = '${REDDIT_URL_PREFIX}' || s.normalized_name
     LIMIT 1
@@ -53,52 +54,19 @@ const SELECT_COLUMNS = `
 `;
 
 const FROM_CLAUSE =
-  "FROM subreddits s LEFT JOIN reddit_state rs ON rs.subreddit = s.normalized_name";
-
-// Idempotent guard so the web admin can read/write the subreddit list even
-// if the ingest bootstrap hasn't created the table yet. Mirrors
-// table_subreddits_configure in ingest/db_setup.py.
-function ensureSubredditsSchema(database: WritableFetchlinksDatabase): void {
-  database.exec(`
-    CREATE TABLE IF NOT EXISTS subreddits (
-      subreddit_id    INTEGER PRIMARY KEY,
-      name            TEXT NOT NULL,
-      normalized_name TEXT NOT NULL UNIQUE,
-      enabled         INTEGER NOT NULL DEFAULT 1,
-      added_at        TEXT NOT NULL,
-      deleted_at      TEXT
-    )
-  `);
-  database.exec(
-    "CREATE INDEX IF NOT EXISTS idx_subreddits_live ON subreddits(enabled, deleted_at)",
-  );
-  // reddit_state and posts are read via LEFT JOIN / subqueries; make sure
-  // reddit_state exists so the JOIN doesn't error on a fresh DB.
-  database.exec(`
-    CREATE TABLE IF NOT EXISTS reddit_state (
-      subreddit TEXT PRIMARY KEY,
-      last_seen_fullname TEXT,
-      time_created TEXT
-    )
-  `);
-}
+  "FROM subreddits s LEFT JOIN data.reddit_state rs ON rs.subreddit = s.normalized_name";
 
 export function openWritableSubredditsDatabase(
   config: DbConfig,
 ): WritableFetchlinksDatabase {
-  const database = openWritableFetchlinksDatabase(config);
-  ensureSubredditsSchema(database);
-  return database;
+  return openWritableFetchlinksDatabase(config);
 }
 
 export function withWritableSubredditsDatabase<T>(
   config: DbConfig,
   callback: (database: WritableFetchlinksDatabase) => T,
 ): T {
-  return withWritableFetchlinksDatabase(config, (database) => {
-    ensureSubredditsSchema(database);
-    return callback(database);
-  });
+  return withWritableFetchlinksDatabase(config, callback);
 }
 
 export function openConfiguredWritableSubredditsDatabase(


### PR DESCRIPTION
Implements roadmap item 1: move ingest onto a home Raspberry Pi (residential IP, to escape Azure-IP RSS throttling) and decouple the web GUI's database access from ingest.

## Design
Two SQLite files, one writer each:
- **control.db (VM-owned)** — feed/subreddit identity + on/off. The web admin writes it; the Pi only reads a pulled copy.
- **data.db (Pi-owned)** — posts, per-feed health, follows snapshots, ingest cursors. The Pi writes it; the web only reads it.

Cross-file relations key on natural keys (`normalized_url`, `normalized_name`, post `unique_id_string`, Bluesky `did`) — never autoincrement ids. Single-host stays one physical file: `control_db`/`controlDbPath` defaults to the data DB path, so the split is opt-in.

## Build steps (six green increments)
1. **Schema split** — `rss_feed_health` carved out of `rss_feeds`; `control_db` config path; `db_setup` creates + backfills health.
2. **Ingest dual-DB wiring** — read identity from control, write posts/health to data; thread `control_db_path`; auto-disable dropped (Pi can't write VM-owned `enabled`; it counts `consecutive_failures`/`last_error` instead).
3. **Web dual-DB wiring** — open control.db read-write and `ATTACH` data.db read-only as `data`; posts/health/follows/state read as `data.*`; `FETCHLINKS_CONTROL_DB` env; two-file-mode tests.
4. **Sync layer** — `deploy/sync/fetchlinks-sync.sh` (pull control.db, ingest, retain, `VACUUM INTO` snapshot, rsync push with atomic rename), `fetchlinks-sync.{service,timer}`, rrsync-restricted `authorized_keys.example`, `sync/README.md`. Pi-initiated SSH/rsync — no inbound to home, no new VM service. Retention runs only on the Pi.
5. **bootstrap role split** — `FETCHLINKS_ROLE=all|web|ingest` gates packages, swap, firewall, units, seeding, credentials, validation; seed/export target `control_db`.
6. **Docs** — OVERVIEW.md two-host architecture + deploy/README.md roles + deploy/sync/README.md.

## Testing
- 345 ingest tests pass (`unittest`).
- 76 web tests pass (`vitest`), including new two-file-mode coverage proving cross-file merge and that admin writes land in control.db while data.db stays read-only.
- Web typecheck + lint clean.

Not exercised in production yet: the live Pi+VM cutover.