### PR TITLE
Stop one malformed URL killing the whole collection cycle

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -111,8 +111,10 @@ run anywhere while the storing half stays specific to one destination.
 
 ### Runtime directory
 
-Kept outside the checkout so deploying or rolling back code never disturbs
-queued batches or resume state:
+Gitignored, so deploying or rolling back code never disturbs queued batches or
+resume state. On the Pi it sits at `~/fetchlinks/runtime/`, inside the checkout
+but invisible to git, which is what keeps the whole deployment in one directory
+while still making `git pull` safe:
 
 ```text
 runtime/

--- a/ingest/SETUP.md
+++ b/ingest/SETUP.md
@@ -1,6 +1,15 @@
 # Setup
 
-These instructions configure and run the Fetchlinks ingest app on Linux.
+These instructions configure and run the Fetchlinks ingest app from a checkout —
+a development machine, or any box where you are running the collector by hand.
+
+**They are not the instructions for the Raspberry Pi.** The deployment keeps
+everything in one directory under `~/fetchlinks/`, installs its own config from
+a template, and reads credentials from `~/fetchlinks/runtime/config/` rather
+than from the paths below. See [../deploy/README.md](../deploy/README.md) for
+that, and use `deploy/bootstrap.sh` rather than following this file. The two
+differ only in *where* the files live; the JSON shapes documented here are the
+same on both.
 
 ## 1) Create and activate virtual environment
 
@@ -21,6 +30,12 @@ pip install -r ingest/requirements.txt
 ```
 
 ## 3) Configure credentials
+
+Credentials are JSON, one file per source, readable only by you. On a checkout
+they live in `~/.fetchlinks/`; **on the Pi the same files live in
+`~/fetchlinks/runtime/config/`** alongside `fetchlinks.toml`, because the
+deployment is one self-contained directory. Only the directory differs — the
+file names and JSON shapes below are identical on both.
 
 Create a credential directory:
 
@@ -99,6 +114,7 @@ or relative to the TOML file's directory. The schema is:
 - `[paths]` — `log_file`, `log_level` (`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`),
   optional `runtime_dir` (the collector's catalog, resume state, and batch
   spool; falls back to `FETCHLINKS_RUNTIME_DIR`, then `~/.fetchlinks/runtime`).
+  The Pi sets `runtime_dir` explicitly so it never relies on that fallback.
   There is deliberately no database setting here: the database URL reaches the
   publisher through `FETCHLINKS_DATABASE_URL`, and the collector never sees one.
 - `[ingest]` — `max_post_age_months`, `excluded_url_host_keywords`,
@@ -122,7 +138,9 @@ or relative to the TOML file's directory. The schema is:
 Notes:
 
 - Each `credential_location` must point at an existing readable JSON file
-  (paths starting with `~` are expanded).
+  (paths starting with `~` are expanded). A relative path resolves against the
+  TOML file's own directory, which is what lets the deployed config on the Pi
+  refer to its credentials as bare filenames like `"reddit.json"`.
 - `excluded_url_host_keywords` are case-insensitive substring matches against
   the URL hostname only. `"insider"` blocks `www.businessinsider.com`;
   `"businessinsider.com"` blocks that domain and its subdomains.

--- a/ingest/tests/test_url_normalization.py
+++ b/ingest/tests/test_url_normalization.py
@@ -1,6 +1,6 @@
 import unittest
 
-from utils import RssPost, normalize_url
+from utils import Post, RssPost, normalize_url
 
 
 class NormalizeUrlTests(unittest.TestCase):
@@ -35,6 +35,32 @@ class NormalizeUrlTests(unittest.TestCase):
     def test_drops_non_http_scheme(self):
         self.assertEqual(normalize_url('ftp://example.com/x'), '')
         self.assertEqual(normalize_url('javascript:alert(1)'), '')
+
+    def test_drops_urls_that_urlsplit_refuses_to_parse(self):
+        # An unbalanced bracket in the netloc is read as a malformed IPv6
+        # literal and urlsplit raises rather than returning empty parts. One of
+        # these in one Bluesky post used to abort the whole collection cycle,
+        # for every source, on every run -- the cursor never advanced past it.
+        for hostile in (
+            'https://[example.com/x',
+            'https://exa[mple.com/x',
+            'http://[::1junk]/x',
+        ):
+            with self.subTest(url=hostile):
+                self.assertEqual(normalize_url(hostile), '')
+
+    def test_drops_unparseable_relative_url_resolved_against_base(self):
+        # The same failure is reachable through the urljoin path.
+        self.assertEqual(
+            normalize_url('//[bad/path', base='https://example.com/feed.xml'),
+            '',
+        )
+
+    def test_post_skips_unparseable_url_but_keeps_the_rest(self):
+        post = Post()
+        post.add_url('https://[example.com/x')
+        post.add_url('https://example.com/good')
+        self.assertEqual(post.urls, ['https://example.com/good'])
 
     def test_strips_whitespace(self):
         self.assertEqual(

--- a/ingest/utils.py
+++ b/ingest/utils.py
@@ -86,11 +86,22 @@ def normalize_url(url: str, base: str = '') -> str:
     if not url:
         return ''
 
-    # Resolve relative forms against the feed/site base when we have one.
-    if base and (url.startswith('//') or url.startswith('/') or not urlsplit(url).scheme):
-        url = urljoin(base, url)
+    # Every URL here came out of somebody else's post or feed, so some of them
+    # are not URLs at all. urlsplit raises on a few shapes rather than
+    # returning something empty -- an unbalanced bracket is read as a malformed
+    # IPv6 literal -- and one of those in one post used to abort the entire
+    # collection cycle for every source. Anything unparseable is simply not a
+    # URL we can use.
+    try:
+        # Resolve relative forms against the feed/site base when we have one.
+        if base and (url.startswith('//') or url.startswith('/')
+                     or not urlsplit(url).scheme):
+            url = urljoin(base, url)
 
-    parts = urlsplit(url)
+        parts = urlsplit(url)
+    except ValueError:
+        return ''
+
     if parts.scheme not in ('http', 'https') or not parts.netloc:
         return ''
     return url


### PR DESCRIPTION
Groundwork from turning on Reddit, Bluesky and Mastodon on the Pi. Two changes, both of which the enablement work surfaced.

### A malformed URL could kill the entire collection cycle

Enabling Bluesky hit this on the second run. A post in the timeline carried a URL with an unbalanced bracket; `urlsplit` read it as a malformed IPv6 literal and raised `ValueError`, which propagated out of `collect_once`. **Every source died — RSS, Reddit and Bluesky — because of one link in one post from a stranger.**

It was also self-perpetuating. The cursor only advances when a batch is queued, and no batch is queued when the cycle raises, so every subsequent hourly run fetched the same page and crashed in the same place. The pipeline was wedged, not degraded.

`normalize_url` already documents itself as returning `''` for anything it cannot make valid, and every caller relies on that, so raising was a contract violation rather than a judgement call. It now treats unparseable input the way it already treats a bad scheme or a missing host. Both `urlsplit` calls and the `urljoin` are inside the guard, since the relative-resolution path can raise just as easily.

Five new tests, including the exact shape that crashed. `python -m unittest discover tests` → **595 tests, OK (79 skipped)**.

### SETUP.md didn't say which machine it was describing

It opened with "configure and run the ingest app on Linux" and then sent you to `~/.fetchlinks/` for credentials. The Pi keeps them in `~/fetchlinks/runtime/config/`, because the deployment is deliberately one self-contained directory. Both were true of different machines and neither said which — and following the wrong one puts the files where the collector won't look, whose symptom is a `FileNotFoundError` at config load that kills the whole cycle rather than just the source you were enabling.

It now names its scope in the first paragraph, points at `deploy/README.md` for the Pi, and states that only the directory differs while the JSON shapes are identical.

`ingest/README.md` also claimed the runtime directory is "kept outside the checkout", which stopped being true when everything moved under `~/fetchlinks/`. What actually protects queued batches is that it's gitignored, so that's what it now says.

### Status on the Pi

Reddit is live and publishing — 861 posts from the 7 catalog subreddits, 712 published, rendering as `reddit/netsec · author`. Bluesky authenticates and collected 126 posts plus 409 follows before hitting the crash above. Mastodon is enabled but hasn't completed a cycle yet. The collect timer is stopped while this lands.