### PR TITLE
Move the admin UI off /admin to /flightdeck

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -16,7 +16,7 @@ For deploying and operating the Pi, see [deploy/README.md](deploy/README.md).
 Raspberry Pi (home, residential IP)          Neon (eu-west-2)          Vercel (lhr1)
   fetchlinks-collect.timer  30 min             PostgreSQL 18             Next.js
     fetch_links.py                               catalog.*                 public pages
-      RSS / Reddit / Bluesky / Mastodon          content.*                 /admin/* (Basic auth)
+      RSS / Reddit / Bluesky / Mastodon          content.*                 /flightdeck/* (Basic auth)
       └─> runtime/outbox/   batch spool
   fetchlinks-publish.timer  hourly
     publish_tool.py publish       ───────────>  insert batches
@@ -27,7 +27,7 @@ Raspberry Pi (home, residential IP)          Neon (eu-west-2)          Vercel (l
 
 Read path: `Internet -> Vercel (lhr1) -> Neon HTTP driver -> PostgreSQL`
 Write path: `Pi -> psycopg over TLS -> PostgreSQL`
-Admin path: `Internet -> Vercel -> /admin/* -> HTTP Basic -> PostgreSQL`
+Admin path: `Internet -> Vercel -> /flightdeck/* -> HTTP Basic -> PostgreSQL`
 
 ## The collector/publisher split
 
@@ -118,9 +118,9 @@ ingest/                            Python, collector + publisher
 
 web/                               Next.js, TypeScript, vitest
 ├── src/app/page.tsx               public posts listing
-├── src/app/admin/                 admin index and the feeds table
+├── src/app/flightdeck/            admin index and the feeds table
 ├── src/server/sql.ts              SqlClient port: Neon HTTP driver or pg
-└── src/proxy.ts                   /admin/* HTTP Basic gate
+└── src/proxy.ts                   /flightdeck/* HTTP Basic gate
 ```
 
 `web/src/server/sql.ts` exists because Neon's HTTP driver suits Vercel but only
@@ -156,8 +156,12 @@ or roll back a cursor.
 - Neither runtime role can perform DDL or write outside its own surface. This
   is asserted against a real instance, not assumed.
 - Source credentials are `0600` under `runtime/config/`, never in the repo.
-- `/admin/*` is gated by HTTP Basic with a constant-time compare. If either
+- `/flightdeck/*` is gated by HTTP Basic with a constant-time compare. If either
   credential variable is unset the route returns 503 rather than opening.
+- The admin route is not called `/admin` so that drive-by scanners probing that
+  path find nothing. This is noise reduction and not a security control: the
+  name is visible in this public repository, and HTTP Basic remains the thing
+  actually standing in the way.
 - Vercel preview deployments are pinned to a separate Neon branch, so a preview
   cannot read or write production data.
 - TLS to the database is enforced by the connection string.

--- a/web/.env.production.example
+++ b/web/.env.production.example
@@ -6,6 +6,6 @@ DATABASE_URL=postgresql://fetchlinks_web:__PASSWORD__@__NEON_POOLED_HOST__/fetch
 NODE_ENV=production
 NEXT_TELEMETRY_DISABLED=1
 
-# Credentials for the /admin/* routes (HTTP Basic). Leave unset to disable.
-FETCHLINKS_ADMIN_USER=admin
+# Credentials for the /flightdeck/* routes (HTTP Basic). Leave unset to disable.
+FETCHLINKS_ADMIN_USER=change-me
 FETCHLINKS_ADMIN_PASS=change-me

--- a/web/README.md
+++ b/web/README.md
@@ -31,7 +31,7 @@ catalog, so the soft delete the admin UI performs is the only delete available
 to it.
 
 To enable the admin UI, also set `FETCHLINKS_ADMIN_USER` and
-`FETCHLINKS_ADMIN_PASS`. Requests to `/admin/*` are gated by HTTP Basic auth
+`FETCHLINKS_ADMIN_PASS`. Requests to `/flightdeck/*` are gated by HTTP Basic auth
 against those values. If either is unset, the admin routes return HTTP 503.
 
 ## Commands

--- a/web/src/app/flightdeck/bluesky/page.tsx
+++ b/web/src/app/flightdeck/bluesky/page.tsx
@@ -4,28 +4,28 @@ import Link from "next/link";
 
 import { formatRelative } from "../../../lib/format-relative";
 import { safeExternalHref } from "../../../lib/safe-external-href";
-import type { MastodonFollow } from "../../../models/mastodon-follows";
+import type { BlueskyFollow } from "../../../models/bluesky-follows";
 import { getSqlClient } from "../../../server/sql";
-import { getMastodonFollows } from "../../../server/mastodon";
+import { getBlueskyFollows } from "../../../server/bluesky";
 
 type LoadResult =
   | {
       status: "ready";
-      follows: MastodonFollow[];
+      follows: BlueskyFollow[];
       lastSyncedAt: string | null;
     }
   | { status: "error" };
 
 export const dynamic = "force-dynamic";
 
-export default async function AdminMastodonPage() {
+export default async function AdminBlueskyPage() {
   const result = await loadFollows();
-  return <AdminMastodonView result={result} />;
+  return <AdminBlueskyView result={result} />;
 }
 
 async function loadFollows(): Promise<LoadResult> {
   try {
-    const snapshot = await getMastodonFollows(getSqlClient(process.env));
+    const snapshot = await getBlueskyFollows(getSqlClient(process.env));
     return {
       status: "ready" as const,
       follows: snapshot.follows,
@@ -36,18 +36,18 @@ async function loadFollows(): Promise<LoadResult> {
   }
 }
 
-export function AdminMastodonView({ result }: { result: LoadResult }) {
+export function AdminBlueskyView({ result }: { result: LoadResult }) {
   if (result.status === "error") {
     return (
       <main className="shell">
         <header className="page-header">
           <div className="page-title">
             <p className="eyebrow">Fetchlinks admin</p>
-            <h1>Mastodon</h1>
+            <h1>Bluesky</h1>
           </div>
         </header>
         <section className="state state-error" role="alert">
-          <h2>Mastodon follows are unavailable</h2>
+          <h2>Bluesky follows are unavailable</h2>
           <p>The database could not be opened. Check the server configuration.</p>
         </section>
       </main>
@@ -56,18 +56,17 @@ export function AdminMastodonView({ result }: { result: LoadResult }) {
 
   const { follows, lastSyncedAt } = result;
   const syncedLabel = formatRelative(lastSyncedAt);
-  const groups = groupByInstance(follows);
 
   return (
     <main className="shell">
       <header className="page-header">
         <div className="page-title">
           <p className="eyebrow">
-            <Link href="/admin">&larr; Admin</Link>
+            <Link href="/flightdeck">&larr; Admin</Link>
           </p>
-          <h1>Mastodon</h1>
+          <h1>Bluesky</h1>
         </div>
-        <div className="feed-counts-tile" aria-label="Mastodon totals">
+        <div className="feed-counts-tile" aria-label="Bluesky totals">
           <span className="count-tile count-tile-ok">
             <strong>{follows.length.toLocaleString("en-US")}</strong>
             <span>following</span>
@@ -76,7 +75,7 @@ export function AdminMastodonView({ result }: { result: LoadResult }) {
       </header>
 
       <p className="admin-readonly-note">
-        Read-only mirror of the accounts each Mastodon credential follows. The
+        Read-only mirror of the accounts this Bluesky credential follows. The
         list is refreshed by the ingest job
         {syncedLabel ? (
           <>
@@ -91,51 +90,20 @@ export function AdminMastodonView({ result }: { result: LoadResult }) {
       {follows.length === 0 ? (
         <section className="state">
           <h2>No follows</h2>
-          <p>The ingest job has not recorded any Mastodon follows yet.</p>
+          <p>The ingest job has not recorded any Bluesky follows yet.</p>
         </section>
       ) : (
-        groups.map((group) => (
-          <section
-            key={group.instanceName}
-            className="post-list"
-            aria-label={`Mastodon follows on ${group.instanceName}`}
-          >
-            <h2 className="feed-group-heading">{group.instanceName}</h2>
-            {group.follows.map((follow) => (
-              <FollowRow
-                key={`${follow.instanceName}:${follow.accountId}`}
-                follow={follow}
-              />
-            ))}
-          </section>
-        ))
+        <section className="post-list" aria-label="Bluesky follows">
+          {follows.map((follow) => (
+            <FollowRow key={follow.did} follow={follow} />
+          ))}
+        </section>
       )}
     </main>
   );
 }
 
-type InstanceGroup = {
-  instanceName: string;
-  follows: MastodonFollow[];
-};
-
-function groupByInstance(follows: MastodonFollow[]): InstanceGroup[] {
-  const groups = new Map<string, MastodonFollow[]>();
-  for (const follow of follows) {
-    const existing = groups.get(follow.instanceName);
-    if (existing) {
-      existing.push(follow);
-    } else {
-      groups.set(follow.instanceName, [follow]);
-    }
-  }
-  return Array.from(groups, ([instanceName, instanceFollows]) => ({
-    instanceName,
-    follows: instanceFollows,
-  }));
-}
-
-function FollowRow({ follow }: { follow: MastodonFollow }) {
+function FollowRow({ follow }: { follow: BlueskyFollow }) {
   return (
     <article className="post-item feed-row feed-row-healthy">
       <header className="feed-row-header">
@@ -143,7 +111,7 @@ function FollowRow({ follow }: { follow: MastodonFollow }) {
       </header>
       <div className="feed-row-footer">
         <FollowStats follow={follow} />
-        <nav aria-label="Mastodon follow actions" className="post-links feed-row-actions">
+        <nav aria-label="Bluesky follow actions" className="post-links feed-row-actions">
           {follow.postSource ? <ViewPostsLink source={follow.postSource} /> : null}
         </nav>
       </div>
@@ -151,17 +119,17 @@ function FollowRow({ follow }: { follow: MastodonFollow }) {
   );
 }
 
-function FollowNameLink({ follow }: { follow: MastodonFollow }) {
-  const url = follow.url ?? "";
-  const href = url ? safeExternalHref(url) : null;
+function FollowNameLink({ follow }: { follow: BlueskyFollow }) {
+  const url = `https://bsky.app/profile/${follow.handle}`;
+  const href = safeExternalHref(url);
   const label = (
     <span className="feed-url-host">
-      {follow.displayName ? `${follow.displayName} ` : ""}@{follow.acct}
+      {follow.displayName ? `${follow.displayName} ` : ""}@{follow.handle}
     </span>
   );
   if (!href) {
     return (
-      <span className="post-source feed-row-url" title={url || undefined}>
+      <span className="post-source feed-row-url" title={url}>
         {label}
       </span>
     );
@@ -179,7 +147,7 @@ function FollowNameLink({ follow }: { follow: MastodonFollow }) {
   );
 }
 
-function FollowStats({ follow }: { follow: MastodonFollow }) {
+function FollowStats({ follow }: { follow: BlueskyFollow }) {
   const items: ReactNode[] = [];
 
   const postLabel = formatRelative(follow.latestPostAt);

--- a/web/src/app/flightdeck/feeds/actions.ts
+++ b/web/src/app/flightdeck/feeds/actions.ts
@@ -10,7 +10,7 @@ import {
   softDeleteRssFeed,
 } from "../../../server/feeds";
 
-const ADMIN_PATH = "/admin/feeds";
+const ADMIN_PATH = "/flightdeck/feeds";
 
 function parseFeedId(value: FormDataEntryValue | null): number {
   const parsed = Number(value);

--- a/web/src/app/flightdeck/feeds/page.tsx
+++ b/web/src/app/flightdeck/feeds/page.tsx
@@ -103,7 +103,7 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
       <header className="page-header">
         <div className="page-title">
           <p className="eyebrow">
-            <Link href="/admin">&larr; Admin</Link>
+            <Link href="/flightdeck">&larr; Admin</Link>
           </p>
           <h1>RSS feeds</h1>
         </div>
@@ -111,13 +111,13 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
           <CountTile
             count={counts.active}
             label={counts.active === 1 ? "active" : "active"}
-            href="/admin/feeds?status=active"
+            href="/flightdeck/feeds?status=active"
             tone="ok"
           />
           <CountTile
             count={counts.errors}
             label={counts.errors === 1 ? "error" : "errors"}
-            href="/admin/feeds?errors=1"
+            href="/flightdeck/feeds?errors=1"
             tone={counts.errors > 0 ? "error" : "muted"}
           />
         </div>
@@ -140,7 +140,7 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
 
       {addFeedback ? <AddFeedbackBanner feedback={addFeedback} /> : null}
 
-      <form action="/admin/feeds" aria-label="Search feeds" className="search-form" method="get">
+      <form action="/flightdeck/feeds" aria-label="Search feeds" className="search-form" method="get">
         <label className="search-form-field">
           <span>Search</span>
           <input
@@ -158,7 +158,7 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
           Search
         </button>
         {filters.status !== "all" || filters.q || filters.errors ? (
-          <Link className="clear-filters" href="/admin/feeds">
+          <Link className="clear-filters" href="/flightdeck/feeds">
             Clear
           </Link>
         ) : null}
@@ -567,7 +567,7 @@ function buildFeedsHref(
     params.set(key, value);
   }
   const query = params.toString();
-  return query ? `/admin/feeds?${query}` : "/admin/feeds";
+  return query ? `/flightdeck/feeds?${query}` : "/flightdeck/feeds";
 }
 
 function AddFeedbackBanner({ feedback }: { feedback: AddFeedback }) {

--- a/web/src/app/flightdeck/mastodon/page.tsx
+++ b/web/src/app/flightdeck/mastodon/page.tsx
@@ -4,28 +4,28 @@ import Link from "next/link";
 
 import { formatRelative } from "../../../lib/format-relative";
 import { safeExternalHref } from "../../../lib/safe-external-href";
-import type { BlueskyFollow } from "../../../models/bluesky-follows";
+import type { MastodonFollow } from "../../../models/mastodon-follows";
 import { getSqlClient } from "../../../server/sql";
-import { getBlueskyFollows } from "../../../server/bluesky";
+import { getMastodonFollows } from "../../../server/mastodon";
 
 type LoadResult =
   | {
       status: "ready";
-      follows: BlueskyFollow[];
+      follows: MastodonFollow[];
       lastSyncedAt: string | null;
     }
   | { status: "error" };
 
 export const dynamic = "force-dynamic";
 
-export default async function AdminBlueskyPage() {
+export default async function AdminMastodonPage() {
   const result = await loadFollows();
-  return <AdminBlueskyView result={result} />;
+  return <AdminMastodonView result={result} />;
 }
 
 async function loadFollows(): Promise<LoadResult> {
   try {
-    const snapshot = await getBlueskyFollows(getSqlClient(process.env));
+    const snapshot = await getMastodonFollows(getSqlClient(process.env));
     return {
       status: "ready" as const,
       follows: snapshot.follows,
@@ -36,18 +36,18 @@ async function loadFollows(): Promise<LoadResult> {
   }
 }
 
-export function AdminBlueskyView({ result }: { result: LoadResult }) {
+export function AdminMastodonView({ result }: { result: LoadResult }) {
   if (result.status === "error") {
     return (
       <main className="shell">
         <header className="page-header">
           <div className="page-title">
             <p className="eyebrow">Fetchlinks admin</p>
-            <h1>Bluesky</h1>
+            <h1>Mastodon</h1>
           </div>
         </header>
         <section className="state state-error" role="alert">
-          <h2>Bluesky follows are unavailable</h2>
+          <h2>Mastodon follows are unavailable</h2>
           <p>The database could not be opened. Check the server configuration.</p>
         </section>
       </main>
@@ -56,17 +56,18 @@ export function AdminBlueskyView({ result }: { result: LoadResult }) {
 
   const { follows, lastSyncedAt } = result;
   const syncedLabel = formatRelative(lastSyncedAt);
+  const groups = groupByInstance(follows);
 
   return (
     <main className="shell">
       <header className="page-header">
         <div className="page-title">
           <p className="eyebrow">
-            <Link href="/admin">&larr; Admin</Link>
+            <Link href="/flightdeck">&larr; Admin</Link>
           </p>
-          <h1>Bluesky</h1>
+          <h1>Mastodon</h1>
         </div>
-        <div className="feed-counts-tile" aria-label="Bluesky totals">
+        <div className="feed-counts-tile" aria-label="Mastodon totals">
           <span className="count-tile count-tile-ok">
             <strong>{follows.length.toLocaleString("en-US")}</strong>
             <span>following</span>
@@ -75,7 +76,7 @@ export function AdminBlueskyView({ result }: { result: LoadResult }) {
       </header>
 
       <p className="admin-readonly-note">
-        Read-only mirror of the accounts this Bluesky credential follows. The
+        Read-only mirror of the accounts each Mastodon credential follows. The
         list is refreshed by the ingest job
         {syncedLabel ? (
           <>
@@ -90,20 +91,51 @@ export function AdminBlueskyView({ result }: { result: LoadResult }) {
       {follows.length === 0 ? (
         <section className="state">
           <h2>No follows</h2>
-          <p>The ingest job has not recorded any Bluesky follows yet.</p>
+          <p>The ingest job has not recorded any Mastodon follows yet.</p>
         </section>
       ) : (
-        <section className="post-list" aria-label="Bluesky follows">
-          {follows.map((follow) => (
-            <FollowRow key={follow.did} follow={follow} />
-          ))}
-        </section>
+        groups.map((group) => (
+          <section
+            key={group.instanceName}
+            className="post-list"
+            aria-label={`Mastodon follows on ${group.instanceName}`}
+          >
+            <h2 className="feed-group-heading">{group.instanceName}</h2>
+            {group.follows.map((follow) => (
+              <FollowRow
+                key={`${follow.instanceName}:${follow.accountId}`}
+                follow={follow}
+              />
+            ))}
+          </section>
+        ))
       )}
     </main>
   );
 }
 
-function FollowRow({ follow }: { follow: BlueskyFollow }) {
+type InstanceGroup = {
+  instanceName: string;
+  follows: MastodonFollow[];
+};
+
+function groupByInstance(follows: MastodonFollow[]): InstanceGroup[] {
+  const groups = new Map<string, MastodonFollow[]>();
+  for (const follow of follows) {
+    const existing = groups.get(follow.instanceName);
+    if (existing) {
+      existing.push(follow);
+    } else {
+      groups.set(follow.instanceName, [follow]);
+    }
+  }
+  return Array.from(groups, ([instanceName, instanceFollows]) => ({
+    instanceName,
+    follows: instanceFollows,
+  }));
+}
+
+function FollowRow({ follow }: { follow: MastodonFollow }) {
   return (
     <article className="post-item feed-row feed-row-healthy">
       <header className="feed-row-header">
@@ -111,7 +143,7 @@ function FollowRow({ follow }: { follow: BlueskyFollow }) {
       </header>
       <div className="feed-row-footer">
         <FollowStats follow={follow} />
-        <nav aria-label="Bluesky follow actions" className="post-links feed-row-actions">
+        <nav aria-label="Mastodon follow actions" className="post-links feed-row-actions">
           {follow.postSource ? <ViewPostsLink source={follow.postSource} /> : null}
         </nav>
       </div>
@@ -119,17 +151,17 @@ function FollowRow({ follow }: { follow: BlueskyFollow }) {
   );
 }
 
-function FollowNameLink({ follow }: { follow: BlueskyFollow }) {
-  const url = `https://bsky.app/profile/${follow.handle}`;
-  const href = safeExternalHref(url);
+function FollowNameLink({ follow }: { follow: MastodonFollow }) {
+  const url = follow.url ?? "";
+  const href = url ? safeExternalHref(url) : null;
   const label = (
     <span className="feed-url-host">
-      {follow.displayName ? `${follow.displayName} ` : ""}@{follow.handle}
+      {follow.displayName ? `${follow.displayName} ` : ""}@{follow.acct}
     </span>
   );
   if (!href) {
     return (
-      <span className="post-source feed-row-url" title={url}>
+      <span className="post-source feed-row-url" title={url || undefined}>
         {label}
       </span>
     );
@@ -147,7 +179,7 @@ function FollowNameLink({ follow }: { follow: BlueskyFollow }) {
   );
 }
 
-function FollowStats({ follow }: { follow: BlueskyFollow }) {
+function FollowStats({ follow }: { follow: MastodonFollow }) {
   const items: ReactNode[] = [];
 
   const postLabel = formatRelative(follow.latestPostAt);

--- a/web/src/app/flightdeck/page.tsx
+++ b/web/src/app/flightdeck/page.tsx
@@ -11,25 +11,25 @@ type AdminSection = {
 
 const SECTIONS: AdminSection[] = [
   {
-    href: "/admin/feeds",
+    href: "/flightdeck/feeds",
     title: "RSS feeds",
     description: "Add, search, and remove RSS feed subscriptions.",
     status: "available",
   },
   {
-    href: "/admin/reddit",
+    href: "/flightdeck/reddit",
     title: "Reddit",
     description: "Add, search, and remove subreddit subscriptions.",
     status: "available",
   },
   {
-    href: "/admin/bluesky",
+    href: "/flightdeck/bluesky",
     title: "Bluesky",
     description: "Read-only view of the accounts this credential follows.",
     status: "available",
   },
   {
-    href: "/admin/mastodon",
+    href: "/flightdeck/mastodon",
     title: "Mastodon",
     description: "Read-only view of the accounts each instance follows.",
     status: "available",

--- a/web/src/app/flightdeck/reddit/actions.ts
+++ b/web/src/app/flightdeck/reddit/actions.ts
@@ -10,7 +10,7 @@ import {
   softDeleteSubreddit,
 } from "../../../server/subreddits";
 
-const ADMIN_PATH = "/admin/reddit";
+const ADMIN_PATH = "/flightdeck/reddit";
 
 function parseSubredditId(value: FormDataEntryValue | null): number {
   const parsed = Number(value);

--- a/web/src/app/flightdeck/reddit/page.tsx
+++ b/web/src/app/flightdeck/reddit/page.tsx
@@ -102,7 +102,7 @@ export function AdminRedditView({ result }: { result: LoadResult }) {
       <header className="page-header">
         <div className="page-title">
           <p className="eyebrow">
-            <Link href="/admin">&larr; Admin</Link>
+            <Link href="/flightdeck">&larr; Admin</Link>
           </p>
           <h1>Subreddits</h1>
         </div>
@@ -110,13 +110,13 @@ export function AdminRedditView({ result }: { result: LoadResult }) {
           <CountTile
             count={counts.active}
             label="active"
-            href="/admin/reddit?status=active"
+            href="/flightdeck/reddit?status=active"
             tone="ok"
           />
           <CountTile
             count={counts.removed}
             label={counts.removed === 1 ? "removed" : "removed"}
-            href="/admin/reddit?status=removed"
+            href="/flightdeck/reddit?status=removed"
             tone="muted"
           />
         </div>
@@ -139,7 +139,7 @@ export function AdminRedditView({ result }: { result: LoadResult }) {
 
       {addFeedback ? <AddFeedbackBanner feedback={addFeedback} /> : null}
 
-      <form action="/admin/reddit" aria-label="Search subreddits" className="search-form" method="get">
+      <form action="/flightdeck/reddit" aria-label="Search subreddits" className="search-form" method="get">
         <label className="search-form-field">
           <span>Search</span>
           <input
@@ -156,7 +156,7 @@ export function AdminRedditView({ result }: { result: LoadResult }) {
           Search
         </button>
         {filters.status !== "all" || filters.q ? (
-          <Link className="clear-filters" href="/admin/reddit">
+          <Link className="clear-filters" href="/flightdeck/reddit">
             Clear
           </Link>
         ) : null}
@@ -471,7 +471,7 @@ function buildRedditHref(
     params.set(key, value);
   }
   const query = params.toString();
-  return query ? `/admin/reddit?${query}` : "/admin/reddit";
+  return query ? `/flightdeck/reddit?${query}` : "/flightdeck/reddit";
 }
 
 function AddFeedbackBanner({ feedback }: { feedback: AddFeedback }) {

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 export const config = {
-  matcher: ["/admin/:path*"],
+  matcher: ["/flightdeck/:path*"],
 };
 
 const REALM = "Fetchlinks admin";


### PR DESCRIPTION
Moves the admin UI from `/admin` to `/flightdeck`. `/admin` is now a 404 with no page behind it, so the constant background scanning of that path no longer reaches a route that authenticates.

This is noise reduction, not a security control — the name is visible in this public repo, and HTTP Basic is still the thing doing the work. It targets the untargeted scanner working a wordlist, not someone attacking this project specifically. The name avoids `cockpit`, `backstage`, `adminer` and `portainer`, which are themselves probed routinely.

### What was actually risky

Not the directory move — the 23 absolute paths hard-coded across the index, the four section pages, and the `ADMIN_PATH` constants that `revalidatePath` uses in both `actions.ts` files. Missing one gives a dead link or a silently stale page after a mutation, and neither the type checker nor the test suite would catch it, since nothing asserts a URL.

So verification was done against a running production build rather than the build output:

| Request | Result |
| --- | --- |
| `/admin`, `/admin/feeds` | 404 |
| `/flightdeck`, `/flightdeck/feeds` (no creds) | 401, `Basic realm="Fetchlinks admin"` |
| `/flightdeck` (correct creds) | 200 |
| `/flightdeck` (wrong password) | 401 |
| `/` | 200, untouched |

### Deliberately unchanged

`FETCHLINKS_ADMIN_USER` / `FETCHLINKS_ADMIN_PASS`, the `Fetchlinks admin` realm, and the `admin-*` CSS classes. They're internal names rather than URLs, and renaming them would break the env var contract with Vercel for nothing. The example admin username is no longer `admin`, which was teaching the wrong default.

The planned credential rotation was dropped: the existing password turned out to be 32 machine-generated characters, so the weakness that step assumed wasn't there.

### After merging

Any bookmark to `/admin/feeds` will 404 — the new path is `/flightdeck/feeds`. The Vercel WAF rate limit rule still needs adding in the dashboard, scoped to `/flightdeck`.

`cd web && npm run validate` passes: lint, typecheck, 50 tests, build.

### Gotcha worth knowing

`next build` regenerates `.next/dev/types/validator.ts` but doesn't prune routes that no longer exist, so the first build after a rename fails with `TS2307` errors naming files that are *correctly* absent. Delete `.next`.