### PR TITLE
Rework the flightdeck feeds page

### DIFF
--- a/web/src/app/flightdeck/feeds/page.tsx
+++ b/web/src/app/flightdeck/feeds/page.tsx
@@ -258,12 +258,12 @@ function FeedRow({
               <ConfirmRemove feedId={feed.id} filters={filters} />
             ) : (
               <Link
-                aria-label="Remove feed"
-                className="feed-action-btn feed-action-btn-icon"
+                className="feed-action-btn feed-action-btn-remove"
                 href={buildFeedsHref(filters, { confirm_remove: String(feed.id) })}
                 title="Remove feed"
               >
                 <TrashIcon />
+                Remove feed
               </Link>
             )
           ) : null}

--- a/web/src/app/flightdeck/feeds/page.tsx
+++ b/web/src/app/flightdeck/feeds/page.tsx
@@ -7,8 +7,9 @@ import { safeExternalHref } from "../../../lib/safe-external-href";
 import type { RssFeed, RssFeedStatus } from "../../../models/rss-feeds";
 import {
   countRssFeedsByStatus,
-  listRssFeeds,
+  listRssFeedsPage,
   type RssFeedCounts,
+  type RssFeedPage,
 } from "../../../server/feeds";
 import { getSqlClient } from "../../../server/sql";
 import {
@@ -26,7 +27,7 @@ type AdminFeedsPageProps = {
 type LoadResult =
   | {
       status: "ready";
-      feeds: RssFeed[];
+      page: RssFeedPage;
       counts: RssFeedCounts;
       filters: ActiveFilters;
       addFeedback: AddFeedback | null;
@@ -38,6 +39,7 @@ type ActiveFilters = {
   status: RssFeedStatus | "all";
   q?: string;
   errors: boolean;
+  page: number;
 };
 
 type AddFeedback =
@@ -46,6 +48,10 @@ type AddFeedback =
   | { kind: "invalid"; reason: string; url?: string };
 
 export const dynamic = "force-dynamic";
+
+// Matches the public list. 719 feeds in one response is 2.3 MB of HTML and
+// slow enough to time out an in-browser evaluation.
+const FEEDS_PER_PAGE = 50;
 
 export default async function AdminFeedsPage({
   searchParams,
@@ -67,7 +73,7 @@ async function loadFeeds(
     const sql = getSqlClient(process.env);
     return {
       status: "ready" as const,
-      feeds: await listRssFeeds(sql, filters),
+      page: await listRssFeedsPage(sql, filters, filters.page, FEEDS_PER_PAGE),
       counts: await countRssFeedsByStatus(sql),
       filters,
       addFeedback,
@@ -96,7 +102,8 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
     );
   }
 
-  const { feeds, counts, filters, addFeedback, confirmRemoveId } = result;
+  const { page, counts, filters, addFeedback, confirmRemoveId } = result;
+  const feeds = page.feeds;
 
   return (
     <main className="shell">
@@ -170,18 +177,54 @@ export function AdminFeedsView({ result }: { result: LoadResult }) {
           <p>No rows match the current filters.</p>
         </section>
       ) : (
-        <section className="post-list" aria-label="RSS feeds">
-          {feeds.map((feed) => (
-            <FeedRow
-              key={feed.id}
-              feed={feed}
-              filters={filters}
-              confirmRemove={confirmRemoveId === feed.id}
-            />
-          ))}
-        </section>
+        <>
+          <section className="post-list" aria-label="RSS feeds">
+            {feeds.map((feed) => (
+              <FeedRow
+                key={feed.id}
+                feed={feed}
+                filters={filters}
+                confirmRemove={confirmRemoveId === feed.id}
+              />
+            ))}
+          </section>
+          <FeedsPagination filters={filters} page={page} />
+        </>
       )}
     </main>
+  );
+}
+
+function FeedsPagination({
+  filters,
+  page,
+}: {
+  filters: ActiveFilters;
+  page: RssFeedPage;
+}) {
+  if (page.totalPages <= 1) return null;
+
+  return (
+    <nav className="pagination" aria-label="Feeds pagination">
+      {page.hasPreviousPage ? (
+        <Link href={buildFeedsHref({ ...filters, page: page.page - 1 })}>
+          Previous
+        </Link>
+      ) : (
+        <span aria-disabled="true">Previous</span>
+      )}
+      <span>
+        Page {page.page.toLocaleString("en-US")} of{" "}
+        {page.totalPages.toLocaleString("en-US")}
+      </span>
+      {page.hasNextPage ? (
+        <Link href={buildFeedsHref({ ...filters, page: page.page + 1 })}>
+          Next
+        </Link>
+      ) : (
+        <span aria-disabled="true">Next</span>
+      )}
+    </nav>
   );
 }
 
@@ -207,8 +250,8 @@ function FeedRow({
       <div className="feed-row-footer">
         <FeedStats feed={feed} />
         <nav aria-label="Feed actions" className="post-links feed-row-actions">
-          {feed.status !== "removed" && feed.siteLink && !confirmRemove ? (
-            <ViewPostsLink siteLink={feed.siteLink} />
+          {feed.status !== "removed" && !confirmRemove ? (
+            <ViewPostsControl siteLink={feed.siteLink} />
           ) : null}
           {feed.status !== "removed" ? (
             confirmRemove ? (
@@ -331,7 +374,16 @@ function FeedStats({ feed }: { feed: RssFeed }) {
     );
   }
 
-  if (items.length === 0) return null;
+  // Always render the container, even when empty: the footer relies on having
+  // exactly two children to keep the actions pinned right, and a row with no
+  // stats otherwise collapses to a different shape than its neighbours.
+  if (items.length === 0) {
+    items.push(
+      <span key="never" className="feed-stat">
+        Never fetched
+      </span>,
+    );
+  }
   return <div className="feed-stats">{items}</div>;
 }
 
@@ -488,15 +540,32 @@ function TrashIcon() {
   );
 }
 
-function ViewPostsLink({ siteLink }: { siteLink: string }) {
+// The primary action on this page: the reason to look at a feed is almost
+// always to see what it produced. A feed only gains a site link after a
+// successful fetch, and 47 of 719 have none, so the control is shown disabled
+// with the reason rather than omitted -- a button that vanishes on some rows
+// reads as a bug.
+function ViewPostsControl({ siteLink }: { siteLink: string | null }) {
+  if (!siteLink) {
+    return (
+      <span
+        aria-disabled="true"
+        className="feed-action-btn feed-action-btn-view feed-action-btn-disabled"
+        title="No site link recorded yet. It is read from the feed on the first successful fetch, and posts cannot be filtered without it."
+      >
+        <ViewPostsIcon />
+        View posts
+      </span>
+    );
+  }
   return (
     <Link
-      aria-label="View posts from this feed"
-      className="feed-action-btn feed-action-btn-icon feed-action-btn-view"
+      className="feed-action-btn feed-action-btn-view"
       href={`/?source=${encodeURIComponent(siteLink)}`}
-      title="View posts from this feed"
+      title={`Show posts collected from ${siteLink}`}
     >
       <ViewPostsIcon />
+      View posts
     </Link>
   );
 }
@@ -528,7 +597,14 @@ function parseFilters(searchParams: PageSearchParams | undefined): ActiveFilters
   const status = pickStatus(getSingleSearchParam(searchParams, "status"));
   const q = getSingleSearchParam(searchParams, "q")?.trim().slice(0, 200) || undefined;
   const errors = getSingleSearchParam(searchParams, "errors") === "1";
-  return { status, q, errors };
+  const page = parsePage(getSingleSearchParam(searchParams, "page"));
+  return { status, q, errors, page };
+}
+
+function parsePage(raw: string | undefined): number {
+  if (!raw) return 1;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
 }
 
 function parseAddFeedback(
@@ -563,6 +639,9 @@ function buildFeedsHref(
   if (filters.status !== "all") params.set("status", filters.status);
   if (filters.q) params.set("q", filters.q);
   if (filters.errors) params.set("errors", "1");
+  // Page 1 is the default, so it stays out of the URL and the plain
+  // /flightdeck/feeds link keeps working as "start again".
+  if (filters.page > 1) params.set("page", String(filters.page));
   for (const [key, value] of Object.entries(extra)) {
     params.set(key, value);
   }

--- a/web/src/app/flightdeck/feeds/page.tsx
+++ b/web/src/app/flightdeck/feeds/page.tsx
@@ -249,7 +249,7 @@ function FeedRow({
       </header>
       <div className="feed-row-footer">
         <FeedStats feed={feed} />
-        <nav aria-label="Feed actions" className="post-links feed-row-actions">
+        <nav aria-label="Feed actions" className="feed-row-actions">
           {feed.status !== "removed" && !confirmRemove ? (
             <ViewPostsControl siteLink={feed.siteLink} />
           ) : null}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -526,10 +526,16 @@ p {
   display: block;
 }
 
+/* .post-source sets a 6px gap to space a source name from its type badge, and
+   it wins on order alone. Here the two spans are the host and path of one URL,
+   so any gap saws it in half. */
+.post-source.feed-row-url {
+  column-gap: 0;
+}
+
 .feed-action-btn-view {
   gap: 6px;
   border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
-  background: var(--accent-soft);
   color: var(--accent-strong);
 }
 
@@ -616,10 +622,13 @@ p {
   justify-content: space-between;
 }
 
-/* Lets the chips take the slack so the actions sit at the right edge on every
-   row. margin-left: auto did the same job but dragged the actions onto their
-   own line as soon as the chips wrapped, which is what made rows look ragged. */
+/* Not .post-links: that stacks its children in a column and rules them off with
+   a border, which is right for the public list and wrong for a row of buttons. */
 .feed-row-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
   flex: 0 0 auto;
 }
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -550,6 +550,26 @@ p {
   background: color-mix(in srgb, var(--accent) 10%, var(--panel));
 }
 
+/* Labelled rather than a bare icon, like the view control beside it. It only
+   opens the confirm step, so it stays muted until hover rather than wearing
+   danger colours for an action that has not been asked for yet. */
+.feed-action-btn-remove {
+  gap: 6px;
+  border-color: var(--border);
+  color: var(--muted);
+}
+
+.feed-action-btn-remove svg {
+  display: block;
+  flex: 0 0 auto;
+}
+
+.feed-action-btn-remove:hover {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 40%, var(--border));
+  background: color-mix(in srgb, var(--danger) 10%, var(--panel));
+}
+
 .feed-action-btn-disabled,
 .feed-action-btn-disabled:hover {
   border-color: var(--border);

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -526,10 +526,30 @@ p {
   display: block;
 }
 
+.feed-action-btn-view {
+  gap: 6px;
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.feed-action-btn-view svg {
+  display: block;
+  flex: 0 0 auto;
+}
+
 .feed-action-btn-view:hover {
   color: var(--accent-strong);
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
   background: color-mix(in srgb, var(--accent) 10%, var(--panel));
+}
+
+.feed-action-btn-disabled,
+.feed-action-btn-disabled:hover {
+  border-color: var(--border);
+  background: var(--subtle);
+  color: var(--muted);
+  cursor: not-allowed;
 }
 
 .feed-action-btn-danger {
@@ -593,10 +613,13 @@ p {
   flex-wrap: wrap;
   gap: 10px;
   align-items: center;
+  justify-content: space-between;
 }
 
+/* Lets the chips take the slack so the actions sit at the right edge on every
+   row. margin-left: auto did the same job but dragged the actions onto their
+   own line as soon as the chips wrapped, which is what made rows look ragged. */
 .feed-row-actions {
-  margin-left: auto;
   flex: 0 0 auto;
 }
 
@@ -676,6 +699,8 @@ p {
   flex-wrap: wrap;
   gap: 6px 10px;
   align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .feed-stat {

--- a/web/src/models/rss-feeds.ts
+++ b/web/src/models/rss-feeds.ts
@@ -23,4 +23,6 @@ export type RssFeedListFilters = {
   status?: RssFeedStatus | "all";
   q?: string;
   errors?: boolean;
+  limit?: number;
+  offset?: number;
 };

--- a/web/src/server/feeds.test.ts
+++ b/web/src/server/feeds.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   addRssFeed,
+  countRssFeeds,
   countRssFeedsByStatus,
   listRssFeeds,
+  listRssFeedsPage,
   normalizeFeedUrl,
   restoreRssFeed,
   softDeleteRssFeed,
@@ -341,5 +343,109 @@ describePostgres("rss feed catalog", () => {
       errors: 0,
       total: 0,
     });
+  });
+
+  async function addFeeds(count: number): Promise<void> {
+    for (let index = 0; index < count; index += 1) {
+      // Zero-padded so lexical order matches numeric order and the assertions
+      // below can name an exact page of results.
+      const label = String(index).padStart(2, "0");
+      await addRssFeed(pg.sql, `https://feed${label}.example/feed`);
+    }
+  }
+
+  it("splits the catalog into pages in the list order", async () => {
+    await addFeeds(5);
+
+    const page = await listRssFeedsPage(pg.sql, {}, 2, 2);
+
+    expect(page.feeds.map((feed) => feed.normalizedUrl)).toEqual([
+      "https://feed02.example/feed",
+      "https://feed03.example/feed",
+    ]);
+    expect(page).toMatchObject({
+      page: 2,
+      pageSize: 2,
+      totalFeeds: 5,
+      totalPages: 3,
+      hasPreviousPage: true,
+      hasNextPage: true,
+    });
+  });
+
+  it("clamps a page beyond the end back to the last page", async () => {
+    await addFeeds(3);
+
+    const page = await listRssFeedsPage(pg.sql, {}, 99, 2);
+
+    expect(page.page).toBe(2);
+    expect(page.hasNextPage).toBe(false);
+    expect(page.feeds.map((feed) => feed.normalizedUrl)).toEqual([
+      "https://feed02.example/feed",
+    ]);
+  });
+
+  it("clamps a page below one back to the first page", async () => {
+    await addFeeds(3);
+
+    const page = await listRssFeedsPage(pg.sql, {}, 0, 2);
+
+    expect(page.page).toBe(1);
+    expect(page.hasPreviousPage).toBe(false);
+  });
+
+  // An empty catalog must still report one page, or the pager renders
+  // "Page 1 of 0".
+  it("reports a single empty page for an empty catalog", async () => {
+    const page = await listRssFeedsPage(pg.sql, {}, 1, 2);
+
+    expect(page).toMatchObject({
+      feeds: [],
+      page: 1,
+      totalFeeds: 0,
+      totalPages: 1,
+      hasPreviousPage: false,
+      hasNextPage: false,
+    });
+  });
+
+  // The total is what the pager divides by, so a total that ignored the
+  // filters would offer pages that render empty.
+  it("counts and pages only the rows matching the filters", async () => {
+    await addFeeds(4);
+    const removed = await addRssFeed(pg.sql, "https://feed99.example/feed");
+    if (removed.status !== "added") throw new Error("expected added");
+    await softDeleteRssFeed(pg.sql, removed.feed.id);
+
+    await expect(countRssFeeds(pg.sql, { status: "active" })).resolves.toBe(4);
+    await expect(countRssFeeds(pg.sql, { status: "removed" })).resolves.toBe(1);
+    await expect(countRssFeeds(pg.sql, { q: "feed0" })).resolves.toBe(4);
+
+    const page = await listRssFeedsPage(pg.sql, { status: "removed" }, 1, 2);
+    expect(page.totalFeeds).toBe(1);
+    expect(page.totalPages).toBe(1);
+    expect(page.feeds.map((feed) => feed.normalizedUrl)).toEqual([
+      "https://feed99.example/feed",
+    ]);
+  });
+
+  // The search pattern and the limit/offset share one placeholder sequence, so
+  // a mis-ordered append would bind the wrong value to the wrong slot.
+  it("keeps a search filter intact alongside limit and offset", async () => {
+    await addFeeds(4);
+    await addRssFeed(pg.sql, "https://other.example/feed");
+
+    const page = await listRssFeedsPage(pg.sql, { q: "feed0" }, 2, 3);
+
+    expect(page.totalFeeds).toBe(4);
+    expect(page.feeds.map((feed) => feed.normalizedUrl)).toEqual([
+      "https://feed03.example/feed",
+    ]);
+  });
+
+  it("leaves the unpaginated list returning every row", async () => {
+    await addFeeds(3);
+
+    await expect(listRssFeeds(pg.sql)).resolves.toHaveLength(3);
   });
 });

--- a/web/src/server/feeds.ts
+++ b/web/src/server/feeds.ts
@@ -81,12 +81,13 @@ function rowToFeed(row: RssFeedRow): RssFeed {
   };
 }
 
-export async function listRssFeeds(
-  sql: SqlClient,
-  filters: RssFeedListFilters = {},
-): Promise<RssFeed[]> {
+// Filters are built once and shared by the list and the count so a page can
+// never report a total that its own rows contradict.
+function buildFeedWhere(
+  filters: RssFeedListFilters,
+  params: SqlParams,
+): string {
   const clauses: string[] = [];
-  const params = new SqlParams();
   const status = filters.status ?? "all";
 
   if (status === "active") {
@@ -112,13 +113,85 @@ export async function listRssFeeds(
     );
   }
 
-  const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+  return clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
+}
+
+export async function listRssFeeds(
+  sql: SqlClient,
+  filters: RssFeedListFilters = {},
+): Promise<RssFeed[]> {
+  const params = new SqlParams();
+  const where = buildFeedWhere(filters, params);
+
+  // Appended after the filter placeholders so the numbering stays contiguous.
+  let limits = "";
+  if (filters.limit !== undefined) {
+    limits += ` LIMIT ${params.next(filters.limit)}`;
+  }
+  if (filters.offset !== undefined) {
+    limits += ` OFFSET ${params.next(filters.offset)}`;
+  }
+
   const rows = await sql.query<RssFeedRow>(
-    `SELECT ${SELECT_COLUMNS} ${FROM_CLAUSE} ${where} ${ORDER_BY}`,
+    `SELECT ${SELECT_COLUMNS} ${FROM_CLAUSE} ${where} ${ORDER_BY}${limits}`,
     params.toArray(),
   );
 
   return rows.map(rowToFeed);
+}
+
+export async function countRssFeeds(
+  sql: SqlClient,
+  filters: RssFeedListFilters = {},
+): Promise<number> {
+  const params = new SqlParams();
+  const where = buildFeedWhere(filters, params);
+  const rows = await sql.query<{ count: number }>(
+    `SELECT COUNT(*)::int AS count ${FROM_CLAUSE} ${where}`,
+    params.toArray(),
+  );
+
+  return rows[0]?.count ?? 0;
+}
+
+export type RssFeedPage = {
+  feeds: RssFeed[];
+  page: number;
+  pageSize: number;
+  totalFeeds: number;
+  totalPages: number;
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+};
+
+export async function listRssFeedsPage(
+  sql: SqlClient,
+  filters: RssFeedListFilters = {},
+  page = 1,
+  pageSize = 50,
+): Promise<RssFeedPage> {
+  const totalFeeds = await countRssFeeds(sql, filters);
+  const totalPages = Math.max(Math.ceil(totalFeeds / pageSize), 1);
+
+  // Counting first means a hand-typed ?page=999 can be clamped before the rows
+  // are fetched, rather than rendering "Page 999 of 15" over an empty list.
+  const resolved = Math.min(Math.max(page, 1), totalPages);
+
+  const feeds = await listRssFeeds(sql, {
+    ...filters,
+    limit: pageSize,
+    offset: (resolved - 1) * pageSize,
+  });
+
+  return {
+    feeds,
+    page: resolved,
+    pageSize,
+    totalFeeds,
+    totalPages,
+    hasPreviousPage: resolved > 1,
+    hasNextPage: resolved < totalPages,
+  };
 }
 
 export type RssFeedCounts = {


### PR DESCRIPTION
Three related fixes to `/flightdeck/feeds`, all touching the same markup.

## Pagination

The route returned all 719 rows: 2.3 MB of HTML, slow enough to time out an in-browser evaluation. It now pages 50 at a time, matching `POSTS_PER_PAGE` on the public list.

`page` is carried by `buildFeedsHref` so it survives the status/search/error filters and vice versa. Page 1 stays out of the URL, so a bare `/flightdeck/feeds` still means "start again". Changing a filter drops the page, which is what you want — the search form and count tiles submit without it.

In `server/feeds.ts`, the WHERE builder is extracted so the list and the count can't disagree about what they're looking at. `listRssFeeds` still returns `RssFeed[]` (~14 existing test call sites destructure it) and gains optional `limit`/`offset`; `countRssFeeds` and `listRssFeedsPage` are new, and the latter composes the former two rather than duplicating filter logic. The count runs first so an out-of-range `?page=` is clamped *before* the rows are fetched — no "Page 999 of 15" over an empty list.

The search pattern and the limit share one `SqlParams` placeholder sequence. That's exactly the bookkeeping that binds the wrong value silently, so there's a test for it.

## View posts

The reason to open a feed is almost always to see what it produced, and that was a 16px icon with no label. It's now a labelled control with the accent treatment.

47 of 719 feeds have no `site_link` — it's read from the feed on the first successful fetch — and there's nothing to filter on without it. Previously the control was simply absent on those rows, which reads as a bug. It's now shown disabled with the reason in the title.

The headline link still points at the feed URL; repointing it was considered and dropped.

## Spacing

Two causes. `.feed-row-footer` pinned its actions right with `margin-left: auto`, which drags the buttons onto their own line the moment the stat chips wrap — and rows carry 0–4 chips, so they wrap at different widths. And `FeedStats` returned `null` when it had nothing to say, so some rows had no chip container at all and a different shape from their neighbours.

The footer now uses `space-between` with `.feed-stats` taking the slack, and a feed that has never been fetched says so rather than rendering blank.

## Validation

`npm run validate` passes: lint (1 pre-existing warning, unrelated), typecheck, 123 tests, build.

The 6 new tests are database tests, which skip without a connection string — so they were **run against a real PostgreSQL 16 in Docker**, where all 123 pass with none skipped. That covers paging, clamping in both directions, the empty catalog reporting one page rather than zero, counts respecting filters, and the placeholder-ordering case above.

Not verified: the rendered appearance, which needs a database the Neon HTTP driver can reach. The preview deploy on this PR is the check for that.