### PR TITLE
Record the admin rate limit rule where it will be found

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -162,6 +162,10 @@ or roll back a cursor.
   path find nothing. This is noise reduction and not a security control: the
   name is visible in this public repository, and HTTP Basic remains the thing
   actually standing in the way.
+- A Vercel WAF rule rate limits that path to 10 requests per minute per IP and
+  denies beyond it, so the shared credential cannot be guessed at request speed.
+  The rule lives in the Vercel dashboard and is therefore invisible here; it is
+  recorded so its absence after a project rebuild is noticed.
 - Vercel preview deployments are pinned to a separate Neon branch, so a preview
   cannot read or write production data.
 - TLS to the database is enforced by the connection string.


### PR DESCRIPTION
Documentation only. Adds the WAF rate limit rule to the security notes in `OVERVIEW.md`.

The rule lives in the Vercel dashboard, so nothing in a fresh clone hints that it exists. That's exactly the kind of configuration that quietly goes missing in a project rebuild and isn't noticed until someone is brute-forcing the admin password — so it belongs written down next to the control it completes.

Rule as configured: `/flightdeck`, 10 requests per 60 seconds, keyed on IP, Deny beyond.

Verified against production rather than assumed — a burst of 16 requests to `/flightdeck` returned 401 eight times then 403 for the rest, the public listing kept returning 200 throughout, and the block cleared itself inside the window. Worth noting the deny began on the 9th request rather than the 11th: counters are per-region and the boundary is approximate, which is why the configured number is a brake rather than a guarantee.

This completes the admin hardening work.