### PR TITLE
Make the post list fit a phone screen

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,18 @@
+# Working in `web/`
+
+The project's own guidance is in [`../AGENTS.md`](../AGENTS.md) — read that
+first. This file exists because `next dev` writes the block below on every run
+if it is missing, so it is committed rather than left to reappear as noise in
+every diff. There is no configuration option to turn it off.
+
+Anything outside the markers is preserved when Next rewrites the block.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -20,12 +20,6 @@ html {
   height: 100%;
 }
 
-html,
-body {
-  max-width: 100vw;
-  overflow-x: hidden;
-}
-
 body {
   min-height: 100%;
   display: flex;
@@ -374,6 +368,13 @@ p {
 .post-item {
   display: grid;
   gap: 8px;
+  /* A grid item's automatic minimum size is its min-content width, so this
+     refuses to shrink below the longest unbroken string it contains -- and the
+     link paths below are deliberately `nowrap`, which makes that a whole URL.
+     Without this the card is as wide as its longest link on every screen, and
+     the phone layout overflows by a factor of five. Every flex or grid
+     ancestor between here and .post-link-path needs the same release. */
+  min-width: 0;
 }
 
 .post-item:hover {
@@ -761,7 +762,13 @@ a.post-source:hover .post-source-type {
 }
 
 .post-item h2 {
-  max-width: 82ch;
+  /* 82ch is a reading-measure cap for wide screens; it must not become a
+     floor on a phone, where it is twice the viewport. */
+  max-width: min(82ch, 100%);
+  /* A title is arbitrary text from a feed and is sometimes a bare URL with no
+     break opportunity in it. Nothing clips overflow any more, so it has to be
+     breakable here rather than pushing the card wide. */
+  word-break: break-word;
 }
 
 .post-links {
@@ -773,6 +780,7 @@ a.post-source:hover .post-source-type {
   color: var(--muted);
   font-size: 14px;
   line-height: 1.4;
+  min-width: 0;
 }
 
 .post-link-list {
@@ -782,6 +790,7 @@ a.post-source:hover .post-source-type {
   list-style: none;
   padding: 0;
   margin: 0;
+  min-width: 0;
 }
 
 .post-link-row {


### PR DESCRIPTION
The site rendered a **1787px-wide document into a 347px viewport**, with 540 overflowing elements.

## Cause

Not the usual suspects — the viewport meta tag is correct and the 640px breakpoint is thorough. Measuring the ancestor chain found the break precisely:

| element | width |
|---|---|
| `section.post-list` | 310px ✅ |
| `article.post-item` | **1773px** ❌ |
| `.post-link-path` | 1566px |

`.post-item` is a grid item, so its automatic minimum size is its *min-content* width. The link paths inside are deliberately `white-space: nowrap` + ellipsis, so min-content is a whole untruncated URL — the card was as wide as its longest link on every screen.

`.post-link-row` and `.post-link-path` already carried `min-width: 0` for exactly this reason, but `.post-item`, `.post-links` and `.post-link-list` sat between them and did not. One unreleased ancestor loses the whole chain, and the ellipsis never engaged because nothing ever constrained it.

Separately, the post title's `max-width: 82ch` is a reading measure for a wide screen and became a *floor* on a phone, at twice the viewport.

## Also removes the mask

`html, body { max-width: 100vw; overflow-x: hidden }`, inherited from the Next.js starter, never made anything fit — it clipped the overflow and suppressed the scrollbar that would have pointed at the culprit. That is why this went unnoticed. With the real overflow fixed, a future regression should be visible rather than silently cropped. Feed titles are arbitrary text and occasionally a bare URL, so the title now breaks on demand rather than relying on that clipping.

## Verification

Measured against **production content** (the dev database has no posts, so a local measurement would have been meaningless) at a 347px viewport, with the guard lifted so `scrollWidth` could not be clamped:

- **before:** 1787px, 540 overflowing elements
- **after:** 338px, **0 overflowing elements**, across 50 real posts

The ellipsis still engages and titles wrap to two lines, so the design intent is intact. All five admin routes were measured the same way — including the feed list filtered to its longest URLs — and were already clean.

`npm run validate` passes: lint, typecheck, 47 tests, production build.

Desktop is unaffected by construction: `min-width: 0` only matters below content width, `min(82ch, 100%)` resolves to `82ch` on wide screens, and removing `overflow-x: hidden` is a no-op once nothing overflows.

## `web/AGENTS.md` / `web/CLAUDE.md`

A side effect of the Next 16.3 upgrade in #73: `next dev` writes a managed block whenever it is absent and offers no config option to disable it. Committing them is Next's own recommendation and the only way to keep the tree clean — ignoring them means regenerating untracked files forever, and a gitignored `AGENTS.md` is its own trap. Text outside the markers survives the rewrite (verified in the generator source), so the file points at the real guidance in the root `AGENTS.md`.