### PR TITLE
Add AGENTS.md, and state that this is a hobby project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,135 @@
+# Working in this repo
+
+Read this before changing anything. It records decisions that are invisible in
+the code and expensive to rediscover — several were found by breaking them.
+
+For what the system *is*, read [OVERVIEW.md](OVERVIEW.md) (architecture, roles,
+cost) and [README.md](README.md) (layout, commands). This file is about how to
+work here, and what not to undo.
+
+## This is a hobby project
+
+One person runs this for their own use. It is not a product, has no users
+besides its owner, no SLA, no on-call, and no availability target.
+
+That is not an excuse for sloppy work — the correctness bar is high, because
+bugs here cost the owner's evenings. But it does mean **the failure modes that
+justify most engineering effort do not apply**:
+
+- **Downtime is fine.** If the site is down for a day, nobody is paged and
+  nothing is lost. Do not add redundancy, failover, health checks, or
+  self-healing.
+- **Losing all collected posts is an accepted outcome**, stated explicitly by
+  the owner. Posts are a one-month rolling window that deletes itself and
+  refills within the hour. **There are no backups, by decision.** Do not propose
+  them, do not add them, do not treat their absence as a gap.
+- **There is no alerting, by decision.** No new articles on the site is the
+  visible symptom of every failure that matters. A monitoring stack would only
+  restate what the front page already shows. Do not add one.
+- **Cost matters more than robustness.** Everything runs inside free tiers, and
+  staying there is a real design constraint (see Cost in OVERVIEW.md). A change
+  that improves resilience but wakes the database more often is a bad trade.
+
+Before proposing work, ask whether it protects against something the owner has
+already said they don't care about. If so, don't.
+
+Prefer the boring, small solution. Complexity that would pay for itself across a
+team of ten is pure cost here.
+
+## plan.md is the source of truth
+
+`plan.md` in the repo root holds the numbered architecture decisions and the
+phase order. It outranks your own reasoning: where it contradicts what seems
+sensible now, the decision wins until it is explicitly revisited.
+
+It is **gitignored**, so a fresh clone will not have it. If it is missing, say
+so rather than guessing at the decisions it holds.
+
+Write back to it when work settles a question. A decision discovered and not
+recorded is one that gets re-litigated in a month.
+
+## Invariants that must not be quietly undone
+
+Each of these cost real debugging. Changing one is allowed; changing one by
+accident is the thing to avoid.
+
+**The collector never touches a database.** `ingest/fetch_links.py` and
+everything it calls write batches to disk and hold no connection string. The
+boundary is enforced by `fetchlinks-collect.service` having **no
+`EnvironmentFile`**. That absence is the whole mechanism — do not add one "for
+consistency". It is why collection survives a database outage, and why the Pi
+holding a residential IP does not also hold write access to production.
+
+**The publisher uses the DIRECT Neon endpoint, never the pooled one.** psycopg3
+promotes repeated statements to server-side prepared statements, which do not
+survive PgBouncer in transaction mode. Pooling exists for the web app's many
+short-lived connections. Getting this wrong fails intermittently under load,
+which is the worst way for it to fail.
+
+**`psycopg[binary]` cannot be used on the Pi.** Raspberry Pi OS runs a 64-bit
+kernel with a 32-bit userland: `uname -m` reports `aarch64` but
+`dpkg --print-architecture` reports `armhf`, and pip resolves `armv8l` wheels,
+for which `psycopg-binary` publishes none. This **cannot** be expressed as a PEP
+508 marker, because `platform_machine` reports the kernel and would select the
+missing wheel. `deploy/bootstrap.sh` branches on `dpkg --print-architecture` and
+installs `libpq5` instead.
+
+**Republishing a batch must never duplicate content.** The spool retries on any
+interruption, so every apply path is idempotent by design. If you touch
+`ingest/publisher/`, prove replay safety with a test rather than reasoning about
+it — a bug here is silent and cumulative.
+
+**Runtime state lives in one gitignored directory.** Everything mutable on the
+Pi is under `~/fetchlinks/runtime/`. There is no `/opt`, `/var/lib` or `/etc`
+fragment. `bootstrap.sh` never overwrites anything there, which is what makes it
+safe to re-run — and why it reports when a template gains a setting the
+deployment lacks.
+
+**Migrations are the only thing that changes schema.** Runtime roles cannot
+perform DDL, and each role is deliberately blind to the other's tables: the
+publisher writes content and cannot touch the catalog; the web app writes
+catalog identity and cannot touch content. See [db/README.md](db/README.md).
+
+## Nothing deploys itself, except Vercel
+
+- **Vercel**: pushing to `master` triggers a production build automatically.
+  Any other branch gets a preview on the development database. Merging is
+  therefore deploying — be sure before you merge.
+- **The Pi**: nothing updates itself. Code reaches it only by
+  `cd ~/fetchlinks && git pull && ./deploy/bootstrap.sh`. This is deliberate:
+  unattended pulls on the one host holding a production credential would run
+  anything merged to `master` within the hour.
+- **Catalog data** does sync automatically, hourly, from Neon to the Pi. Feeds
+  added in the web admin need no deployment.
+
+## Validation
+
+Run what already exists; do not add new tooling to run it.
+
+```bash
+cd ingest && python -m unittest discover tests   # ~590 tests, seconds
+cd web && npm run validate                       # lint, typecheck, vitest, build
+```
+
+Tests needing a real database skip unless `FETCHLINKS_TEST_DATABASE_URL` is set,
+so a checkout with no database still validates cleanly. Skips are expected; a
+run reporting only passes and skips is a good run.
+
+Dependency changes require the full `npm run validate`, not just `npm audit`.
+
+## Conventions
+
+Comments explain **why**, never what. If a line needs a comment to say what it
+does, rename something instead. Load-bearing oddities — a `-` prefix on a
+systemd `ExecStart`, an ordering dependency, a workaround for someone else's bug
+— must say why they are there, because they look like mistakes otherwise.
+
+Commit messages are prose, not bullet lists of changed files. Say what changed,
+and why it needed to change. If it fixes something subtle, explain the failure
+it prevents so the next reader does not reintroduce it.
+
+Do not add dependencies, linters, formatters, or CI without being asked. Do not
+create markdown files for planning or notes.
+
+Fix bugs you cause or that are tightly coupled to your change. Leave unrelated
+ones alone, but mention them.

--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ npm run validate
 The web query tests use the same variable and skip the same way, so a checkout
 with no database still validates.
 
-## Deployment Examples
+## Deployment
 
-`deploy/` still contains the systemd and nginx examples for the previous
-single-host VM deployment. They are superseded by the Neon/Vercel/Pi deployment
-and will be replaced once it has been demonstrated end to end.
+`deploy/` installs the collector and publisher on a Raspberry Pi as three
+systemd timers. See [deploy/README.md](deploy/README.md). The web app deploys
+to Vercel automatically on every push to `master`.
 
-For detailed setup notes, see `ingest/SETUP.md` and `web/README.md`.
+For detailed setup notes, see `ingest/SETUP.md` and `web/README.md`. Agents
+working in this repo should start with [AGENTS.md](AGENTS.md).


### PR DESCRIPTION
Adds `AGENTS.md`. The repo had none — the only one on the box belongs to a different project.

## Why

Two kinds of knowledge are currently undiscoverable from the code.

**Invariants that look like mistakes.** The collector unit having no `EnvironmentFile` is a security boundary, not an omission. The publisher needs Neon's *direct* endpoint because psycopg3 promotes statements to prepared ones, which PgBouncer's transaction mode drops. `psycopg[binary]` cannot install on the Pi's 32-bit userland, and no PEP 508 marker can express that because `platform_machine` reports the 64-bit kernel. Every one of these was found by breaking it, and every one is easy to "fix" straight back into breakage.

**Scope.** This is one person's hobby project: no users, no SLA, no on-call. Downtime is fine, losing every collected post is an accepted outcome, and backups and alerting have both been explicitly ruled out. Written down, that redirects effort. Left unwritten, the obvious contribution is exactly the resilience and observability work the owner has already declined — paid for out of the free tiers the project deliberately lives inside.

So the file leads with the hobby framing, then the decisions, then the invariants, then how to validate. It defers to `OVERVIEW.md` and `README.md` for what the system *is* rather than duplicating them, and notes that `plan.md` is gitignored so a fresh clone won't have it.

## Also

Drops the README's "Deployment Examples" section, which still told readers `deploy/` contains nginx and single-host VM examples. Those were deleted in #72.

## Verification

Every factual claim checked against the tree rather than remembered:

- `cd ingest && python -m unittest discover tests` — 592 tests, OK (79 skipped, all needing a database)
- `db/README.md` exists, as linked
- `fetchlinks-collect.service` contains no `EnvironmentFile` directive — the only match is the comment explaining its absence