### PR TITLE
Make the post list read like a feed reader

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -12,8 +12,48 @@
   --accent-soft: #e2f1eb;
   --link: #0b5d7e;
   --link-hover: #084865;
+  --visited: #6b5a86;
   --danger: #a23b3b;
   --focus: #b66a00;
+  --on-accent: #ffffff;
+  --control-height: 38px;
+  color-scheme: light;
+}
+
+/* Touch targets need to be bigger than mouse targets, and that depends on the
+   input device rather than the screen width -- a touchscreen laptop is wide
+   and still needs the room. */
+@media (pointer: coarse) {
+  :root {
+    --control-height: 44px;
+  }
+}
+
+/* The whole theme is these variables, so honouring the OS preference is a
+   matter of restating them rather than auditing every rule. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #14171a;
+    --foreground: #e6e9e6;
+    --muted: #9aa5a0;
+    --subtle: #232a2c;
+    --panel: #1b2023;
+    --panel-alt: #212729;
+    --border: #333c3f;
+    --border-strong: #4a5559;
+    --accent: #4bbfa2;
+    --accent-strong: #7fd8c0;
+    --accent-soft: #1d3733;
+    --link: #6fc3e8;
+    --link-hover: #a3dbf3;
+    --visited: #b9a6dd;
+    --danger: #e58080;
+    --focus: #f0a730;
+    /* The dark accent is a light mint, so the text sitting on it has to go
+       dark rather than stay white. */
+    --on-accent: #0d1a17;
+    color-scheme: dark;
+  }
 }
 
 html {
@@ -60,6 +100,13 @@ select {
   width: min(1180px, 100%);
   margin: 0 auto;
   padding: 24px;
+}
+
+/* The post list is prose, not a table: 1180px of it is a very long line for an
+   18px headline. The admin pages keep the wide shell because their rows really
+   do need the room. */
+.shell-reading {
+  width: min(820px, 100%);
 }
 
 .page-header {
@@ -195,11 +242,11 @@ p {
 
 .search-form-field input {
   width: 100%;
-  min-height: 36px;
+  min-height: var(--control-height);
   padding: 0 10px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: #ffffff;
+  background: var(--panel);
   color: var(--foreground);
   text-overflow: ellipsis;
 }
@@ -207,7 +254,7 @@ p {
 .search-form-btn,
 .clear-filters {
   display: inline-flex;
-  min-height: 36px;
+  min-height: var(--control-height);
   align-items: center;
   justify-content: center;
   padding: 0 16px;
@@ -220,7 +267,7 @@ p {
 .search-form-btn {
   border: 1px solid var(--accent);
   background: var(--accent);
-  color: #ffffff;
+  color: var(--on-accent);
   cursor: pointer;
 }
 
@@ -322,25 +369,25 @@ p {
 
 .add-form-field input {
   width: 100%;
-  min-height: 36px;
+  min-height: var(--control-height);
   padding: 0 10px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: #ffffff;
+  background: var(--panel);
   color: var(--foreground);
   text-overflow: ellipsis;
 }
 
 .add-form-btn {
   display: inline-flex;
-  min-height: 36px;
+  min-height: var(--control-height);
   align-items: center;
   justify-content: center;
   padding: 0 16px;
   border: 1px solid var(--accent);
   border-radius: 6px;
   background: var(--accent);
-  color: #ffffff;
+  color: var(--on-accent);
   font: inherit;
   font-size: 14px;
   font-weight: 700;
@@ -382,17 +429,11 @@ p {
   background: var(--panel-alt);
 }
 
-.post-heading {
-  display: flex;
-  align-items: start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
 .post-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px 10px;
+  align-items: baseline;
+  gap: 2px 6px;
   min-width: 0;
   color: var(--muted);
   font-size: 13px;
@@ -400,16 +441,21 @@ p {
 }
 
 .post-date {
-  flex-shrink: 0;
-  margin-left: auto;
   color: var(--muted);
   font-size: 13px;
   line-height: 1.4;
   white-space: nowrap;
 }
 
+.post-target-host {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .post-meta-separator {
-  color: var(--border);
+  color: var(--border-strong);
 }
 
 .status-pill {
@@ -746,7 +792,7 @@ a.post-source:hover .post-source-type {
 
 .pagination a {
   display: inline-flex;
-  min-height: 32px;
+  min-height: var(--control-height);
   align-items: center;
   justify-content: center;
   border: 1px solid var(--accent);
@@ -758,7 +804,7 @@ a.post-source:hover .post-source-type {
 
 .pagination a:hover {
   background: var(--accent);
-  color: #ffffff;
+  color: var(--on-accent);
 }
 
 .post-item h2 {
@@ -769,6 +815,21 @@ a.post-source:hover .post-source-type {
      break opportunity in it. Nothing clips overflow any more, so it has to be
      breakable here rather than pushing the card wide. */
   word-break: break-word;
+}
+
+.post-title a {
+  display: block;
+  color: var(--link);
+}
+
+.post-title a:hover {
+  color: var(--link-hover);
+  text-decoration: underline;
+}
+
+/* The one piece of state that matters on a feed you re-read every hour. */
+.post-title a:visited {
+  color: var(--visited);
 }
 
 .post-links {
@@ -892,11 +953,11 @@ a.post-source:hover .post-source-type {
 
 .filter-search input {
   width: 100%;
-  min-height: 36px;
+  min-height: var(--control-height);
   padding: 0 10px;
   border: 1px solid var(--border);
   border-radius: 6px;
-  background: #ffffff;
+  background: var(--panel);
   color: var(--foreground);
   text-overflow: ellipsis;
 }
@@ -909,14 +970,14 @@ a.post-source:hover .post-source-type {
 
 .filter-actions button {
   display: inline-flex;
-  min-height: 36px;
+  min-height: var(--control-height);
   align-items: center;
   justify-content: center;
   padding: 0 16px;
   border: 1px solid var(--accent);
   border-radius: 6px;
   background: var(--accent);
-  color: #ffffff;
+  color: var(--on-accent);
   font: inherit;
   font-size: 14px;
   font-weight: 700;
@@ -958,7 +1019,7 @@ a.post-source:hover .post-source-type {
 
 .pagination span[aria-disabled="true"] {
   display: inline-flex;
-  min-height: 32px;
+  min-height: var(--control-height);
   align-items: center;
   justify-content: center;
   border: 1px solid var(--border);
@@ -1009,17 +1070,19 @@ a.post-source:hover .post-source-type {
     padding: 14px;
   }
 
-  .post-heading {
-    display: grid;
-  }
-
   .post-source {
     max-width: 100%;
     white-space: normal;
   }
 
+  /* Feed titles are arbitrary text and some run to a full sentence. On a phone
+     that turns the one-line byline into three, so a long name is clipped
+     rather than allowed to outweigh the headline it belongs to. */
   .post-source-mid {
     max-width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   .pagination {

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -5,26 +5,64 @@ import type { PostPage } from "../models/read-models";
 import { LatestPostsView, loadLatestPosts } from "./page";
 
 describe("Home", () => {
-  it("renders posts with the source label, extracted URL rows, and pagination links", () => {
+  it("links the headline to the post's first URL and dates it relatively", () => {
     const markup = renderToStaticMarkup(<LatestPostsView result={createReadyResult()} />);
 
     expect(markup).toContain("Latest posts");
-    expect(markup).toContain("Newest post");
     expect(markup).toContain("Grace");
     expect(markup).toContain("reddit/test");
     expect(markup).toContain('href="/?source_type=reddit&amp;author=Grace"');
-    expect(markup).toContain("Apr 28, 2026, 10:00 AM");
-    expect(markup).toContain('aria-label="Post links"');
-    expect(markup).toContain('class="post-link-list"');
-    expect(markup).toContain('class="post-link-row"');
-    expect(markup).toContain('class="post-link-host"');
-    expect(markup).toContain('class="post-link-path"');
-    expect(markup).toContain('class="post-source-action"');
-    expect(markup).toContain("source");
+
+    // The headline itself is the link, rather than a URL row beneath it.
+    expect(markup).toContain(
+      '<h2 class="post-title"><a href="https://example.com/direct-b" rel="noreferrer" target="_blank" title="https://example.com/direct-b">Newest post</a></h2>',
+    );
+
+    // The absolute timestamp stays reachable as the tooltip.
+    expect(markup).toContain('title="Apr 28, 2026, 10:00 AM"');
+    expect(markup).toContain("2026-04-28T10:00:00Z");
+
+    // The post links to example.com but came from reddit.com, so the target
+    // host earns its place in the metadata line.
+    expect(markup).toContain('class="post-target-host">example.com<');
+
+    // The remaining URL is demoted; the one the headline uses is not repeated.
+    expect(markup).toContain('aria-label="Other links in this post"');
     expect(markup).toContain('href="https://example.com/unshortened-b"');
-    expect(markup).toContain('href="https://example.com/direct-b"');
-    expect(markup).not.toContain(">link 1<");
+    expect(markup).not.toContain('class="post-link-row"><a href="https://example.com/direct-b"');
+
+    expect(markup).toContain('class="post-source-action"');
+    expect(markup).toContain('href="https://example.com/source-post"');
     expect(markup).toContain('href="/?page=2"');
+  });
+
+  it("omits the target host when the post links back to its own source", () => {
+    const markup = renderToStaticMarkup(
+      <LatestPostsView
+        result={createReadyResult({
+          page: createPostPage({ posts: [createRssPost()] }),
+        })}
+      />,
+    );
+
+    // Feed and article share example.com, so printing the domain again is noise.
+    expect(markup).not.toContain("post-target-host");
+  });
+
+  it("drops the single link list when the headline already covers it", () => {
+    const markup = renderToStaticMarkup(
+      <LatestPostsView
+        result={createReadyResult({
+          page: createPostPage({ posts: [createRssPost()] }),
+        })}
+      />,
+    );
+
+    expect(markup).toContain(
+      '<h2 class="post-title"><a href="https://example.com/a" rel="noreferrer" target="_blank" title="https://example.com/a">First RSS post</a></h2>',
+    );
+    expect(markup).not.toContain("post-link-list");
+    expect(markup).not.toContain("post-link-row");
   });
 
   it("renders a search-only filter bar and preserves filters in pagination links", () => {
@@ -50,7 +88,7 @@ describe("Home", () => {
     );
   });
 
-  it("renders the RSS source label as a filter linking by source_type and source", () => {
+  it("names the publication rather than repeating the feed URL and the type", () => {
     const markup = renderToStaticMarkup(
       <LatestPostsView
         result={createReadyResult({
@@ -61,11 +99,31 @@ describe("Home", () => {
       />,
     );
 
-    expect(markup).toContain(">rss<");
-    expect(markup).toContain("example.com/blog");
+    // "rss · example.com/blog · Ada" collapses to the one part a reader needs,
+    // rendered as a name rather than as a lowercase type token.
+    expect(markup).toContain('<span class="post-source-mid">Ada</span>');
+    expect(markup).not.toContain(">rss<");
+    expect(markup).not.toContain("post-source-type");
+    expect(markup).toContain('title="Ada — https://example.com/blog"');
     expect(markup).toContain(
       'href="/?source_type=rss&amp;source=https%3A%2F%2Fexample.com%2Fblog"',
     );
+  });
+
+  it("heads a filtered view with what is being filtered to", () => {
+    const bySource = renderToStaticMarkup(
+      <LatestPostsView
+        result={createReadyResult({ filters: { source: "https://example.com/blog" } })}
+      />,
+    );
+    const byQuery = renderToStaticMarkup(
+      <LatestPostsView result={createReadyResult({ filters: { q: "AI" } })} />,
+    );
+
+    expect(bySource).toContain("<h1>example.com/blog</h1>");
+    expect(bySource).not.toContain("<h1>Latest posts</h1>");
+    expect(byQuery).toContain("Results for");
+    expect(byQuery).toContain("AI");
   });
 
   it("renders an empty state when no posts exist", () => {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
+import { Fragment } from "react";
 
+import { formatRelative } from "../lib/format-relative";
 import { safeExternalHref } from "../lib/safe-external-href";
 import type {
   PostPage,
@@ -73,14 +75,28 @@ export async function loadLatestPosts({
 
   try {
     const sql = getSqlClient(env);
+    const requested = await getPosts(sql, {
+      ...activeFilters,
+      page,
+      pageSize: POSTS_PER_PAGE,
+    });
+
+    // A hand-typed ?page= past the end otherwise renders "Page 999 of 50" over
+    // an empty list, with a Previous link into more emptiness. Land on the last
+    // real page instead. The second query only happens on that dead path.
+    const lastPage = Math.max(requested.totalPages, 1);
+    const resolved =
+      page > lastPage && requested.totalPosts > 0
+        ? await getPosts(sql, {
+            ...activeFilters,
+            page: lastPage,
+            pageSize: POSTS_PER_PAGE,
+          })
+        : requested;
 
     return {
       status: "ready",
-      page: await getPosts(sql, {
-        ...activeFilters,
-        page,
-        pageSize: POSTS_PER_PAGE,
-      }),
+      page: resolved,
       filters: activeFilters,
     };
   } catch {
@@ -91,7 +107,7 @@ export async function loadLatestPosts({
 export function LatestPostsView({ result }: { result: LatestPostsResult }) {
   if (result.status === "error") {
     return (
-      <main className="shell">
+      <main className="shell shell-reading">
         <PageHeader />
         <section className="state state-error" role="alert">
           <h2>Posts are unavailable</h2>
@@ -104,7 +120,7 @@ export function LatestPostsView({ result }: { result: LatestPostsResult }) {
   const { page } = result;
 
   return (
-    <main className="shell">
+    <main className="shell shell-reading">
       <PageHeader filters={result.filters} page={page} />
       <FilterBar filters={result.filters} />
       {page.posts.length === 0 ? (
@@ -141,9 +157,9 @@ function PageHeader({
     <header className="page-header">
       <div className="page-title">
         <p className="eyebrow">
-          Fetchlinks
+          <Link href="/">Fetchlinks</Link>
         </p>
-        <h1>Latest posts</h1>
+        <h1>{describeFilters(filters) ?? "Latest posts"}</h1>
       </div>
       {page ? (
         <p
@@ -156,6 +172,27 @@ function PageHeader({
       ) : null}
     </header>
   );
+}
+
+/**
+ * What the reader is currently looking at, for the page heading. Without this
+ * a filtered view still announces itself as "Latest posts" and the only clue
+ * that a filter is applied is the match count.
+ */
+function describeFilters(filters: ActiveFilters): string | undefined {
+  if (filters.author) {
+    return filters.author;
+  }
+
+  if (filters.source) {
+    return formatUrlLabel(filters.source);
+  }
+
+  if (filters.sourceType) {
+    return filters.sourceType;
+  }
+
+  return filters.q ? `Results for “${filters.q}”` : undefined;
 }
 
 function FilterBar({ filters }: { filters: ActiveFilters }) {
@@ -205,29 +242,68 @@ function PostListItem({
   filters: ActiveFilters;
   post: PostSummary;
 }) {
+  const primary = pickPrimaryLink(post);
+  const extraUrls = post.urls.filter((url) => url.id !== primary?.urlId);
   const directHref = safeExternalHref(post.directLink);
+  const showDirectLink = directHref !== null && directHref !== primary?.href;
+  const title = post.description ?? "Untitled post";
+  const absoluteDate = formatPostDate(post.dateCreated);
+  const sourceHost = getHostname(post.source);
+  // The feed and the article it links to usually live on the same host, so
+  // showing both just prints the domain twice. Only worth the space when the
+  // post sends you somewhere other than where it came from.
+  const targetHost =
+    primary?.hostname && primary.hostname !== sourceHost
+      ? primary.hostname
+      : undefined;
 
   return (
     <article className="post-item">
-      <header className="post-heading">
-        <div className="post-meta">
-          <SourceLabel currentQ={filters.q} post={post} />
-        </div>
-        <time className="post-date" dateTime={post.dateCreated}>
-          {formatPostDate(post.dateCreated)}
+      <h2 className="post-title">
+        {primary ? (
+          <a
+            href={primary.href}
+            rel="noreferrer"
+            target="_blank"
+            title={primary.title}
+          >
+            {title}
+          </a>
+        ) : (
+          title
+        )}
+      </h2>
+      <div className="post-meta">
+        <SourceLabel currentQ={filters.q} post={post} />
+        <span aria-hidden="true" className="post-meta-separator">
+          ·
+        </span>
+        <time
+          className="post-date"
+          dateTime={post.dateCreated}
+          title={absoluteDate}
+        >
+          {formatRelative(post.dateCreated) ?? absoluteDate}
         </time>
-      </header>
-      <h2>{post.description ?? "Untitled post"}</h2>
-      {post.urls.length > 0 || directHref ? (
+        {targetHost ? (
+          <>
+            <span aria-hidden="true" className="post-meta-separator">
+              ·
+            </span>
+            <span className="post-target-host">{targetHost}</span>
+          </>
+        ) : null}
+      </div>
+      {extraUrls.length > 0 || showDirectLink ? (
         <div className="post-links">
-          {post.urls.length > 0 ? (
-            <ul className="post-link-list" aria-label="Post links">
-              {post.urls.map((url) => (
+          {extraUrls.length > 0 ? (
+            <ul className="post-link-list" aria-label="Other links in this post">
+              {extraUrls.map((url) => (
                 <PostLinkRow key={url.id} url={url} />
               ))}
             </ul>
           ) : null}
-          {directHref ? (
+          {showDirectLink ? (
             <a
               className="post-source-action"
               href={directHref}
@@ -243,6 +319,59 @@ function PostListItem({
   );
 }
 
+type PrimaryLink = {
+  href: string;
+  hostname: string | undefined;
+  title: string;
+  urlId?: number;
+};
+
+/**
+ * The link the headline should open: the post's first usable URL, falling back
+ * to its permalink at the source. Everything else is demoted to the list below,
+ * which in practice is almost always empty.
+ */
+function pickPrimaryLink(post: PostSummary): PrimaryLink | undefined {
+  for (const url of post.urls) {
+    const href = safeExternalHref(url.href);
+
+    if (href) {
+      return {
+        href,
+        hostname: getHostname(href),
+        title: describeUrl(url),
+        urlId: url.id,
+      };
+    }
+  }
+
+  const directHref = safeExternalHref(post.directLink);
+
+  return directHref
+    ? { href: directHref, hostname: getHostname(directHref), title: directHref }
+    : undefined;
+}
+
+function describeUrl(url: PostUrl) {
+  return url.href !== url.originalUrl
+    ? `${url.href} (via ${url.originalUrl})`
+    : url.href;
+}
+
+function getHostname(value: string | null | undefined): string | undefined {
+  const safe = safeExternalHref(value);
+
+  if (!safe) {
+    return undefined;
+  }
+
+  try {
+    return new URL(safe).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
 function SourceLabel({
   currentQ,
   post,
@@ -254,23 +383,24 @@ function SourceLabel({
   const filterHref = buildSourceFilterHref(descriptor, currentQ);
   const title = descriptor.tooltip ?? post.source;
 
-  const content = (
-    <>
-      <span className="post-source-type">{descriptor.typeLabel}</span>
-      {descriptor.middle ? (
-        <>
-          <span className="post-source-sep">·</span>
-          <span className="post-source-mid">{descriptor.middle}</span>
-        </>
-      ) : null}
-      {descriptor.author ? (
-        <>
-          <span className="post-source-sep">·</span>
-          <span className="post-source-author">{descriptor.author}</span>
-        </>
-      ) : null}
-    </>
-  );
+  const parts = [
+    descriptor.typeLabel
+      ? { className: "post-source-type", text: descriptor.typeLabel }
+      : undefined,
+    descriptor.name
+      ? { className: "post-source-mid", text: descriptor.name }
+      : undefined,
+    descriptor.author
+      ? { className: "post-source-author", text: descriptor.author }
+      : undefined,
+  ].filter((part) => part !== undefined);
+
+  const content = parts.map((part, index) => (
+    <Fragment key={part.className}>
+      {index > 0 ? <span className="post-source-sep">·</span> : null}
+      <span className={part.className}>{part.text}</span>
+    </Fragment>
+  ));
 
   if (filterHref) {
     return (
@@ -290,10 +420,7 @@ function SourceLabel({
 function PostLinkRow({ url }: { url: PostUrl }) {
   const href = safeExternalHref(url.href);
   const { hostname, pathLabel } = splitUrlForDisplay(url.href);
-  const usesUnshortenedUrl = url.href !== url.originalUrl;
-  const title = usesUnshortenedUrl
-    ? `${url.href} (via ${url.originalUrl})`
-    : url.href;
+  const title = describeUrl(url);
 
   const content = (
     <>
@@ -400,8 +527,8 @@ function buildPageHref(page: number, filters: ActiveFilters) {
 }
 
 type SourceDescriptor = {
-  typeLabel: string;
-  middle?: string;
+  typeLabel?: string;
+  name?: string;
   author?: string;
   filter?: {
     sourceType?: SourceType;
@@ -437,17 +564,21 @@ function getSourceDescriptor(post: PostSummary): SourceDescriptor {
   }
 
   if (post.sourceType === "rss") {
+    // A publication name is prose, not a type token, so it renders as a name
+    // and the `rss` marker is dropped: the other sources all announce
+    // themselves, so an unmarked source is an RSS feed. The feed URL is
+    // plumbing a reader never needs, and survives as the tooltip.
+    const name = author ?? formatUrlLabel(post.source);
+
     return {
-      typeLabel: "rss",
-      middle: formatUrlLabel(post.source),
-      author,
+      name,
       filter: { sourceType: "rss", source: post.source },
-      tooltip: post.source,
+      tooltip: post.source ? `${name} — ${post.source}` : name,
     };
   }
 
   return {
-    typeLabel: formatUrlLabel(post.source),
+    name: formatUrlLabel(post.source),
     author,
     filter: post.source ? { source: post.source } : undefined,
     tooltip: post.source,


### PR DESCRIPTION
The headline was not a link. The only way to open an article was a 14px URL row with a 24px tap target, under a source and date that rendered above the title — so the page read metadata-first and the thing a reader actually wants was the smallest target on the card.

**The headline is now the link.** Measuring 200 posts across four pages found every one has exactly one URL and none has a distinct direct link, so the multi-link list was setting the default presentation for a case that never occurs. It still renders when a post genuinely has extra URLs. That alone takes the average card from **216px to 126px** at phone width — from under three posts per screen to four and a half.

**Metadata said the same thing three times:** the feed's URL, its publication name, then the article URL immediately below — identical for ~70% of posts. The byline is now one line: publication, relative time, and the target host *only when it differs* from the source, which is what makes a syndicated repost visible. The feed URL survives as the tooltip.

A publication name is prose, not a type token, so it renders as a name rather than in the lowercase monospace reserved for `rss`/`reddit`/`bluesky`. The `rss` marker is dropped entirely — every other source announces itself, so an unmarked source is a feed.

**Absolute timestamps** on a page called "Latest posts" made the reader do arithmetic. Now relative, with the absolute value kept as the tooltip and in `datetime`.

**Visited links had no styling at all**, which for a list whose whole purpose is "what have I not read yet" is the cheapest possible fix.

Smaller: 820px reading measure instead of 1180px; dark mode following the system preference; 44px controls on a coarse pointer (keyed on `pointer: coarse`, because a touchscreen laptop is wide and still has fingers); filtered views say what they are filtered to; and `/?page=999` clamps to the last real page instead of rendering "Page 999 of 50" with nothing on it.

### Verification

Measured against **production data** at 347px (the dev branch has no posts, so a local measurement would pass vacuously): document 338px, **0 overflowing elements**, ellipsis and title wrapping from the previous mobile fix still holding.

Also caught and fixed in passing: an earlier whole-file PowerShell rewrite had double-encoded UTF-8 and added a BOM to `page.tsx`, turning `·` into `Â·` and the curly quotes into `â€œ`. Repaired and verified byte-level before commit.

`npm run validate` passes (lint, typecheck, tests, build); `page.test.tsx` is 10 tests.