### PR TITLE
Document the smoke test connection strings in .env.example

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -9,3 +9,14 @@ DATABASE_URL=postgresql://fetchlinks_web:password@ep-example.eu-west-2.aws.neon.
 # These connect over TCP, so a local container works. Unset it and the
 # integration suites skip.
 FETCHLINKS_TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/fetchlinks_web_test
+
+# Used by `npm run validate:production`. Both must point at the Neon
+# development branch, never production.
+#
+# The first seeds and removes the fixture, so it needs write access to content:
+# use the owner or publisher role. The second is what the application runs as
+# and must be the web role — serving the app as the owner would pass while
+# proving nothing, since a missing grant on the web role is invisible to a role
+# that can already read everything.
+FETCHLINKS_SMOKE_DATABASE_URL=postgresql://neondb_owner:password@ep-example.eu-west-2.aws.neon.tech/fetchlinks?sslmode=require
+FETCHLINKS_SMOKE_WEB_DATABASE_URL=postgresql://fetchlinks_web:password@ep-example-pooler.eu-west-2.aws.neon.tech/fetchlinks?sslmode=require


### PR DESCRIPTION
Adds FETCHLINKS_SMOKE_DATABASE_URL and FETCHLINKS_SMOKE_WEB_DATABASE_URL to web/.env.example. The smoke test gained a second connection string when it was fixed to run the application as the web role rather than the owner, but the example file was never updated to match.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>